### PR TITLE
feat: mobx - replaced old shared state with mobx

### DIFF
--- a/frontend/src/rooms/RoomStore.ts
+++ b/frontend/src/rooms/RoomStore.ts
@@ -1,11 +1,11 @@
-import { createSharedStateContext } from "~shared/sharedState";
+import { createStoreContext } from "~shared/sharedState";
 
 interface State {
   newTopicId: string | null;
   editingNameTopicId: string | null;
 }
 
-export const [RoomStoreContext, useRoomStoreContext] = createSharedStateContext<State>(() => ({
+export const [RoomStoreContext, useRoomStoreContext] = createStoreContext<State>(() => ({
   newTopicId: null,
   editingNameTopicId: null,
 }));

--- a/frontend/src/topics/TopicStore.ts
+++ b/frontend/src/topics/TopicStore.ts
@@ -1,12 +1,12 @@
 import { MessageDetailedInfoFragment } from "~gql";
-import { createSharedStateContext } from "~shared/sharedState";
+import { createStoreContext } from "~shared/sharedState";
 
 interface State {
   currentlyReplyingToMessage: MessageDetailedInfoFragment | null;
   editedMessageId: string | null;
 }
 
-export const [TopicStoreContext, useTopicStoreContext] = createSharedStateContext<State>(() => ({
+export const [TopicStoreContext, useTopicStoreContext] = createStoreContext<State>(() => ({
   currentlyReplyingToMessage: null,
   editedMessageId: null,
 }));

--- a/frontend/src/ui/message/reply/ReplyButton.tsx
+++ b/frontend/src/ui/message/reply/ReplyButton.tsx
@@ -3,17 +3,18 @@ import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { IconReply } from "~ui/icons";
 import { useTopicStoreContext } from "~frontend/topics/TopicStore";
 import { MessageDetailedInfoFragment } from "~gql";
+import { observer } from "mobx-react";
 
 interface Props {
   message: MessageDetailedInfoFragment;
 }
 
-export const ReplyButton = ({ message }: Props) => {
+export const ReplyButton = observer(({ message }: Props) => {
   const topicContext = useTopicStoreContext();
 
   async function handleMarkAsBeingRepliedTo() {
-    topicContext.update((draft) => (draft.currentlyReplyingToMessage = message));
+    topicContext.currentlyReplyingToMessage = message;
   }
 
   return <WideIconButton kind="secondary" tooltip="Reply" onClick={handleMarkAsBeingRepliedTo} icon={<IconReply />} />;
-};
+});

--- a/frontend/src/views/RoomView/TopicsList/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/index.tsx
@@ -12,6 +12,8 @@ import { isCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { CollapsePanel } from "~ui/collapse/CollapsePanel";
 import { useNewItemInArrayEffect } from "~shared/hooks/useNewItemInArrayEffect";
 import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
+import { runInAction } from "mobx";
+import { observer } from "mobx-react";
 
 interface Props {
   room: RoomDetailedInfoFragment;
@@ -19,7 +21,7 @@ interface Props {
   isRoomOpen: boolean;
 }
 
-export function TopicsList({ room, activeTopicId, isRoomOpen }: Props) {
+export const TopicsList = observer(function TopicsList({ room, activeTopicId, isRoomOpen }: Props) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const roomId = room.id;
   const spaceId = room.space_id;
@@ -45,9 +47,9 @@ export function TopicsList({ room, activeTopicId, isRoomOpen }: Props) {
     topics,
     (topic) => topic.id,
     (newTopic) => {
-      roomContext.update((draft) => {
-        draft.newTopicId = newTopic.id;
-        draft.editingNameTopicId = newTopic.id;
+      runInAction(() => {
+        roomContext.newTopicId = newTopic.id;
+        roomContext.editingNameTopicId = newTopic.id;
       });
       routes.spaceRoomTopic.push({ topicId: newTopic.id, spaceId: room.space_id, roomId: room.id });
     }
@@ -88,7 +90,7 @@ export function TopicsList({ room, activeTopicId, isRoomOpen }: Props) {
       </UIHolder>
     </CollapsePanel>
   );
-}
+});
 
 const UIHolder = styled.div`
   overflow-y: hidden;

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "express": "^4.17.1",
     "hasura-cli": "^2.0.1",
     "husky": "^7.0.1",
+    "mobx": "^6.3.2",
+    "mobx-react": "^7.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-use": "^17.2.4",

--- a/shared/sharedState.tsx
+++ b/shared/sharedState.tsx
@@ -1,64 +1,37 @@
-import { createContext, PropsWithChildren, useContext, useRef, useState } from "react";
+import { autorun, computed, configure, makeAutoObservable, runInAction } from "mobx";
+import { createContext, PropsWithChildren, useContext, useEffect } from "react";
 import { useConst } from "~shared/hooks/useConst";
 import { assert } from "./assert";
-import { createChannel } from "./channel";
-import { updateValue, ValueUpdater } from "./updateValue";
 
-interface SharedStateContext<T> {
-  useValue(): T;
-  useSelector<S>(selector: (value: T) => S): S;
-  update(updater: ValueUpdater<T>): void;
-  getValue(): T;
+export function select<T>(selector: () => T): T {
+  return computed(selector).get();
 }
 
-/**
- * This function allows creating shared state that can be used across multiple components in the same context.
- *
- * If any of components will update the value, all other components in the same context will re-render.
- *
- * Usage
- *
- * interface State {
- *   topicId: string;
- *   currentlyReplyingToMessageId: string | null
- * }
- *
- * interface ContextProviderProps {
- *   topicId: string;
- * }
- *
- * const [TopicStoreContext, useTopicContext] = createSharedStateContext<State, ContextProviderProps>(props => {
- *   return {
- *     topicId: props.topicId;
- *     currentlyReplyingToMessageId: null
- *   }
- * })
- *
- * To render context:
- *
- * <TopicStoreContext topicId="abc">content</TopicStoreContext>
- *
- * To use the state:
- *
- * const topicContext = useTopicStore();
- *
- * Updating the state.
- *
- * There are 2 ways of updating the state.
- *
- * First is to just provide new state value:
- *
- * topicContext.update({topicId: 'abc', currentlyReplyingToMessageId: 'cde'})
- *
- * Second is to use updater function which is based on immer, so you can mutate draft in the callback:
- *
- * topicContext.update(draft => draft.currentlyReplyingToMessageId = 'abc')
- *
- * If an update is made, all components using 'topicContext.useValue()' will be re-rendered
- */
+export function useAutorun(runner: () => void) {
+  useEffect(() => {
+    return autorun(runner);
+  });
+}
+
+export function createActionHandler(handler: () => void) {
+  return () => {
+    runInAction(() => {
+      handler();
+    });
+  };
+}
+
+configure({
+  // Not sure if we want to enable this. By default mobx will warn when updating state outside of runInAction call or
+  // store updating itself (store 'methods' will automatically be wrapped in runInAction) (https://mobx.js.org/actions.html)
+  enforceActions: "never",
+});
+
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function createSharedStateContext<T, P = {}>(initialValueInitializator: (contextProviderProps: P) => T) {
-  const context = createContext<SharedStateContext<T> | null>(null);
+export function createStoreContext<T extends object, P = {}>(
+  initialValueInitializator: (contextProviderProps: P) => T
+) {
+  const context = createContext<T | null>(null);
 
   function useSharedStateContext() {
     const rawContextValue = useContext(context);
@@ -67,85 +40,16 @@ export function createSharedStateContext<T, P = {}>(initialValueInitializator: (
     return rawContextValue;
   }
 
+  function createStore(props: P) {
+    const rawResult = initialValueInitializator(props);
+
+    return makeAutoObservable(rawResult);
+  }
+
   function SharedStateContextProvider(props: PropsWithChildren<P>) {
-    const initialValue = useConst(() => initialValueInitializator(props));
+    const initialValue = useConst(() => createStore(props));
 
-    const lastValueRef = useRef(initialValue);
-
-    const channel = useConst(() => createChannel<T>());
-
-    channel.useSubscribe((newValue) => {
-      lastValueRef.current = newValue;
-    });
-
-    function update(updaterOrNewState: ValueUpdater<T>) {
-      const newValueState = updateValue(lastValueRef.current, updaterOrNewState);
-
-      channel.publish(newValueState);
-    }
-
-    /**
-     * This hook will use shared state value.
-     *
-     * It has very similar API to regular useState hook, but updates will be broadcasted to all other users of this state
-     * in the same context.
-     *
-     * Also update function supports immer based state mutations.
-     */
-    function useValue() {
-      const [value, setValue] = useState(lastValueRef.current);
-
-      channel.useSubscribe(setValue);
-
-      return value;
-    }
-
-    /**
-     * It is useful if we want to follow shared state value, but only re-render if some specific change occurs.
-     *
-     * Use case:
-     * Let's say you have 'editedMessageId' in the store and then you have <Message id={messageId} /> component.
-     *
-     * This component has to show edit tools only if its messageId === editedMessageId.
-     *
-     * It means it only has to re-render when value of messageId === editedMessageId changes, not when value of editedMessageId changes.
-     *
-     * Therefore it can be used like
-     *
-     * const amIEditedNow = useSharedStateSelector(state => state.editedMessageId === messageId);
-     *
-     * ---
-     *
-     * amIEditedNow is true / false and component will only re-render if result value changes.
-     */
-    function useSelector<S>(selector: (stateValue: T) => S) {
-      const [selectedValue, setSelectedValue] = useState(() => {
-        return selector(lastValueRef.current);
-      });
-
-      channel.useSubscribe((newStateValue) => {
-        const newSelectedValue = selector(newStateValue);
-
-        setSelectedValue(newSelectedValue);
-      });
-
-      return selectedValue as S;
-    }
-
-    function getValue() {
-      return lastValueRef.current;
-    }
-
-    const contextValue = useConst<SharedStateContext<T>>(() => {
-      return {
-        getValue,
-        useSelector,
-        useValue,
-        update,
-      };
-    });
-
-    return <context.Provider value={contextValue}>{props.children}</context.Provider>;
+    return <context.Provider value={initialValue}>{props.children}</context.Provider>;
   }
 
   return [SharedStateContextProvider, useSharedStateContext] as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8446,6 +8446,23 @@ mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mobx-react-lite@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz#331d7365a6b053378dfe9c087315b4e41c5df69f"
+  integrity sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==
+
+mobx-react@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.2.0.tgz#241e925e963bb83a31d269f65f9f379e37ecbaeb"
+  integrity sha512-KHUjZ3HBmZlNnPd1M82jcdVsQRDlfym38zJhZEs33VxyVQTvL77hODCArq6+C1P1k/6erEeo2R7rpE7ZeOL7dg==
+  dependencies:
+    mobx-react-lite "^3.2.0"
+
+mobx@^6.3.2:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.3.2.tgz#125590961f702a572c139ab69392bea416d2e51b"
+  integrity sha512-xGPM9dIE1qkK9Nrhevp0gzpsmELKU4MFUJRORW/jqxVFIHHWIoQrjDjL8vkwoJYY3C2CeVJqgvl38hgKTalTWg==
+
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"


### PR DESCRIPTION
This PR replaces our `shared state` 'lib' with mobx

It modifies a bit the API we have:

```ts
const replyingToMessageId = topicContext.useSelector((store) => store.currentlyReplyingToMessage);
// becomes
const replyingToMessageId = select(() => topicContext.currentlyReplyingToMessage);
```

```ts
  const handleStopReplyingToMessage = () => {
    topicContext.update((draft) => (draft.currentlyReplyingToMessage = null));
    // becomes
    topicContext.currentlyReplyingToMessage = null;
  };
```

There are some details

eg. running multiple properties changes should be wrapped in `runInAction`

```ts
      runInAction(() => {
        roomContext.newTopicId = newTopic.id;
        roomContext.editingNameTopicId = newTopic.id;
      });
```

so mobx will update components after all the changes, not after each one

It is also possible to call `effect` without the need of component re-rendering if used value is not needed for the render itself:

we can use this:
```ts
  useAutorun(() => {
    if (!roomContext.editingNameTopicId) {
      focusEditor();
    }
  });
```

Note ^ `.editingNameTopicId` is not used 'during' the render so `editingNameTopicId` will not cause re-render, even tho effect is using it.

Before we had

```ts
const isEditingAnyTopicTitle = roomContext.useSelector((store) => !!store.editingNameTopicId);
  useDependencyChangeEffect(() => {
    if (!isEditingAnyTopicTitle) focusEditor();
  }, [isEditingAnyTopicTitle]);
```

Note ^ component was re-rendering when `isEditingAnyTopicTitle` changed, even tho the only places we actually use it is inside the effect, which means it was kinda wasted render.