### PR TITLE
feat: add new messages to ui as soon as theyre sent without waiting for subscribtion update

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,8 @@
     "styled-normalize": "^8.0.7",
     "styled-reset": "^4.3.4",
     "subscriptions-transport-ws": "^0.9.18",
-    "react-hook-form": "^7.0.6"
+    "react-hook-form": "^7.0.6",
+    "immer": "^9.0.1"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^10.0.9",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -8,7 +8,7 @@ import { WithAdditionalParams } from "next-auth/_utils";
 import { AppContext, AppProps } from "next/app";
 import Head from "next/head";
 import { createGlobalStyle } from "styled-components";
-import { Provider as ApolloProvider } from "~frontend/apollo";
+import { Provider as ApolloProvider } from "~frontend/gql/client/apollo";
 import { parseJWTWithoutValidation } from "~frontend/authentication/jwt";
 import { global } from "~frontend/styles/global";
 import { renderWithPageLayout } from "~frontend/utils/pageLayout";

--- a/frontend/src/gql/client/apollo.test.tsx
+++ b/frontend/src/gql/client/apollo.test.tsx
@@ -1,14 +1,15 @@
-import { gql } from "@apollo/client";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { graphql, rest } from "msw";
 import { setupServer } from "msw/node";
 import { Provider } from "next-auth/client";
 import { PropsWithChildren } from "react";
-import { Provider as ApolloProvider } from "./apollo";
-import { GoogleLoginButton } from "./authentication/GoogleLoginButton";
-import { useCurrentUser } from "./authentication/useCurrentUser";
+import { GoogleLoginButton } from "~frontend/authentication/GoogleLoginButton";
+import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useGetRoomsQuery } from "~frontend/gql";
 
-import { useGetRoomsQuery } from "./gql";
+import { gql } from "@apollo/client";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { Provider as ApolloProvider } from "./apollo";
 
 jest.mock(
   "next-auth/client",

--- a/frontend/src/gql/client/apollo.tsx
+++ b/frontend/src/gql/client/apollo.tsx
@@ -1,9 +1,10 @@
+import Cookie from "js-cookie";
+import React from "react";
+import { GRAPHQL_SUBSCRIPTION_HOST } from "~frontend/config";
+
 import { ApolloClient, ApolloLink, ApolloProvider, HttpLink, InMemoryCache, split as splitLinks } from "@apollo/client";
 import { WebSocketLink } from "@apollo/client/link/ws";
 import { getMainDefinition } from "@apollo/client/utilities";
-import Cookie from "js-cookie";
-import React, { useMemo } from "react";
-import { GRAPHQL_SUBSCRIPTION_HOST } from "./config";
 
 const TOKEN_COOKIE_NAME = "next-auth.session-token";
 
@@ -28,7 +29,7 @@ const authorizationHeaderLink = new ApolloLink((operation, forward) => {
 });
 
 function createSocketLink() {
-  return new WebSocketLink({
+  const socketLink = new WebSocketLink({
     uri: `${GRAPHQL_SUBSCRIPTION_HOST}/v1/graphql`,
     options: {
       reconnect: true,
@@ -48,6 +49,8 @@ function createSocketLink() {
       },
     },
   });
+
+  return socketLink;
 }
 
 const httpLink = new HttpLink({ uri: "/graphql" });
@@ -73,9 +76,8 @@ const createApolloClient = (): ApolloClient<unknown> => {
   });
 };
 
-export const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  // Memoize apollo client so data cache persists across pages when navigating
-  const client = useMemo(createApolloClient, []);
+export const apolloClient = createApolloClient();
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+export const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
 };

--- a/frontend/src/views/thread/Composer.tsx
+++ b/frontend/src/views/thread/Composer.tsx
@@ -1,10 +1,15 @@
 import React, { useRef } from "react";
 import styled from "styled-components";
-import { useCreateTextMessageMutation } from "~frontend/gql";
+import { ThreadMessageBasicInfoFragment, useCreateTextMessageMutation } from "~frontend/gql";
 import { EmojiPicker } from "~ui/EmojiPicker";
 import { Field, useFieldValue } from "~ui/field";
 
