### PR TITLE
fix: fixed wrong ui for datetime picker in safari

### DIFF
--- a/ui/time/DateTimeInput.tsx
+++ b/ui/time/DateTimeInput.tsx
@@ -46,7 +46,7 @@ export const DateTimeInput = ({ value, onChange, isReadonly = false, label }: Pr
         icon={<IconCalendar />}
         indicateDropdown
       >
-        <UIHolder isReadonly={isReadonly} onFocus={openPicker} type="button" onClick={openPicker}>
+        <UIHolder isReadonly={isReadonly} onFocus={openPicker} onClick={openPicker}>
           <TextBody>{format(value, "dd.MM.yyyy, p")}</TextBody>
         </UIHolder>
       </FieldWithLabel>


### PR DESCRIPTION
<img width="669" alt="CleanShot 2021-07-20 at 14 42 27@2x" src="https://user-images.githubusercontent.com/7311462/126325909-fd244445-8d83-4c82-a2a3-797fc3bf6c35.png">

Safari has in-built styles that any element (even div) with `type="button"` will have button like built in styles.