### PR TITLE
ACA-526: fix: do not use shared cache for ssr

### DIFF
--- a/frontend/src/apollo/client.tsx
+++ b/frontend/src/apollo/client.tsx
@@ -171,7 +171,7 @@ export const getApolloClient = memoize((options: ApolloClientOptions = {}): Apol
   return new ApolloClient({
     ssrMode,
     link,
-    cache,
+    cache: ssrMode ? new InMemoryCache({ typePolicies }) : cache,
   });
 });
 


### PR DESCRIPTION
The same cache object was used for all requests during SSR. 