### PR TITLE
ACA-351 Full text search

### DIFF
--- a/infrastructure/hasura/metadata/functions.yaml
+++ b/infrastructure/hasura/metadata/functions.yaml
@@ -1,1 +1,3 @@
-[]
+- function:
+    schema: public
+    name: search_full_text

--- a/infrastructure/hasura/metadata/tables.yaml
+++ b/infrastructure/hasura/metadata/tables.yaml
@@ -35,6 +35,29 @@
         filter: {}
 - table:
     schema: public
+    name: full_text_search
+  select_permissions:
+    - role: user
+      permission:
+        columns:
+          - room_id
+          - room_name
+          - user_id
+          - topic_id
+          - topic_name
+          - message_created_at
+          - message_type
+          - message_id
+          - message_content
+          - transcription_id
+          - attachment_id
+          - attachment_name
+          - transcript
+        filter:
+          user_id:
+            _eq: X-Hasura-User-Id
+- table:
+    schema: public
     name: last_seen_message
   insert_permissions:
     - role: user
@@ -201,6 +224,9 @@
     - role: user
       permission:
         filter: {}
+- table:
+    schema: public
+    name: message_full_text
 - table:
     schema: public
     name: message_type
@@ -591,6 +617,9 @@
           - transcript
           - updated_at
         filter: {}
+- table:
+    schema: public
+    name: transcription_full_text
 - table:
     schema: public
     name: transcription_status

--- a/infrastructure/hasura/migrations/1621428792340_view_transcription_full_text/up.sql
+++ b/infrastructure/hasura/migrations/1621428792340_view_transcription_full_text/up.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW transcription_full_text AS
+    SELECT id transcription_id, string_agg(txt, ' ') transcript
+    FROM (
+        SELECT id, jsonb_array_elements(jsonb_array_elements(transcript -> 'transcript') -> 'words') ->> 'text' txt
+        FROM transcription WHERE status = 'completed'
+        ) t
+    GROUP BY t.id;

--- a/infrastructure/hasura/migrations/1621428817175_view_message_full_text/up.sql
+++ b/infrastructure/hasura/migrations/1621428817175_view_message_full_text/up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW message_full_text AS
+SELECT message.id, topic_id, user_id, transcription_id, type, created_at, string_agg(content_txt, ' ') AS content_txt
+FROM message LEFT JOIN (
+    SELECT id, jsonb_array_elements(content) ->> 'insert' AS content_txt
+    FROM message
+    WHERE is_draft = false
+) t ON t.id = message.id
+GROUP BY message.id, topic_id, user_id, transcription_id, type;

--- a/infrastructure/hasura/migrations/1621428862848_materialized_view_full_text_search/up.sql
+++ b/infrastructure/hasura/migrations/1621428862848_materialized_view_full_text_search/up.sql
@@ -1,0 +1,21 @@
+CREATE MATERIALIZED VIEW full_text_search AS
+SELECT room.id room_id,
+       room.name room_name,
+       room_participants.user_id user_id,
+       topic.id topic_id,
+       topic.name topic_name,
+       message.created_at message_created_at,
+       type message_type,
+       message.id message_id,
+       content_txt message_content,
+       transcription_full_text.transcription_id transcription_id,
+       attachment.id attachment_id,
+       original_name attachment_name,
+       transcript
+FROM room
+    INNER JOIN room_participants on room.id = room_participants.room_id
+    INNER JOIN topic on room.id = topic.room_id
+    INNER JOIN message_full_text as message on topic.id = message.topic_id
+    LEFT JOIN message_attachments ma on message.id = ma.message_id
+    LEFT JOIN attachment on ma.attachment_id = attachment.id
+    LEFT JOIN transcription_full_text on message.transcription_id = transcription_full_text.transcription_id;

--- a/infrastructure/hasura/migrations/1621429087530_trigger_refresh_full_text_search/up.sql
+++ b/infrastructure/hasura/migrations/1621429087530_trigger_refresh_full_text_search/up.sql
@@ -1,0 +1,43 @@
+CREATE OR REPLACE FUNCTION refresh_full_text_search()
+    RETURNS TRIGGER LANGUAGE plpgsql
+AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW full_text_search;
+RETURN NULL;
+END $$;
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON message FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON transcription FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON room_participants FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON room FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON topic FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON message_attachments FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();
+
+CREATE TRIGGER refresh_search
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON attachment FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_full_text_search();

--- a/infrastructure/hasura/migrations/1621429462855_idx_full_text_search/up.sql
+++ b/infrastructure/hasura/migrations/1621429462855_idx_full_text_search/up.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION pg_trgm;
+CREATE INDEX full_text_search_idx ON full_text_search
+    USING GIN ((room_name || ' ' || topic_name || ' ' || COALESCE(message_content, '') || ' ' || COALESCE(transcript, '') || ' ' || COALESCE(attachment_name, '')) gin_trgm_ops);

--- a/infrastructure/hasura/migrations/1621429485253_fn_search_full_text/up.sql
+++ b/infrastructure/hasura/migrations/1621429485253_fn_search_full_text/up.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION search_full_text(search text)
+    RETURNS SETOF full_text_search AS $$
+SELECT *
+FROM full_text_search
+WHERE
+        search <% (room_name || ' ' || topic_name || ' ' || COALESCE(message_content, '') || ' ' || COALESCE(transcript, '') || ' ' || COALESCE(attachment_name, ''))
+ORDER BY
+    similarity(search,(room_name || ' ' || topic_name || ' ' || COALESCE(message_content, '') || ' ' || COALESCE(transcript, '') || ' ' || COALESCE(attachment_name, ''))) DESC;
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
This PR enables full text search functionality in hasura:

Included search fields:
* room_name
* topic_name
* message_content
* transcript
* attachment_name

Example query
```graphql
query MyQuery {
  search_full_text(args: {search: "nice"}) {
    room_id
    user_id
    room_name
    topic_name
    transcript
    message_content
    topic_id
    transcription_id
    message_id
    message_type
    message_created_at
    attachment_name
    attachment_id
  }
}
```

`message_full_text` and `transcription_full_text` are intermediate views to extract the raw text from the json column