### PR TITLE
feat: reuse general tooltip for reaction tooltips

### DIFF
--- a/frontend/src/ui/message/reactions/MessageReactions/MessageReaction.tsx
+++ b/frontend/src/ui/message/reactions/MessageReactions/MessageReaction.tsx
@@ -1,15 +1,12 @@
 import React, { useRef } from "react";
 import styled, { css } from "styled-components";
-import { AnimatePresence } from "framer-motion";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { MessageDetailedInfoFragment, ReactionBasicInfoFragment } from "~gql";
 import { BACKGROUND_ACCENT, BACKGROUND_ACCENT_WEAK, WHITE, SECONDARY_TEXT_COLOR } from "~ui/colors";
 import { addMessageReaction, removeMessageReaction } from "~frontend/gql/reactions";
-import { Popover } from "~ui/popovers/Popover";
 import { MessageReactionTooltip } from "./MessageReactionTooltip";
-import { useBoolean } from "~shared/hooks/useBoolean";
-import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
 import { fontSize } from "~ui/baseStyles";
+import { Tooltip } from "~ui/popovers/Tooltip";
 
 interface Props {
   message: MessageDetailedInfoFragment;
@@ -41,28 +38,18 @@ export const MessageReaction = ({ message, emoji, reactions }: Props) => {
   };
 
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const [isHovered, { set: setHovered, unset: unsetHovered }] = useBoolean(false);
-  const shouldShowTooltip = useDebouncedValue(isHovered, { onDelay: 150, offDelay: 0 });
 
   return (
     <>
-      <UIReactionButton
-        onMouseEnter={setHovered}
-        onMouseLeave={unsetHovered}
-        ref={buttonRef}
-        onClick={handleClick}
-        isSelected={isSelectedByCurrentUser}
-      >
+      <UIReactionButton ref={buttonRef} onClick={handleClick} isSelected={isSelectedByCurrentUser}>
         <p>{emoji}</p>
         <p>{reactions.length}</p>
       </UIReactionButton>
-      <AnimatePresence>
-        {shouldShowTooltip && (
-          <Popover distance={10} anchorRef={buttonRef} placement="bottom">
-            <MessageReactionTooltip reactions={reactions} emoji={emoji} />
-          </Popover>
-        )}
-      </AnimatePresence>
+      <Tooltip
+        anchorRef={buttonRef}
+        placement="bottom"
+        label={<MessageReactionTooltip reactions={reactions} emoji={emoji} />}
+      />
     </>
   );
 };