-export const MessageComposer: React.FC<{ threadId: string }> = ({ threadId }) => {
+interface Props {
+  threadId: string;
+  onMessageAdded?: (data: ThreadMessageBasicInfoFragment) => void;
+}
+
+export const MessageComposer = ({ threadId, onMessageAdded }: Props) => {
   const [createTextMessage] = useCreateTextMessageMutation();
   const inputRef = useRef<HTMLInputElement>(null);
   const textField = useFieldValue("", inputRef);
@@ -19,12 +24,20 @@ export const MessageComposer: React.FC<{ threadId: string }> = ({ threadId }) =>
           alert("Message content is required");
         }
 
-        await createTextMessage({
+        const newMessageResponse = await createTextMessage({
           variables: {
             text: textField.value,
             threadId,
           },
         });
+
+        const newMessage = newMessageResponse.data?.message;
+
+        if (!newMessage) {
+          return;
+        }
+
+        onMessageAdded?.(newMessage);
 
         textField.reset();
       }}

--- a/frontend/src/views/thread/ScrollableMessages.tsx
+++ b/frontend/src/views/thread/ScrollableMessages.tsx
@@ -13,7 +13,7 @@ const UIHolder = styled.div`
   padding-right: 20px;
 `;
 
-export const ScrollableMessages = ({ children, className }: Props) => {
+const ScrollableMessagesRaw = ({ children, className }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useScrollToBottom({ ref, bottomMargin: 80 });
@@ -24,3 +24,6 @@ export const ScrollableMessages = ({ children, className }: Props) => {
     </UIHolder>
   );
 };
+
+// Allow ScrollableMessages to be used as nested selector.
+export const ScrollableMessages = styled(ScrollableMessagesRaw)``;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ntl": "^5.1.0",
         "prettier": "^2.2.1",
         "ts-node": "^9.1.1",
-        "tslib": "^1.14.1",
+        "tslib": "^2.2.0",
         "typescript": "^4.2.3"
       },
       "engines": {
@@ -120,6 +120,7 @@
         "express-http-proxy": "^1.6.2",
         "focus-visible": "^5.2.0",
         "framer-motion": "^3.10.6",
+        "immer": "^9.0.1",
         "js-cookie": "^2.2.1",
         "jsonwebtoken": "^8.5.1",
         "next": "^10.0.9",
@@ -192,6 +193,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@apollo/client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@ardatan/aggregate-error": {
       "version": "0.0.6",
@@ -1219,11 +1226,6 @@
       "peerDependencies": {
         "cosmiconfig": ">=6"
       }
-    },
-    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.0",
@@ -3440,10 +3442,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/dialog/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/@reach/portal": {
       "version": "0.13.2",
       "license": "MIT",
@@ -3455,10 +3453,6 @@
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x"
       }
-    },
-    "node_modules/@reach/portal/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/@reach/utils": {
       "version": "0.13.2",
@@ -3472,10 +3466,6 @@
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x"
       }
-    },
-    "node_modules/@reach/utils/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -4634,10 +4624,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@wry/context/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/@wry/equality": {
       "version": "0.4.0",
       "license": "MIT",
@@ -4648,10 +4634,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@wry/equality/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/@wry/trie": {
       "version": "0.3.0",
       "license": "MIT",
@@ -4661,10 +4643,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@wry/trie/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/@xobotyi/scrollbar-width": {
       "version": "1.9.5",
@@ -5847,11 +5825,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/camel-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "dev": true,
@@ -5897,11 +5870,6 @@
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
       }
-    },
-    "node_modules/capital-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -5966,11 +5934,6 @@
         "upper-case": "^2.0.1",
         "upper-case-first": "^2.0.1"
       }
-    },
-    "node_modules/change-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -6710,11 +6673,6 @@
         "tslib": "^2.0.3",
         "upper-case": "^2.0.2"
       }
-    },
-    "node_modules/constant-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -7665,11 +7623,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/dot-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/dotenv": {
       "version": "8.2.0",
@@ -9061,6 +9014,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/focus-lock/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/focus-visible": {
       "version": "5.2.0",
       "license": "W3C"
@@ -9163,6 +9122,12 @@
         "react": ">=16.8 || ^17.0.0",
         "react-dom": ">=16.8 || ^17.0.0"
       }
+    },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/framesync": {
       "version": "5.2.0",
@@ -9665,11 +9630,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/graphql-config/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/graphql-request": {
       "version": "3.4.0",
       "dev": true,
