### PR TITLE
refactor: extract filters from queried topics list

### DIFF
--- a/frontend/src/views/HomeView/RecentTopics/RecentTopics.tsx
+++ b/frontend/src/views/HomeView/RecentTopics/RecentTopics.tsx
@@ -1,18 +1,16 @@
 import styled from "styled-components";
+import { TopicsQueryVariables } from "~gql";
 import { useTopicsQuery } from "~frontend/gql/topics";
-import { useTopicFilterVariables } from "./Filters/filter";
-import { TopicFilters } from "./Filters/TopicFilters";
 import { groupBy } from "./groupBy";
 import { RoomRecentTopics } from "./RoomRecentTopics";
 
 interface Props {
   className?: string;
+  query: TopicsQueryVariables;
 }
 
-export const RecentTopics = styled(function RecentTopics({ className }: Props) {
-  const [topicQueryVariables, setFilters] = useTopicFilterVariables();
-
-  const [topics = []] = useTopicsQuery(topicQueryVariables);
+export const QueriedTopicsList = styled(function RecentTopics({ className, query }: Props) {
+  const [topics = []] = useTopicsQuery(query);
 
   const roomGroups = groupBy(
     topics,
@@ -22,7 +20,6 @@ export const RecentTopics = styled(function RecentTopics({ className }: Props) {
 
   return (
     <UIHolder className={className}>
-      <TopicFilters onFiltersChange={setFilters} />
       {roomGroups.map((roomGroup) => {
         return (
           <UISingleRoomRecentTopics key={roomGroup.groupItem.id}>
@@ -34,11 +31,7 @@ export const RecentTopics = styled(function RecentTopics({ className }: Props) {
   );
 })``;
 
-const UIHolder = styled.div`
-  ${TopicFilters} {
-    margin-bottom: 32px;
-  }
-`;
+const UIHolder = styled.div``;
 
 const UISingleRoomRecentTopics = styled.div`
   margin-bottom: 1rem;

--- a/frontend/src/views/HomeView/index.tsx
+++ b/frontend/src/views/HomeView/index.tsx
@@ -3,10 +3,13 @@ import { PageTitle } from "~ui/typo";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { SearchBar } from "~frontend/ui/search/SearchBar";
 import { Container } from "~ui/layout/Container";
-import { RecentTopics } from "./RecentTopics/RecentTopics";
+import { QueriedTopicsList } from "./RecentTopics/RecentTopics";
+import { useTopicFilterVariables } from "./RecentTopics/Filters/filter";
+import { TopicFilters } from "./RecentTopics/Filters/TopicFilters";
 
 export function HomeView() {
   const user = useAssertCurrentUser();
+  const [topicQuery, setFilters] = useTopicFilterVariables();
 
   return (
     <UIHolder>
@@ -17,14 +20,19 @@ export function HomeView() {
         <PageTitle>Hello, {user.name}!</PageTitle>
         <div>Here are rooms & topics with recent activity.</div>
       </UIGreeting>
-      <RecentTopics />
+      <TopicFilters onFiltersChange={setFilters} />
+      <QueriedTopicsList query={topicQuery} />
     </UIHolder>
   );
 }
 
 const UIHolder = styled(Container)`
-  ${RecentTopics} {
-    margin-bottom: 2rem;
+  ${TopicFilters} {
+    margin-bottom: 32px;
+  }
+
+  ${QueriedTopicsList} {
+    margin-bottom: 32px;
   }
 `;
 


### PR DESCRIPTION
Moves the filter UI outside of the RecentTopics.

Renamed `RecentTopics` to `QueriedTopicsList`