### PR TITLE
fix: avatar list now does not block search results

### DIFF
--- a/ui/popovers/PopoverMenuTrigger.tsx
+++ b/ui/popovers/PopoverMenuTrigger.tsx
@@ -44,7 +44,12 @@ export const PopoverMenuTrigger = styled(
         </UIHolder>
         <AnimatePresence>
           {isOpen && (
-            <PopoverMenu placement={placement} options={options} anchorRef={anchorRef} onCloseRequest={closePopover} />
+            <UIPopoverMenu
+              placement={placement}
+              options={options}
+              anchorRef={anchorRef}
+              onCloseRequest={closePopover}
+            />
           )}
         </AnimatePresence>
       </>
@@ -52,6 +57,8 @@ export const PopoverMenuTrigger = styled(
   }
 )``;
 
-const UIHolder = styled.div`
+const UIHolder = styled.div``;
+
+const UIPopoverMenu = styled(PopoverMenu)`
   z-index: ${zIndex.Popover};
 `;


### PR DESCRIPTION
## Problem

`PopoverMenuTrigger` had a popover z-index over the entire contents of the component. This included the "trigger" button as well.

## Fix

Only have the `PopoverMenu` have a popover z-index.