### PR TITLE
feat: made gql variables optional when possible

### DIFF
--- a/frontend/src/apollo.test.tsx
+++ b/frontend/src/apollo.test.tsx
@@ -74,7 +74,7 @@ function TestComponent() {
 }
 
 function TestQueryComponent() {
-  const { data } = useGetRoomsQuery({});
+  const { data } = useGetRoomsQuery();
   return <>Rooms: {data ? data.room.map((room) => <li key={room.id}>{room.id}</li>) : "Loading"}</>;
 }
 

--- a/frontend/src/gql/utils.ts
+++ b/frontend/src/gql/utils.ts
@@ -14,9 +14,13 @@ import { useRef } from "react";
 import { assert } from "~shared/assert";
 import { apolloClient } from "~frontend/apollo";
 
+type EmptyObject = Record<string, never>;
+
+type VoidableIfEmpty<V> = EmptyObject extends V ? V | void : V;
+
 export function createQuery<Data, Variables>(query: DocumentNode) {
-  function useQuery(variables: Variables, options?: QueryHookOptions<Data, Variables>) {
-    return useRawQuery(query, { ...options, variables });
+  function useQuery(variables: VoidableIfEmpty<Variables>, options?: QueryHookOptions<Data, Variables>) {
+    return useRawQuery(query, { ...options, variables: variables as Variables });
   }
 
   function update(variables: Variables, updater: (dataDraft: Draft<Data>) => void) {
@@ -90,9 +94,9 @@ export function createSubscription<Data, Variables>(subscription: DocumentNode) 
   // Create query with manager that will be used to update query if needed
   const [useQuery, queryManager] = createQuery<Data, Variables>(queryNode);
 
-  function useSubscription(variables: Variables, options?: SubscriptionHookOptions<Data, Variables>) {
+  function useSubscription(variables: VoidableIfEmpty<Variables>, options?: SubscriptionHookOptions<Data, Variables>) {
     const queryResult = useQuery(variables);
-    const subscriptionResult = useRawSubscription(subscription, { ...options, variables });
+    const subscriptionResult = useRawSubscription(subscription, { ...options, variables: variables as Variables });
 
     const data = useLatest(queryResult.data, subscriptionResult.data);
 


### PR DESCRIPTION
Modified useQuery hook so variables argument is optional if query has no variables (empty interface `{}`)

Before
```ts
useQueryThatHasNoVariables({});
```

now
```ts
useQueryThatHasNoVariables()
```