### PR TITLE
fix: prisma db url password encoding error

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -31,7 +31,9 @@ if (DB_VARS.some((key) => !ENV_VARS.includes(key))) {
   throw error;
 }
 
-const prismaDatabaseUrl = `postgresql://${process.env.DB_USER}:${process.env.DB_PASSWORD}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}?schema=public`;
+const prismaDatabaseUrl = `postgresql://${process.env.DB_USER}:${encodeURIComponent(process.env.DB_PASSWORD)}@${
+  process.env.DB_HOST
+}:${process.env.DB_PORT}/${process.env.DB_NAME}?schema=public`;
 
 export const db = new PrismaClient({
   datasources: {


### PR DESCRIPTION
```
PrismaClientInitializationError2 [PrismaClientInitializationError]: The provided database string is invalid.
Error parsing connection string: invalid port number in `postgresql://app:******=@127.0.0.1:5432/app?schema=public`.
Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string.
In some cases, certain characters must be escaped. Please check the string for any illegal characters.
```