### PR TITLE
fix: allow the message editor content to overflow

### DIFF
--- a/richEditor/RichEditor.tsx
+++ b/richEditor/RichEditor.tsx
@@ -176,8 +176,12 @@ const UIEditorHolder = styled.div`
 const UIEditorContent = styled.div`
   padding: 16px;
   display: flex;
+
   flex-direction: column;
   gap: 16px;
+
+  max-height: 25vh;
+  overflow: auto;
 `;
 
 const UIHolder = styled.div`

--- a/richEditor/Theme.tsx
+++ b/richEditor/Theme.tsx
@@ -11,9 +11,6 @@ export const richEditorContentCss = css`
 
   line-height: 1.25;
 
-  max-height: 25vh;
-  overflow: auto;
-
   ol {
     list-style-type: decimal;
   }


### PR DESCRIPTION
## Fix

Editor was not overflowing correctly on long messages. Now we add an overflow and a max-height.

<img width="973" alt="Screenshot 2021-07-09 at 00 09 03" src="https://user-images.githubusercontent.com/4765697/124991296-22bdd500-e04a-11eb-82ef-fd25cb4d30de.png">


<img width="842" alt="Screenshot 2021-07-09 at 00 08 10" src="https://user-images.githubusercontent.com/4765697/124991294-22253e80-e04a-11eb-8158-2c5dc34c06a6.png">