--- a/frontend/src/ui/message/reactions/MessageReactions/MessageReactionTooltip.tsx
+++ b/frontend/src/ui/message/reactions/MessageReactions/MessageReactionTooltip.tsx
@@ -4,7 +4,6 @@ import { getEmojiDataFromNative, Data as EmojiDataset } from "emoji-mart";
 import data from "emoji-mart/data/all.json";
 import { ReactionBasicInfoFragment } from "~gql";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { borderRadius, colors } from "~ui/baseStyles";
 import { WHITE } from "~ui/colors";
 
 interface Props {
@@ -34,28 +33,13 @@ export const MessageReactionTooltip = ({ reactions, emoji }: Props) => {
   const emojiShortName = getEmojiDataFromNative(emoji, "apple", data as never as EmojiDataset).id;
 
   return (
-    <UIHolder>
-      <UIContent>
-        <UIReacted>{getTextThatShowsWhoReacted()}</UIReacted> reacted with <UIEmojiName>:{emojiShortName}:</UIEmojiName>
-      </UIContent>
-    </UIHolder>
+    <UIContent>
+      <UIReacted>{getTextThatShowsWhoReacted()}</UIReacted> reacted with <UIEmojiName>:{emojiShortName}:</UIEmojiName>
+    </UIContent>
   );
 };
 
-const UIHolder = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background-color: ${colors.tooltip.background};
-  max-width: 160px;
-  padding: 8px;
-  ${borderRadius.label};
-  pointer-events: none;
-  line-height: 1.2rem;
-`;
-
 const UIContent = styled.div`
-  font-size: 12px;
   color: hsla(0, 0%, 100%, 60%);
   text-align: center;
   word-break: break-word;

--- a/shared/channel.ts
+++ b/shared/channel.ts
@@ -9,6 +9,7 @@ export interface Channel<T> {
   subscribe(subscriber: Subscriber<T>): Cancel;
   useLastValue(): T | null;
   useSubscribe(subscriber: Subscriber<T>): void;
+  useLastValueSelector<R>(selector: (lastValue: T | null) => R): R;
 }
 
 type ValueWrapper<T> = { value: T } | null;
@@ -70,6 +71,18 @@ export function createChannel<T>(): Channel<T> {
     return value;
   }
 
+  function useLastValueSelector<R>(selector: (lastValue: T | null) => R): R {
+    const [selectedValue, setSelectedValue] = useState(() => {
+      return selector(getLastValue());
+    });
+
+    useSubscribe((newValue) => {
+      setSelectedValue(selector(newValue));
+    });
+
+    return selectedValue;
+  }
+
   function useSubscribe(subscriber: Subscriber<T>) {
     useEffect(() => {
       return subscribe(subscriber);
@@ -82,6 +95,7 @@ export function createChannel<T>(): Channel<T> {
     subscribe,
     useLastValue,
     useSubscribe,
+    useLastValueSelector,
   };
 }
 

--- a/shared/domEvents.ts
+++ b/shared/domEvents.ts
@@ -6,6 +6,8 @@ export function createWindowEvent<K extends keyof WindowEventMap>(
   handler: (event: WindowEventMap[K]) => void,
   options?: AddEventListenerOptions
 ) {
+  if (typeof window === "undefined") return;
+
   window.addEventListener(type, handler, options);
 
   return function cancel() {
@@ -28,6 +30,8 @@ export function createDocumentEvent<K extends keyof DocumentEventMap>(
   handler: (event: DocumentEventMap[K]) => void,
   options?: AddEventListenerOptions
 ) {
+  if (typeof document === "undefined") return;
+
   document.addEventListener(type, handler, options);
 
   return function cancel() {

--- a/ui/popovers/Tooltip.tsx
+++ b/ui/popovers/Tooltip.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import styled from "styled-components";
+import { createChannel } from "~shared/channel";
+import { createDocumentEvent, createWindowEvent, useElementEvent } from "~shared/domEvents";
+import { useId } from "~shared/id";
+import { AnimatePresence } from "framer-motion";
+import { TooltipLabel, TooltipLabelProps } from "./TooltipLabel";
+import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
+
+/**
+ * Having shared channel instead of 'isOpened' local state ensures there is never more than 1 tooltips opened at once
+ */
+const activeTooltipIdChannel = createChannel<string | null>();
+
+createDocumentEvent("blur", () => {
+  activeTooltipIdChannel.publish(null);
+});
+
+createWindowEvent(
+  "scroll",
+  () => {
+    activeTooltipIdChannel.publish(null);
+  },
+  { capture: true }
+);
+
+export const Tooltip = styled((props: TooltipLabelProps) => {
+  const id = useId();
+
+  const isActive = activeTooltipIdChannel.useLastValueSelector<boolean>((activeTooltipId) => activeTooltipId === id);
+
+  const shouldRender = useDebouncedValue(isActive, { onDelay: 150, offDelay: 0 });
+
+  useElementEvent(
+    props.anchorRef,
+    "mouseenter",
+    () => {
+      activeTooltipIdChannel.publish(id);
+    },
+    {}
+  );
+
+  useElementEvent(
+    props.anchorRef,
+    "mouseleave",
+    () => {
+      activeTooltipIdChannel.publish(null);
+    },
+    { isEnabled: isActive }
+  );
+
+  return <AnimatePresence>{shouldRender && <TooltipLabel {...props} />}</AnimatePresence>;
+})``;

--- a/ui/popovers/TooltipLabel.tsx
+++ b/ui/popovers/TooltipLabel.tsx
@@ -1,19 +1,20 @@
-import React, { RefObject } from "react";
+import React, { ReactNode, RefObject } from "react";
 import styled from "styled-components";
 import { POP_PRESENCE_STYLES } from "~ui/animations";
 import { borderRadius, colors, fontSize } from "~ui/baseStyles";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
-import { Popover } from "./Popover";
+import { Popover, PopoverPlacement } from "./Popover";
 
-interface Props {
+export interface TooltipLabelProps {
   anchorRef: RefObject<HTMLElement>;
-  label: string;
+  label: ReactNode;
   isDisabled?: boolean;
+  placement?: PopoverPlacement;
 }
 
-export const TooltipLabel = styled(({ anchorRef, label, isDisabled }: Props) => {
+export const TooltipLabel = styled(({ anchorRef, label, isDisabled, placement = "top" }: TooltipLabelProps) => {
   return (
-    <Popover anchorRef={anchorRef} isDisabled={isDisabled} placement="top">
+    <Popover anchorRef={anchorRef} isDisabled={isDisabled} placement={placement}>
       <UITooltip presenceStyles={POP_PRESENCE_STYLES}>{label}</UITooltip>
     </Popover>
   );
@@ -27,4 +28,8 @@ const UITooltip = styled(PresenceAnimator)`
   padding: 0.5rem 0.75rem;
   ${borderRadius.item};
   pointer-events: none;
+  line-height: 1.5em;
+  font-size: 0.875rem;
+  max-width: 240px;
+  text-align: center;
 `;


### PR DESCRIPTION
![CleanShot 2021-07-21 at 10 12 04](https://user-images.githubusercontent.com/7311462/126454890-8212943a-d59f-49b3-8a5e-0a72732f8c87.gif)

Reusing the same tooltip component for both normal `data-tooltip` and reactions.

It results in the same UI, typography and animations for every tooltip

FYI @RodionChachura 