### PR TITLE
feat: added code workspaces support

### DIFF
--- a/acapela.code-workspace
+++ b/acapela.code-workspace
@@ -1,0 +1,114 @@
+{
+  "folders": [
+    {
+      "path": "./frontend"
+    },
+    {
+      "path": "./backend"
+    },
+    {
+      "path": "./config"
+    },
+    {
+      "path": "./db"
+    },
+    {
+      "path": "./docs"
+    },
+    {
+      "path": "./gql"
+    },
+    {
+      "path": "./infrastructure"
+    },
+    {
+      "path": "./richEditor"
+    },
+    {
+      "path": "./scripts"
+    },
+    {
+      "path": "./shared"
+    },
+    {
+      "path": "./tooling"
+    },
+    {
+      "path": "./ui"
+    }
+  ],
+  "settings": {
+    "files.associations": {
+      ".env.local": "env",
+      ".env.production": "env",
+      ".env.sample": "env"
+    },
+    "editor.rulers": [
+      // Matching prettier breakline length config
+      120
+    ],
+    "files.insertFinalNewline": true,
+    "search.exclude": {
+      "**/node_modules": true,
+      ".next/**/*": true,
+      "**/.next/**/*": true,
+      // DB client is auto generated, huge file that could pollute search easily
+      "db/client/**/*": true,
+      ".yarn/**/*": true
+    },
+    "prettier.requireConfig": true,
+    // Will use auto-imports ~package instead of ../../package if import is from different package
+    "typescript.preferences.importModuleSpecifier": "shortest",
+    "typescript.suggest.autoImports": true,
+    "[html]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "spellright.documentTypes": ["markdown", "plaintext", "typescript"],
+    "colorInfo.languages": [
+      {
+        "selector": "css",
+        "colors": "css"
+      },
+      {
+        "selector": "sass",
+        "colors": "css"
+      },
+      {
+        "selector": "scss",
+        "colors": "css"
+      },
+      {
+        "selector": "less",
+        "colors": "css"
+      },
+      {
+        "selector": "typescript",
+        "colors": "css"
+      },
+      {
+        "selector": "typescriptreact",
+        "colors": "css"
+      }
+    ],
+    "cSpell.words": [
+      "Hasura",
+      "Scrollable",
+      "Unprocessable",
+      "immer",
+      "timestamptz",
+      "Userback",
+      "godaddy",
+      "healthz",
+      "sonix",
+      "Sonix",
+      "acapela",
+      "sendgrid",
+      "pino",
+      "gmail",
+      "nextauth",
+      "autoLinks",
+      "displayer"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "scripts": {
+    "code": "code acapela.code-workspace",
     "unstable:scope": "func() { ( npm \"$2\" --prefix \"$1\" --save --package-lock-only --no-package-lock \"$3\" ; ) && npm i;}; func",
     "frontend:dev": "yarn frontend dev",
     "frontend:test": "yarn frontend test",


### PR DESCRIPTION
I'd like to test if we'll have better monorepo performance in vs code with workspaces. ( https://code.visualstudio.com/docs/editor/workspaces )

To open in workspaces mode, call `yarn code`

It seems to create scoped TS-Server etc for each workspace which might return in way smoother IDE experience.