### PR TITLE
doc: change order of first install cmds

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -58,14 +58,18 @@ It will show you all other available commands as a console interactive select:
 
 ![YARN START](./docs/yarn-start.gif)
 
-First, we need to seed the database:
-
-- `hasura:migrations`
-- `hasura:meta`
-
-In order to bring the project up, run these commands in different terminals (using `yarn start` and selecting them):
+First, we need to get docker running (using `yarn start` and selecting them)
 
 - `docker:up`
+
+Then we need to seed the database (again with `yarn start` and selecting them):
+
+- `hasura:migrations`
+- `hasura:seeds`
+- `hasura:meta`
+
+In order to bring the project up, run these in different terminals (using `yarn start` and selecting them):
+
 - `frontend:dev`
 - `backend:dev`
 


### PR DESCRIPTION
# Context

I got into an installation hickups after running the initial migrations on an already running `hasura` image and gave me a few weird errors. 

Running `docker:up` was necessary before running the hasura migrations, but it was not explicitly displayed in the correct order.

# What's included

A change in order of the getting started commands to setup the monorepo properly