@@ -9708,10 +9668,6 @@
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
-    },
-    "node_modules/graphql-tag/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/graphql-upload": {
       "version": "11.0.0",
@@ -9989,11 +9945,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/header-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/headers-utils": {
       "version": "1.2.5",
       "dev": true,
@@ -10212,6 +10163,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.1.tgz",
+      "integrity": "sha512-7CCw1DSgr8kKYXTYOI1qMM/f5qxT5vIVMeGLDCDX8CSxsggr1Sjdoha4OhsP0AZ1UvWbyZlILHvLjaynuu02Mg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -10870,11 +10830,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/is-lower-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
       "dev": true,
@@ -11071,11 +11026,6 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/is-upper-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
@@ -14191,16 +14141,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lower-case-first/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/lower-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "dev": true,
@@ -15110,11 +15050,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/no-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
       "dev": true,
@@ -15761,11 +15696,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/param-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -15859,11 +15789,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/pascal-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "dev": true,
@@ -15884,11 +15809,6 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/path-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -16253,6 +16173,12 @@
         "style-value-types": "4.1.1",
         "tslib": "^1.10.0"
       }
+    },
+    "node_modules/popmotion/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -18082,6 +18008,18 @@
         }
       }
     },
+    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/react-remove-scroll/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/react-style-singleton": {
       "version": "2.1.1",
       "license": "MIT",
@@ -18102,6 +18040,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-style-singleton/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
@@ -18133,10 +18077,6 @@
         "react": "^16.8.0  || ^17.0.0",
         "react-dom": "^16.8.0  || ^17.0.0"
       }
-    },
-    "node_modules/react-use/node_modules/tslib": {
-      "version": "2.2.0",
-      "license": "0BSD"
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -18788,6 +18728,13 @@
         "npm": ">=2.0.0"
       }
     },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
@@ -19073,11 +19020,6 @@
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
       }
-    },
-    "node_modules/sentence-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/serve-static": {
       "version": "1.14.1",
@@ -19388,11 +19330,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/snake-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "dev": true,
@@ -19682,11 +19619,6 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/sponge-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -20175,6 +20107,12 @@
         "tslib": "^1.10.0"
       }
     },
+    "node_modules/style-value-types/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/styled-components": {
       "version": "5.2.1",
       "license": "MIT",
@@ -20458,11 +20396,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/swap-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/symbol-observable": {
       "version": "2.0.3",
       "license": "MIT",
@@ -20720,11 +20653,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/title-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "dev": true,
@@ -20880,10 +20808,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ts-invariant/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/ts-jest": {
       "version": "26.5.4",
@@ -21087,7 +21011,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -21103,6 +21029,13 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -21297,6 +21230,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/typeorm/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/typeorm/node_modules/y18n": {
       "version": "5.0.5",
@@ -21516,16 +21455,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/upper-case-first/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/upper-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -21614,6 +21543,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
       }
