### PR TITLE
fix: ignore .npmrc during docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .env
 .env.test
 .git
+.npmrc


### PR DESCRIPTION
This is currently breaking the master release pipeline.