### PR TITLE
fix: only fire toasts only once on actual, successful updates

### DIFF
--- a/frontend/src/gql/attachments.ts
+++ b/frontend/src/gql/attachments.ts
@@ -67,7 +67,7 @@ export const [useRemoveMessageAttachment, { mutate: removeMessageAttachment }] =
         },
       };
     },
-    onResult(message, variables) {
+    onOptimisticOrActualResponse(message, variables) {
       MessageDetailedInfoFragment.update(variables.messageId, (message) => {
         message.message_attachments = message.message_attachments.filter((messageAttachment) => {
           return messageAttachment.attachment.id !== variables.attachmentId;

--- a/frontend/src/gql/messages.ts
+++ b/frontend/src/gql/messages.ts
@@ -121,7 +121,7 @@ export const [useCreateMessageMutation, { mutate: createMessage }] = createMutat
         },
       };
     },
-    onOptimisticAndActualResponse: (message, variables) => {
+    onOptimisticOrActualResponse: (message, variables) => {
       topicMessagesQueryManager.update({ topicId: variables.topicId }, (current) => {
         if (!message) {
           return;

--- a/frontend/src/gql/rooms.ts
+++ b/frontend/src/gql/rooms.ts
@@ -132,7 +132,7 @@ export const [useCreateRoomMutation] = createMutation<CreateRoomMutation, Create
     }
   `,
   {
-    onOptimisticAndActualResponse(room, variables) {
+    onOptimisticOrActualResponse(room, variables) {
       if (!room || !variables.input.space_id) return;
 
       SpaceDetailedInfoFragment.update(variables.input.space_id, (space) => {
@@ -186,11 +186,13 @@ export const [useAddRoomMemberMutation] = createMutation<AddRoomMemberMutation, 
         insert_room_member_one: { __typename: "room_member", user_id: vars.userId, room_id: vars.roomId },
       };
     },
-    onOptimisticAndActualResponse(data, vars, phase) {
+    onOptimisticOrActualResponse(data, vars) {
       RoomDetailedInfoFragment.update(vars.roomId, (room) => {
         room.members.push({ __typename: "room_member", user: UserBasicInfoFragment.assertRead(vars.userId) });
       });
-      phase === "actual" && addToast({ type: "info", content: `Room member was added` });
+    },
+    onActualResponse() {
+      addToast({ type: "info", content: `Room member was added` });
     },
   }
 );
@@ -213,11 +215,13 @@ export const [useRemoveRoomMemberMutation] = createMutation<
         delete_room_member: { __typename: "room_member_mutation_response", affected_rows: 1 },
       };
     },
-    onOptimisticAndActualResponse(data, vars, phase) {
+    onOptimisticOrActualResponse(data, vars) {
       RoomDetailedInfoFragment.update(vars.roomId, (room) => {
         room.members = room.members.filter((member) => member.user.id !== vars.userId);
       });
-      phase === "actual" && addToast({ type: "info", content: `Room member was added` });
+    },
+    onActualResponse() {
+      addToast({ type: "info", content: `Room member was added` });
     },
   }
 );
@@ -273,7 +277,7 @@ export const [useDeleteRoomMutation, { mutate: deleteRoom }] = createMutation<
         room: RoomDetailedInfoFragment.assertRead(vars.roomId),
       };
     },
-    onOptimisticAndActualResponse(removedRoom) {
+    onOptimisticOrActualResponse(removedRoom) {
       if (!removedRoom.space_id) return;
       SpaceDetailedInfoFragment.update(removedRoom.space_id, (space) => {
         space.rooms = space.rooms.filter((room) => room.id !== removedRoom.id);

--- a/frontend/src/gql/spaces.ts
+++ b/frontend/src/gql/spaces.ts
@@ -140,7 +140,7 @@ export const [useCreateSpaceMutation] = createMutation<CreateSpaceMutation, Crea
         space: { id: getUUID(), name: variables.name, __typename: "space", members: [] },
       };
     },
-    onOptimisticAndActualResponse(space, { teamId }) {
+    onOptimisticOrActualResponse(space, { teamId }) {
       TeamDetailedInfoFragment.update(teamId, (team) => {
         team.spaces.push(space);
       });
@@ -196,7 +196,7 @@ export const [useDeleteSpaceMutation, { mutate: deleteSpace }] = createMutation<
         deletedSpace: space,
       };
     },
-    onOptimisticAndActualResponse(deletedSpace) {
+    onOptimisticOrActualResponse(deletedSpace) {
       TeamDetailedInfoFragment.update(deletedSpace.team_id, (team) => {
         team.spaces = team.spaces.filter((space) => space.id !== deletedSpace.id);
       });
@@ -223,7 +223,7 @@ export const [useAddSpaceMemberMutation] = createMutation<AddSpaceMemberMutation
         },
       };
     },
-    onOptimisticAndActualResponse(data, variables, phase) {
+    onOptimisticOrActualResponse(data, variables) {
       SpaceBasicInfoFragment.update(variables.spaceId, (space) => {
         space.members.push({
           __typename: "space_member",
@@ -232,7 +232,9 @@ export const [useAddSpaceMemberMutation] = createMutation<AddSpaceMemberMutation
           space_id: variables.spaceId,
         });
       });
-      phase === "actual" && addToast({ type: "info", content: `Space member was added` });
+    },
+    onActualResponse() {
+      addToast({ type: "info", content: `Space member was added` });
     },
   }
 );
@@ -258,11 +260,13 @@ export const [useRemoveSpaceMemberMutation] = createMutation<
         },
       };
     },
-    onOptimisticAndActualResponse(data, variables, phase) {
+    onOptimisticOrActualResponse(data, variables) {
       SpaceBasicInfoFragment.update(variables.spaceId, (space) => {
         space.members = space.members.filter((member) => member.user.id !== variables.userId);
       });
-      phase === "actual" && addToast({ type: "info", content: `Space member was removed` });
+    },
+    onActualResponse() {
+      addToast({ type: "info", content: `Space member was removed` });
     },
   }
 );

--- a/frontend/src/gql/teams.ts
+++ b/frontend/src/gql/teams.ts
@@ -118,8 +118,8 @@ export const [useCreateTeamInvitationMutation] = createMutation<
     }
   `,
   {
-    onOptimisticAndActualResponse(_, __, phase) {
-      phase === "actual" && addToast({ type: "info", content: `Team invitation was sent` });
+    onActualResponse() {
+      addToast({ type: "info", content: `Space member was removed` });
     },
   }
 );

--- a/frontend/src/gql/topics.ts
+++ b/frontend/src/gql/topics.ts
@@ -93,7 +93,7 @@ export const [useCreateTopicMutation, { mutate: createTopic }] = createMutation<
         },
       };
     },
-    onOptimisticAndActualResponse(topic, variables) {
+    onOptimisticOrActualResponse(topic, variables) {
       RoomDetailedInfoFragment.update(variables.roomId, (data) => {
         data.topics.push(topic);
       });
@@ -157,7 +157,7 @@ export const [useAddTopicMemberMutation] = createMutation<AddTopicMemberMutation
         },
       };
     },
-    onOptimisticAndActualResponse(data, vars) {
+    onOptimisticOrActualResponse(data, vars) {
       TopicDetailedInfoFragment.update(vars.topicId, (topic) => {
         topic.members.push({ __typename: "topic_member", user: UserBasicInfoFragment.assertRead(vars.userId) });
       });
@@ -186,7 +186,7 @@ export const [useRemoveTopicMemberMutation] = createMutation<
         },
       };
     },
-    onOptimisticAndActualResponse(data, vars) {
+    onOptimisticOrActualResponse(data, vars) {
       TopicDetailedInfoFragment.update(vars.topicId, (topic) => {
         topic.members = topic.members.filter((member) => member.user.id !== vars.userId);
       });
@@ -261,11 +261,14 @@ export const [useDeleteTopicMutation] = createMutation<DeleteTopicMutation, Dele
 
       return { __typename: "mutation_root", topic };
     },
-    onOptimisticAndActualResponse(removedTopic, _, phase) {
+    onOptimisticOrActualResponse(removedTopic) {
       RoomDetailedInfoFragment.update(removedTopic.room.id, (room) => {
         room.topics = room.topics.filter((topic) => topic.id !== removedTopic.id);
       });
-      phase === "actual" && addToast({ type: "info", content: `Topic was removed` });
+    },
+
+    onActualResponse() {
+      addToast({ type: "info", content: `Topic was removed` });
     },
   }
 );


### PR DESCRIPTION
Before toasts were fired both for optimistic and actual update resulting in them being quickly called twice.

![CleanShot 2021-06-23 at 12 45 04](https://user-images.githubusercontent.com/7311462/123083916-ddca5980-d420-11eb-8675-2674ef7e2119.gif)