+    },
+    "node_modules/use-sidecar/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/use-subscription": {
       "version": "1.5.1",
@@ -22362,6 +22297,13 @@
         "ts-invariant": "^0.7.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@ardatan/aggregate-error": {
@@ -23091,12 +23033,6 @@
         "make-error": "^1",
         "ts-node": "^9",
         "tslib": "^2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "@eslint/eslintrc": {
@@ -24669,11 +24605,6 @@
         "react-focus-lock": "^2.5.0",
         "react-remove-scroll": "^2.4.1",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@reach/portal": {
@@ -24681,11 +24612,6 @@
       "requires": {
         "@reach/utils": "0.13.2",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@reach/utils": {
@@ -24694,11 +24620,6 @@
         "@types/warning": "^3.0.0",
         "tslib": "^2.1.0",
         "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -25445,33 +25366,18 @@
       "version": "0.6.0",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@wry/equality": {
       "version": "0.4.0",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@wry/trie": {
       "version": "0.3.0",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@xobotyi/scrollbar-width": {
@@ -25540,6 +25446,7 @@
         "focus-visible": "^5.2.0",
         "framer-motion": "^3.10.6",
         "identity-obj-proxy": "^3.0.0",
+        "immer": "^9.0.1",
         "js-cookie": "^2.2.1",
         "jsonwebtoken": "^8.5.1",
         "msw": "^0.26.2",
@@ -26386,12 +26293,6 @@
       "requires": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "camelcase": {
@@ -26425,12 +26326,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "capture-exit": {
@@ -26468,12 +26363,6 @@
         "sentence-case": "^3.0.4",
         "snake-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "change-case-all": {
@@ -26991,12 +26880,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "constants-browserify": {
@@ -27629,12 +27512,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "dotenv": {
@@ -28592,6 +28469,13 @@
       "version": "0.8.1",
       "requires": {
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "focus-visible": {
@@ -28644,6 +28528,13 @@
         "popmotion": "9.3.1",
         "style-value-types": "4.1.1",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "framesync": {
@@ -28983,10 +28874,6 @@
             "path-type": "^4.0.0",
             "yaml": "^1.7.2"
           }
-        },
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
         }
       }
     },
@@ -29014,11 +28901,6 @@
       "version": "2.12.3",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "graphql-upload": {
@@ -29185,12 +29067,6 @@
       "requires": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "headers-utils": {
@@ -29324,6 +29200,11 @@
     "ignore": {
       "version": "4.0.6",
       "dev": true
+    },
+    "immer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.1.tgz",
+      "integrity": "sha512-7CCw1DSgr8kKYXTYOI1qMM/f5qxT5vIVMeGLDCDX8CSxsggr1Sjdoha4OhsP0AZ1UvWbyZlILHvLjaynuu02Mg=="
     },
     "immutable": {
       "version": "3.7.6",
@@ -29733,12 +29614,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "is-negative-zero": {
@@ -29853,12 +29728,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "is-utf8": {
@@ -31895,12 +31764,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "lower-case-first": {
@@ -31908,12 +31771,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "lowercase-keys": {
@@ -32512,12 +32369,6 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "node-cleanup": {
@@ -32951,12 +32802,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "parent-module": {
@@ -33020,12 +32865,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "pascalcase": {
@@ -33041,12 +32880,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "path-exists": {
@@ -33274,6 +33107,13 @@
         "hey-listen": "^1.0.8",
         "style-value-types": "4.1.1",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "posix-character-classes": {
@@ -34452,6 +34292,13 @@
         "tslib": "^1.0.0",
         "use-callback-ref": "^1.2.3",
         "use-sidecar": "^1.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "react-remove-scroll-bar": {
@@ -34459,6 +34306,13 @@
       "requires": {
         "react-style-singleton": "^2.1.0",
         "tslib": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "react-style-singleton": {
@@ -34467,6 +34321,13 @@
         "get-nonce": "^1.0.0",
         "invariant": "^2.2.4",
         "tslib": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "react-universal-interface": {
@@ -34490,11 +34351,6 @@
         "throttle-debounce": "^3.0.1",
         "ts-easing": "^0.2.0",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0"
-        }
       }
     },
     "read-pkg": {
@@ -34910,6 +34766,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -35114,12 +34978,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "serve-static": {
@@ -35329,12 +35187,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "snapdragon": {
@@ -35550,12 +35402,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "sprintf-js": {
@@ -35895,6 +35741,13 @@
       "requires": {
         "hey-listen": "^1.0.8",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "styled-components": {
@@ -36085,12 +35938,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "symbol-observable": {
@@ -36251,12 +36098,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "tmp": {
@@ -36355,11 +36196,6 @@
       "version": "0.7.3",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "ts-jest": {
@@ -36479,13 +36315,23 @@
       }
     },
     "tslib": {
-      "version": "1.14.1"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "tsutils": {
       "version": "3.21.0",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "tty-browserify": {
@@ -36609,6 +36455,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "y18n": {
           "version": "5.0.5"
@@ -36739,12 +36590,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "upper-case-first": {
@@ -36752,12 +36597,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "dev": true
-        }
       }
     },
     "uri-js": {
@@ -36814,6 +36653,13 @@
       "requires": {
         "detect-node-es": "^1.1.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "use-subscription": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ntl": "^5.1.0",
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
-    "tslib": "^1.14.1",
+    "tslib": "^2.2.0",
     "typescript": "^4.2.3"
   },
   "config": {


### PR DESCRIPTION
What changed:

Before: after sending a new message, it was not showing in the UI until the socket subscription picked it. Hasura has 1s socket interval so it often had a visual delay

Now: as soon as mutation resolved, data from mutation is added to the temporary list of 'optimistic messages' to display in the UI .


![CleanShot 2021-04-16 at 12 30 16](https://user-images.githubusercontent.com/7311462/115011955-87d0b700-9eaf-11eb-8546-43e1cc95906c.gif)
