### PR TITLE
style: fix linting issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 backend/dist
 frontend/.next
+frontend/src/gql/generated.ts

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,5 +1,4 @@
 import "./dotenv";
-import path from "path";
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 
 import { warn } from "@acapela/shared/logger";

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -47,6 +47,7 @@ interface Session {}
 type AuthAdapter = AdapterInstance<User, Profile, Session, VerificationRequest>;
 
 const authAdapterProvider: Adapter = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getAdapter(appOptions): Promise<AuthAdapter> {
     await initializeSecrets();
 
@@ -155,7 +156,7 @@ const authAdapterProvider: Adapter = {
         const expires = new Date(Date.now() + ONE_DAY);
         const verificationRequest = await db.verification_requests.create({ data: { identifier, token, expires } });
 
-        await sendVerificationRequest({ identifier, url, token, baseUrl: appOptions.baseUrl, provider });
+        await sendVerificationRequest({ identifier, url });
         return verificationRequest;
       },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -175,12 +176,12 @@ const authAdapterProvider: Adapter = {
 interface VerificationRequestParams {
   identifier: string;
   url: string;
-  baseUrl: string;
-  token: string;
+  // baseUrl: string;
+  // token: string;
   // provider: ProviderEmailOptions;
 }
 
-async function sendVerificationRequest({ identifier: email, baseUrl, token, url }: VerificationRequestParams) {
+async function sendVerificationRequest({ identifier: email, url }: VerificationRequestParams) {
   await sendEmail({
     from: "acapela@meetnomore.com",
     subject: "Login to acapela",

--- a/frontend/pages/home.tsx
+++ b/frontend/pages/home.tsx
@@ -18,7 +18,8 @@ const Page = authenticated(function HomePage() {
   );
 });
 
-(Page as any).getLayout = (page) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Page as any).getLayout = (page: any) => {
   return <MainLayout>{page}</MainLayout>;
 };
 

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -18,7 +18,8 @@ const Page = authenticated(function ActivePage() {
   );
 });
 
-(Page as any).getLayout = (page) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Page as any).getLayout = (page: any) => {
   return <MainLayout>{page}</MainLayout>;
 };
 

--- a/frontend/src/apollo.test.tsx
+++ b/frontend/src/apollo.test.tsx
@@ -17,7 +17,7 @@ jest.mock(
       useSession() {
         return [{}, false];
       },
-      signIn(method: string) {
+      signIn() {
         //
       },
     };
@@ -64,7 +64,7 @@ gql`
 `;
 
 function TestComponent() {
-  const { user, loading } = useCurrentUser();
+  const { user } = useCurrentUser();
   if (user) {
     return <TestQueryComponent />;
   }

--- a/frontend/src/apollo.tsx
+++ b/frontend/src/apollo.tsx
@@ -1,8 +1,7 @@
-import { ApolloClient, ApolloProvider, InMemoryCache, HttpLink, split as splitLinks } from "@apollo/client";
+import { ApolloClient, ApolloLink, ApolloProvider, HttpLink, InMemoryCache, split as splitLinks } from "@apollo/client";
 import { WebSocketLink } from "@apollo/client/link/ws";
-import { ApolloLink } from "@apollo/client";
 import { getMainDefinition } from "@apollo/client/utilities";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { GRAPHQL_SUBSCRIPTION_HOST } from "./config";
 
 const TOKEN_COOKIE_NAME = "next-auth.session-token";

--- a/frontend/src/authentication/authenticated.tsx
+++ b/frontend/src/authentication/authenticated.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/client";
 

--- a/frontend/src/design/Avatar.test.tsx
+++ b/frontend/src/design/Avatar.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Avatar } from "./Avatar";
 
 describe("Avatar", () => {

--- a/frontend/src/gql/.eslintignore
+++ b/frontend/src/gql/.eslintignore
@@ -1,1 +1,0 @@
-generated.ts


### PR DESCRIPTION
- For some reason, ESLint doesn't pick up `.eslintignore` under `/frontend`, so adding rules from there to the global one
- Any `any`-related issues are ignored in a manner similar to other places in the code