### PR TITLE
fix: workaround socket issue in prod

### DIFF
--- a/shared/channel.ts
+++ b/shared/channel.ts
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+type Cleanup = () => void;
+
+type SubscriberResult = Cleanup | void;
+
+type Subscriber<T> = (value: T) => SubscriberResult;
+
+export function createChannel<T>() {
+  const subscribers = new Set<Subscriber<T>>();
+  const currentCleanupMap = new Map<Subscriber<T>, Cleanup>();
+
+  function cleanupSubscriber(subscriber: Subscriber<T>) {
+    const cleanup = currentCleanupMap.get(subscriber);
+
+    if (!cleanup) {
+      return;
+    }
+
+    currentCleanupMap.delete(subscriber);
+
+    cleanup();
+  }
+
+  function subscribe(subscriber: Subscriber<T>) {
+    subscribers.add(subscriber);
+
+    return function stop() {
+      cleanupSubscriber(subscriber);
+      subscribers.delete(subscriber);
+    };
+  }
+
+  function publish(value: T) {
+    const subscribersList = Array.from(subscribers);
+    for (const subscriber of subscribersList) {
+      cleanupSubscriber(subscriber);
+
+      const newCleanup = subscriber(value);
+
+      if (newCleanup) {
+        currentCleanupMap.set(subscriber, newCleanup);
+      }
+    }
+  }
+
+  function useSubscribe(subscriber: Subscriber<T>) {
+    useEffect(() => {
+      return subscribe(subscriber);
+    }, [subscriber]);
+  }
+
+  return {
+    subscribe,
+    publish,
+    useSubscribe,
+  };
+}


### PR DESCRIPTION
This is not here to stay.

We have socket issue in prod

To workaround it (as I'm not sure if Chris will be able to solve it tomorrow) I added simple code that will refetch every running useQuery hook after every mutation success.

It is obviously awful in terms of performance, but it'll smothen tomorrows onboarding and I hope we'll fix sockets quickly and remove this.