### PR TITLE
feat: only show spaces of current team in spaces page

### DIFF
--- a/frontend/src/gql/generated.ts
+++ b/frontend/src/gql/generated.ts
@@ -8066,7 +8066,9 @@ export type SpaceDetailedInfoFragment = (
   )> }
 );
 
-export type GetSpacesQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetSpacesQueryVariables = Exact<{
+  teamId: Scalars['uuid'];
+}>;
 
 
 export type GetSpacesQuery = (

--- a/frontend/src/gql/spaces.ts
+++ b/frontend/src/gql/spaces.ts
@@ -53,8 +53,8 @@ export const [useGetSpacesQuery, getSpacesQueryManager] = createQuery<GetSpacesQ
   () => gql`
     ${SpaceBasicInfoFragment()}
 
-    query GetSpaces {
-      space {
+    query GetSpaces($teamId: uuid!) {
+      space(where: { team_id: { _eq: $teamId } }) {
         ...SpaceBasicInfo
       }
     }
@@ -87,8 +87,8 @@ export const [useCreateSpaceMutation] = createMutation<CreateSpaceMutation, Crea
     }
   `,
   {
-    onSuccess(data) {
-      getSpacesQueryManager.update({}, (draft) => {
+    onSuccess(data, { teamId }) {
+      getSpacesQueryManager.update({ teamId }, (draft) => {
         if (!data.space) return;
 
         draft.space.push(data.space);

--- a/frontend/src/views/SpacesView/SpacesList.tsx
+++ b/frontend/src/views/SpacesView/SpacesList.tsx
@@ -3,9 +3,11 @@ import { PageTitle } from "~ui/typo";
 import { useGetSpacesQuery } from "~frontend/gql/spaces";
 import { NoticeLabel } from "~frontend/ui/NoticeLabel";
 import { SpaceCard } from "~frontend/ui/spaces/SpaceCard";
+import { useAssertCurrentTeamId } from "~frontend/authentication/useCurrentUser";
 
 export function SpacesList() {
-  const [data, { loading }] = useGetSpacesQuery.subscription();
+  const teamId = useAssertCurrentTeamId();
+  const [data, { loading }] = useGetSpacesQuery.subscription({ teamId });
 
   const spacesList = data?.space ?? [];
 


### PR DESCRIPTION
Right now spaces page would show spaces from all of your teams instead only the current one,

This pr fixes it