### PR TITLE
fix: fixed broken user query permissions

### DIFF
--- a/frontend/src/ui/MembersManager/UserPickerModal.tsx
+++ b/frontend/src/ui/MembersManager/UserPickerModal.tsx
@@ -54,6 +54,7 @@ export function UserPickerModal({ currentUsers, currentUserLabel, onCloseRequest
 
 const UIMembers = styled.div`
   display: flex;
+  flex-direction: column;
   margin-top: 1rem;
 
   & > * {

--- a/infrastructure/hasura/metadata/tables.yaml
+++ b/infrastructure/hasura/metadata/tables.yaml
@@ -691,12 +691,9 @@
           - owner_id
           - slug
         filter:
-          _or:
-            - owner_id:
-                _eq: X-Hasura-User-Id
-            - memberships:
-                user_id:
-                  _eq: X-Hasura-User-Id
+          memberships:
+            user_id:
+              _eq: X-Hasura-User-Id
   update_permissions:
     - role: user
       permission:
@@ -1128,7 +1125,6 @@
               memberships:
                 user_id:
                   _eq: X-Hasura-User-Id
-        limit: 1
   update_permissions:
     - role: user
       permission:


### PR DESCRIPTION
For some reason, there was hard select limit of `1` result in `user` table which caused user based queries like user picker to work incorrectly.

now user picker should work correctly:

<img width="576" alt="CleanShot 2021-05-31 at 11 32 07@2x" src="https://user-images.githubusercontent.com/7311462/120172961-d8a03300-c203-11eb-84ea-1e8989fa8df8.png">
