### PR TITLE
fix: fix recordings

### DIFF
--- a/frontend/src/views/topic/Composer.tsx
+++ b/frontend/src/views/topic/Composer.tsx
@@ -59,7 +59,7 @@ export const MessageComposer = ({ topicId }: Props) => {
             await createMessage({
               topicId: topicId,
               type: messageType,
-              content: "",
+              content: [],
               attachments: uploadedAttachments.map((attachment) => ({
                 attachment_id: attachment.uuid,
               })),


### PR DESCRIPTION
Empty message content has to follow quill format, meaning an empty array.