### PR TITLE
feat: toggle code span or code block depending on selection

### DIFF
--- a/richEditor/Toolbar.tsx
+++ b/richEditor/Toolbar.tsx
@@ -47,6 +47,17 @@ export const Toolbar = forwardRef<HTMLDivElement, Props>(function Toolbar(
     };
   }
 
+  function handleCreateCodeSnippet() {
+    const isSelectionEmpty = editor.state.selection.empty;
+
+    if (isSelectionEmpty) {
+      editor.chain().focus().toggleCodeBlock().run();
+      return;
+    }
+
+    editor.chain().focus().toggleCode().run();
+  }
+
   return (
     <UIHolder ref={ref}>
       <UISection>
@@ -71,9 +82,9 @@ export const Toolbar = forwardRef<HTMLDivElement, Props>(function Toolbar(
           icon={<IconTextStrikethrough />}
         />
         <ToolbarButton
-          onClick={createFormatHandler("toggleCodeBlock")}
+          onClick={handleCreateCodeSnippet}
           tooltipLabel="Code Block"
-          isHighlighted={getIsFormatActive("code-block")}
+          isHighlighted={getIsFormatActive("code-block") || getIsFormatActive("code")}
           icon={<IconBrackets />}
         />
         {/* TODO now we 'only' have autolinks. Integrate nice UI to create links with modal */}


### PR DESCRIPTION
![CleanShot 2021-06-30 at 13 20 32](https://user-images.githubusercontent.com/7311462/123952233-ff3dbf00-d9a5-11eb-9d2d-8bc0313fbe0f.gif)

Editor now properly toggles either `code` or `code-block` format depending on selection while clicking it.

Before it was always converting entire paragraph to code, even if you only selected a single word