### PR TITLE
Part of Aca 533: Remove unused room_invites table

### DIFF
--- a/backend/src/rooms/rooms.ts
+++ b/backend/src/rooms/rooms.ts
@@ -1,4 +1,4 @@
-import { db, Room, RoomInvites, RoomParticipants } from "~db";
+import { db, Room, RoomParticipants } from "~db";
 
 export async function findRoomById(roomId: string): Promise<Room | null> {
   return await db.room.findUnique({
@@ -11,32 +11,6 @@ export async function addRoomParticipant(roomId: string, participantId: string):
     data: {
       room_id: roomId,
       user_id: participantId,
-    },
-  });
-}
-
-// Transactional
-export async function addRoomParticipantAndInvalidateInvite(invite: RoomInvites, participantId: string): Promise<Room> {
-  return await db.room.update({
-    where: {
-      id: invite.room_id,
-    },
-    data: {
-      room_invites: {
-        update: {
-          where: {
-            id: invite.id,
-          },
-          data: {
-            used_at: new Date(),
-          },
-        },
-      },
-      room_member: {
-        create: {
-          user_id: participantId,
-        },
-      },
     },
   });
 }

--- a/db/index.ts
+++ b/db/index.ts
@@ -6,7 +6,6 @@ export type {
   message as Message,
   message_type as MessageType,
   room as Room,
-  room_invites as RoomInvites,
   room_member as RoomParticipants,
   topic as Topic,
   user as User,

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -74,39 +74,24 @@ model message_type {
 }
 
 model room {
-  id                              String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  creator_id                      String         @db.Uuid
+  id                              String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  creator_id                      String        @db.Uuid
   name                            String
-  created_at                      DateTime       @default(now()) @db.Timestamptz(6)
-  deadline                        DateTime       @default(dbgenerated("date_trunc('hour'::text, (now() + '7 days'::interval))")) @db.Timestamptz(6)
+  created_at                      DateTime      @default(now()) @db.Timestamptz(6)
+  deadline                        DateTime      @default(dbgenerated("date_trunc('hour'::text, (now() + '7 days'::interval))")) @db.Timestamptz(6)
   notification_job_id             String?
   summary                         String?
-  finished_at                     DateTime?      @db.Timestamptz(6)
-  space_id                        String         @db.Uuid
+  finished_at                     DateTime?     @db.Timestamptz(6)
+  space_id                        String        @db.Uuid
   slug                            String
   source_google_calendar_event_id String?
-  is_private                      Boolean        @default(false)
-  user                            user           @relation(fields: [creator_id], references: [id])
-  space                           space          @relation(fields: [space_id], references: [id])
-  room_invites                    room_invites[]
+  is_private                      Boolean       @default(false)
+  user                            user          @relation(fields: [creator_id], references: [id])
+  space                           space         @relation(fields: [space_id], references: [id])
   room_member                     room_member[]
   topic                           topic[]
 
   @@unique([slug, space_id], name: "room_slug_space_id_key")
-}
-
-model room_invites {
-  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  room_id    String    @db.Uuid
-  inviter_id String    @db.Uuid
-  code       String    @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  email      String
-  created_at DateTime  @default(now()) @db.Timestamptz(6)
-  used_at    DateTime? @db.Timestamptz(6)
-  user       user      @relation(fields: [inviter_id], references: [id])
-  room       room      @relation(fields: [room_id], references: [id])
-
-  @@unique([room_id, email], name: "room_invites_room_id_email_key")
 }
 
 model room_member {
@@ -232,7 +217,6 @@ model user {
   message                                               message[]
   message_reaction                                      message_reaction[]
   room                                                  room[]
-  room_invites                                          room_invites[]
   room_member                                           room_member[]
   space_member                                          space_member[]
   team_team_owner_idTouser                              team[]              @relation("team_owner_idTouser")

--- a/frontend/src/gql/invitations.ts
+++ b/frontend/src/gql/invitations.ts
@@ -1,38 +1,7 @@
 import { gql } from "@apollo/client";
-import {
-  AcceptInviteMutation,
-  AcceptInviteMutationVariables,
-  CreateInviteMutation,
-  CreateInviteMutationVariables,
-  LookupTeamNameQuery,
-  LookupTeamNameQueryVariables,
-} from "~gql";
+import { LookupTeamNameQuery, LookupTeamNameQueryVariables } from "~gql";
 
-import { createMutation, createQuery } from "./utils";
-
-export const [useCreateInviteMutation] = createMutation<CreateInviteMutation, CreateInviteMutationVariables>(
-  () => gql`
-    mutation CreateInvite($email: String!, $roomId: uuid) {
-      invite: insert_room_invites_one(object: { email: $email, room_id: $roomId }) {
-        id
-        email
-        usedAt: used_at
-      }
-    }
-  `
-);
-
-export const [useAcceptInviteMutation] = createMutation<AcceptInviteMutation, AcceptInviteMutationVariables>(
-  () => gql`
-    mutation AcceptInvite($token: String!) {
-      invite: accept_invite(token: $token) {
-        team {
-          id
-        }
-      }
-    }
-  `
-);
+import { createQuery } from "./utils";
 
 export const [lookupTeamName] = createQuery<LookupTeamNameQuery, LookupTeamNameQueryVariables>(
   () => gql`

--- a/gql/generated.ts
+++ b/gql/generated.ts
@@ -37,18 +37,6 @@ export interface DownloadUrlResponse {
   downloadUrl: Scalars['String'];
 }
 
-export interface InviteAcceptCommand {
-  code: Scalars['String'];
-}
-
-export interface InviteAcceptResponse {
-  __typename?: 'InviteAcceptResponse';
-  invite?: Maybe<Room_Invites>;
-  invite_id: Scalars['ID'];
-  team?: Maybe<Team>;
-  team_id: Scalars['ID'];
-}
-
 export interface LookupTeamNameResponse {
   __typename?: 'LookupTeamNameResponse';
   inviter_name: Scalars['String'];
@@ -1793,8 +1781,6 @@ export type Message_Update_Column =
 /** mutation root */
 export interface Mutation_Root {
   __typename?: 'mutation_root';
-  /** perform the action: "accept_invite" */
-  accept_invite?: Maybe<InviteAcceptResponse>;
   /** delete data from the table: "account" */
   delete_account?: Maybe<Account_Mutation_Response>;
   /** delete single row from the table: "account" */
@@ -1829,10 +1815,6 @@ export interface Mutation_Root {
   delete_room?: Maybe<Room_Mutation_Response>;
   /** delete single row from the table: "room" */
   delete_room_by_pk?: Maybe<Room>;
-  /** delete data from the table: "room_invites" */
-  delete_room_invites?: Maybe<Room_Invites_Mutation_Response>;
-  /** delete single row from the table: "room_invites" */
-  delete_room_invites_by_pk?: Maybe<Room_Invites>;
   /** delete data from the table: "room_member" */
   delete_room_member?: Maybe<Room_Member_Mutation_Response>;
   /** delete single row from the table: "room_member" */
@@ -1915,10 +1897,6 @@ export interface Mutation_Root {
   insert_message_type_one?: Maybe<Message_Type>;
   /** insert data into the table: "room" */
   insert_room?: Maybe<Room_Mutation_Response>;
-  /** insert data into the table: "room_invites" */
-  insert_room_invites?: Maybe<Room_Invites_Mutation_Response>;
-  /** insert a single row into the table: "room_invites" */
-  insert_room_invites_one?: Maybe<Room_Invites>;
   /** insert data into the table: "room_member" */
   insert_room_member?: Maybe<Room_Member_Mutation_Response>;
   /** insert a single row into the table: "room_member" */
@@ -2003,10 +1981,6 @@ export interface Mutation_Root {
   update_room?: Maybe<Room_Mutation_Response>;
   /** update single row of the table: "room" */
   update_room_by_pk?: Maybe<Room>;
-  /** update data of the table: "room_invites" */
-  update_room_invites?: Maybe<Room_Invites_Mutation_Response>;
-  /** update single row of the table: "room_invites" */
-  update_room_invites_by_pk?: Maybe<Room_Invites>;
   /** update data of the table: "room_member" */
   update_room_member?: Maybe<Room_Member_Mutation_Response>;
   /** update single row of the table: "room_member" */
@@ -2057,12 +2031,6 @@ export interface Mutation_Root {
   update_whitelist_by_pk?: Maybe<Whitelist>;
   /** perform the action: "upgrade_current_user" */
   upgrade_current_user?: Maybe<UpgradeUserResponse>;
-}
-
-
-/** mutation root */
-export interface Mutation_RootAccept_InviteArgs {
-  token: Scalars['String'];
 }
 
 
@@ -2167,18 +2135,6 @@ export interface Mutation_RootDelete_RoomArgs {
 
 /** mutation root */
 export interface Mutation_RootDelete_Room_By_PkArgs {
-  id: Scalars['uuid'];
-}
-
-
-/** mutation root */
-export interface Mutation_RootDelete_Room_InvitesArgs {
-  where: Room_Invites_Bool_Exp;
-}
-
-
-/** mutation root */
-export interface Mutation_RootDelete_Room_Invites_By_PkArgs {
   id: Scalars['uuid'];
 }
 
@@ -2445,20 +2401,6 @@ export interface Mutation_RootInsert_Message_Type_OneArgs {
 export interface Mutation_RootInsert_RoomArgs {
   objects: Array<Room_Insert_Input>;
   on_conflict?: Maybe<Room_On_Conflict>;
-}
-
-
-/** mutation root */
-export interface Mutation_RootInsert_Room_InvitesArgs {
-  objects: Array<Room_Invites_Insert_Input>;
-  on_conflict?: Maybe<Room_Invites_On_Conflict>;
-}
-
-
-/** mutation root */
-export interface Mutation_RootInsert_Room_Invites_OneArgs {
-  object: Room_Invites_Insert_Input;
-  on_conflict?: Maybe<Room_Invites_On_Conflict>;
 }
 
 
@@ -2767,20 +2709,6 @@ export interface Mutation_RootUpdate_Room_By_PkArgs {
 
 
 /** mutation root */
-export interface Mutation_RootUpdate_Room_InvitesArgs {
-  _set?: Maybe<Room_Invites_Set_Input>;
-  where: Room_Invites_Bool_Exp;
-}
-
-
-/** mutation root */
-export interface Mutation_RootUpdate_Room_Invites_By_PkArgs {
-  _set?: Maybe<Room_Invites_Set_Input>;
-  pk_columns: Room_Invites_Pk_Columns_Input;
-}
-
-
-/** mutation root */
 export interface Mutation_RootUpdate_Room_MemberArgs {
   _set?: Maybe<Room_Member_Set_Input>;
   where: Room_Member_Bool_Exp;
@@ -3033,12 +2961,6 @@ export interface Query_Root {
   room_aggregate: Room_Aggregate;
   /** fetch data from the table: "room" using primary key columns */
   room_by_pk?: Maybe<Room>;
-  /** fetch data from the table: "room_invites" */
-  room_invites: Array<Room_Invites>;
-  /** fetch aggregated fields from the table: "room_invites" */
-  room_invites_aggregate: Room_Invites_Aggregate;
-  /** fetch data from the table: "room_invites" using primary key columns */
-  room_invites_by_pk?: Maybe<Room_Invites>;
   /** fetch data from the table: "room_last_posted_message" */
   room_last_posted_message: Array<Room_Last_Posted_Message>;
   /** fetch aggregated fields from the table: "room_last_posted_message" */
@@ -3380,32 +3302,6 @@ export interface Query_RootRoom_AggregateArgs {
 
 /** query root */
 export interface Query_RootRoom_By_PkArgs {
-  id: Scalars['uuid'];
-}
-
-
-/** query root */
-export interface Query_RootRoom_InvitesArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** query root */
-export interface Query_RootRoom_Invites_AggregateArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** query root */
-export interface Query_RootRoom_Invites_By_PkArgs {
   id: Scalars['uuid'];
 }
 
@@ -3848,10 +3744,6 @@ export interface Room {
   members_aggregate: Room_Member_Aggregate;
   name: Scalars['String'];
   notification_job_id?: Maybe<Scalars['String']>;
-  /** An array relationship */
-  room_invites: Array<Room_Invites>;
-  /** An aggregated array relationship */
-  room_invites_aggregate: Room_Invites_Aggregate;
   slug: Scalars['String'];
   source_google_calendar_event_id?: Maybe<Scalars['String']>;
   /** An object relationship */
@@ -3882,26 +3774,6 @@ export interface RoomMembers_AggregateArgs {
   offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Room_Member_Order_By>>;
   where?: Maybe<Room_Member_Bool_Exp>;
-}
-
-
-/** columns and relationships of "room" */
-export interface RoomRoom_InvitesArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** columns and relationships of "room" */
-export interface RoomRoom_Invites_AggregateArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
 }
 
 
@@ -3975,7 +3847,6 @@ export interface Room_Bool_Exp {
   members?: Maybe<Room_Member_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
   notification_job_id?: Maybe<String_Comparison_Exp>;
-  room_invites?: Maybe<Room_Invites_Bool_Exp>;
   slug?: Maybe<String_Comparison_Exp>;
   source_google_calendar_event_id?: Maybe<String_Comparison_Exp>;
   space?: Maybe<Space_Bool_Exp>;
@@ -4003,7 +3874,6 @@ export interface Room_Insert_Input {
   members?: Maybe<Room_Member_Arr_Rel_Insert_Input>;
   name?: Maybe<Scalars['String']>;
   notification_job_id?: Maybe<Scalars['String']>;
-  room_invites?: Maybe<Room_Invites_Arr_Rel_Insert_Input>;
   slug?: Maybe<Scalars['String']>;
   source_google_calendar_event_id?: Maybe<Scalars['String']>;
   space?: Maybe<Space_Obj_Rel_Insert_Input>;
@@ -4011,226 +3881,6 @@ export interface Room_Insert_Input {
   summary?: Maybe<Scalars['String']>;
   topics?: Maybe<Topic_Arr_Rel_Insert_Input>;
 }
-
-/** columns and relationships of "room_invites" */
-export interface Room_Invites {
-  __typename?: 'room_invites';
-  code: Scalars['uuid'];
-  created_at: Scalars['timestamptz'];
-  email: Scalars['String'];
-  id: Scalars['uuid'];
-  /** An object relationship */
-  inviter: User;
-  inviter_id: Scalars['uuid'];
-  /** An object relationship */
-  room: Room;
-  room_id: Scalars['uuid'];
-  used_at?: Maybe<Scalars['timestamptz']>;
-}
-
-/** aggregated selection of "room_invites" */
-export interface Room_Invites_Aggregate {
-  __typename?: 'room_invites_aggregate';
-  aggregate?: Maybe<Room_Invites_Aggregate_Fields>;
-  nodes: Array<Room_Invites>;
-}
-
-/** aggregate fields of "room_invites" */
-export interface Room_Invites_Aggregate_Fields {
-  __typename?: 'room_invites_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Room_Invites_Max_Fields>;
-  min?: Maybe<Room_Invites_Min_Fields>;
-}
-
-
-/** aggregate fields of "room_invites" */
-export interface Room_Invites_Aggregate_FieldsCountArgs {
-  columns?: Maybe<Array<Room_Invites_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-}
-
-/** order by aggregate values of table "room_invites" */
-export interface Room_Invites_Aggregate_Order_By {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Room_Invites_Max_Order_By>;
-  min?: Maybe<Room_Invites_Min_Order_By>;
-}
-
-/** input type for inserting array relation for remote table "room_invites" */
-export interface Room_Invites_Arr_Rel_Insert_Input {
-  data: Array<Room_Invites_Insert_Input>;
-  on_conflict?: Maybe<Room_Invites_On_Conflict>;
-}
-
-/** Boolean expression to filter rows from the table "room_invites". All fields are combined with a logical 'AND'. */
-export interface Room_Invites_Bool_Exp {
-  _and?: Maybe<Array<Maybe<Room_Invites_Bool_Exp>>>;
-  _not?: Maybe<Room_Invites_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Room_Invites_Bool_Exp>>>;
-  code?: Maybe<Uuid_Comparison_Exp>;
-  created_at?: Maybe<Timestamptz_Comparison_Exp>;
-  email?: Maybe<String_Comparison_Exp>;
-  id?: Maybe<Uuid_Comparison_Exp>;
-  inviter?: Maybe<User_Bool_Exp>;
-  inviter_id?: Maybe<Uuid_Comparison_Exp>;
-  room?: Maybe<Room_Bool_Exp>;
-  room_id?: Maybe<Uuid_Comparison_Exp>;
-  used_at?: Maybe<Timestamptz_Comparison_Exp>;
-}
-
-/** unique or primary key constraints on table "room_invites" */
-export type Room_Invites_Constraint =
-  /** unique or primary key constraint */
-  | 'room_invites_code_key'
-  /** unique or primary key constraint */
-  | 'room_invites_pkey'
-  /** unique or primary key constraint */
-  | 'room_invites_room_id_email_key';
-
-/** input type for inserting data into table "room_invites" */
-export interface Room_Invites_Insert_Input {
-  code?: Maybe<Scalars['uuid']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['uuid']>;
-  inviter?: Maybe<User_Obj_Rel_Insert_Input>;
-  inviter_id?: Maybe<Scalars['uuid']>;
-  room?: Maybe<Room_Obj_Rel_Insert_Input>;
-  room_id?: Maybe<Scalars['uuid']>;
-  used_at?: Maybe<Scalars['timestamptz']>;
-}
-
-/** aggregate max on columns */
-export interface Room_Invites_Max_Fields {
-  __typename?: 'room_invites_max_fields';
-  code?: Maybe<Scalars['uuid']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['uuid']>;
-  inviter_id?: Maybe<Scalars['uuid']>;
-  room_id?: Maybe<Scalars['uuid']>;
-  used_at?: Maybe<Scalars['timestamptz']>;
-}
-
-/** order by max() on columns of table "room_invites" */
-export interface Room_Invites_Max_Order_By {
-  code?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
-  email?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  inviter_id?: Maybe<Order_By>;
-  room_id?: Maybe<Order_By>;
-  used_at?: Maybe<Order_By>;
-}
-
-/** aggregate min on columns */
-export interface Room_Invites_Min_Fields {
-  __typename?: 'room_invites_min_fields';
-  code?: Maybe<Scalars['uuid']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['uuid']>;
-  inviter_id?: Maybe<Scalars['uuid']>;
-  room_id?: Maybe<Scalars['uuid']>;
-  used_at?: Maybe<Scalars['timestamptz']>;
-}
-
-/** order by min() on columns of table "room_invites" */
-export interface Room_Invites_Min_Order_By {
-  code?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
-  email?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  inviter_id?: Maybe<Order_By>;
-  room_id?: Maybe<Order_By>;
-  used_at?: Maybe<Order_By>;
-}
-
-/** response of any mutation on the table "room_invites" */
-export interface Room_Invites_Mutation_Response {
-  __typename?: 'room_invites_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Room_Invites>;
-}
-
-/** input type for inserting object relation for remote table "room_invites" */
-export interface Room_Invites_Obj_Rel_Insert_Input {
-  data: Room_Invites_Insert_Input;
-  on_conflict?: Maybe<Room_Invites_On_Conflict>;
-}
-
-/** on conflict condition type for table "room_invites" */
-export interface Room_Invites_On_Conflict {
-  constraint: Room_Invites_Constraint;
-  update_columns: Array<Room_Invites_Update_Column>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-/** ordering options when selecting data from "room_invites" */
-export interface Room_Invites_Order_By {
-  code?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
-  email?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  inviter?: Maybe<User_Order_By>;
-  inviter_id?: Maybe<Order_By>;
-  room?: Maybe<Room_Order_By>;
-  room_id?: Maybe<Order_By>;
-  used_at?: Maybe<Order_By>;
-}
-
-/** primary key columns input for table: "room_invites" */
-export interface Room_Invites_Pk_Columns_Input {
-  id: Scalars['uuid'];
-}
-
-/** select columns of table "room_invites" */
-export type Room_Invites_Select_Column =
-  /** column name */
-  | 'code'
-  /** column name */
-  | 'created_at'
-  /** column name */
-  | 'email'
-  /** column name */
-  | 'id'
-  /** column name */
-  | 'inviter_id'
-  /** column name */
-  | 'room_id'
-  /** column name */
-  | 'used_at';
-
-/** input type for updating data in table "room_invites" */
-export interface Room_Invites_Set_Input {
-  code?: Maybe<Scalars['uuid']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['uuid']>;
-  inviter_id?: Maybe<Scalars['uuid']>;
-  room_id?: Maybe<Scalars['uuid']>;
-  used_at?: Maybe<Scalars['timestamptz']>;
-}
-
-/** update columns of table "room_invites" */
-export type Room_Invites_Update_Column =
-  /** column name */
-  | 'code'
-  /** column name */
-  | 'created_at'
-  /** column name */
-  | 'email'
-  /** column name */
-  | 'id'
-  /** column name */
-  | 'inviter_id'
-  /** column name */
-  | 'room_id'
-  /** column name */
-  | 'used_at';
 
 /** columns and relationships of "room_last_posted_message" */
 export interface Room_Last_Posted_Message {
@@ -4571,7 +4221,6 @@ export interface Room_Order_By {
   members_aggregate?: Maybe<Room_Member_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
   notification_job_id?: Maybe<Order_By>;
-  room_invites_aggregate?: Maybe<Room_Invites_Aggregate_Order_By>;
   slug?: Maybe<Order_By>;
   source_google_calendar_event_id?: Maybe<Order_By>;
   space?: Maybe<Space_Order_By>;
@@ -5122,12 +4771,6 @@ export interface Subscription_Root {
   room_aggregate: Room_Aggregate;
   /** fetch data from the table: "room" using primary key columns */
   room_by_pk?: Maybe<Room>;
-  /** fetch data from the table: "room_invites" */
-  room_invites: Array<Room_Invites>;
-  /** fetch aggregated fields from the table: "room_invites" */
-  room_invites_aggregate: Room_Invites_Aggregate;
-  /** fetch data from the table: "room_invites" using primary key columns */
-  room_invites_by_pk?: Maybe<Room_Invites>;
   /** fetch data from the table: "room_last_posted_message" */
   room_last_posted_message: Array<Room_Last_Posted_Message>;
   /** fetch aggregated fields from the table: "room_last_posted_message" */
@@ -5469,32 +5112,6 @@ export interface Subscription_RootRoom_AggregateArgs {
 
 /** subscription root */
 export interface Subscription_RootRoom_By_PkArgs {
-  id: Scalars['uuid'];
-}
-
-
-/** subscription root */
-export interface Subscription_RootRoom_InvitesArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** subscription root */
-export interface Subscription_RootRoom_Invites_AggregateArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** subscription root */
-export interface Subscription_RootRoom_Invites_By_PkArgs {
   id: Scalars['uuid'];
 }
 
@@ -7700,10 +7317,6 @@ export interface User {
   email_verified?: Maybe<Scalars['timestamptz']>;
   id: Scalars['uuid'];
   /** An array relationship */
-  invites: Array<Room_Invites>;
-  /** An aggregated array relationship */
-  invites_aggregate: Room_Invites_Aggregate;
-  /** An array relationship */
   messages: Array<Message>;
   /** An aggregated array relationship */
   messages_aggregate: Message_Aggregate;
@@ -7768,26 +7381,6 @@ export interface UserCreated_Team_Invitations_AggregateArgs {
   offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Team_Invitation_Order_By>>;
   where?: Maybe<Team_Invitation_Bool_Exp>;
-}
-
-
-/** columns and relationships of "user" */
-export interface UserInvitesArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
-}
-
-
-/** columns and relationships of "user" */
-export interface UserInvites_AggregateArgs {
-  distinct_on?: Maybe<Array<Room_Invites_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Room_Invites_Order_By>>;
-  where?: Maybe<Room_Invites_Bool_Exp>;
 }
 
 
@@ -7959,7 +7552,6 @@ export interface User_Bool_Exp {
   email?: Maybe<String_Comparison_Exp>;
   email_verified?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Uuid_Comparison_Exp>;
-  invites?: Maybe<Room_Invites_Bool_Exp>;
   messages?: Maybe<Message_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
   owned_teams?: Maybe<Team_Bool_Exp>;
@@ -7987,7 +7579,6 @@ export interface User_Insert_Input {
   email?: Maybe<Scalars['String']>;
   email_verified?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['uuid']>;
-  invites?: Maybe<Room_Invites_Arr_Rel_Insert_Input>;
   messages?: Maybe<Message_Arr_Rel_Insert_Input>;
   name?: Maybe<Scalars['String']>;
   owned_teams?: Maybe<Team_Arr_Rel_Insert_Input>;
@@ -8076,7 +7667,6 @@ export interface User_Order_By {
   email?: Maybe<Order_By>;
   email_verified?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  invites_aggregate?: Maybe<Room_Invites_Aggregate_Order_By>;
   messages_aggregate?: Maybe<Message_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
   owned_teams_aggregate?: Maybe<Team_Aggregate_Order_By>;
@@ -8385,37 +7975,6 @@ export type AttachmentQuery = (
   & { attachment?: Maybe<(
     { __typename?: 'attachment' }
     & AttachmentDetailedInfoFragment
-  )> }
-);
-
-export type CreateInviteMutationVariables = Exact<{
-  email: Scalars['String'];
-  roomId?: Maybe<Scalars['uuid']>;
-}>;
-
-
-export type CreateInviteMutation = (
-  { __typename?: 'mutation_root' }
-  & { invite?: Maybe<(
-    { __typename?: 'room_invites' }
-    & Pick<Room_Invites, 'id' | 'email'>
-    & { usedAt: Room_Invites['used_at'] }
-  )> }
-);
-
-export type AcceptInviteMutationVariables = Exact<{
-  token: Scalars['String'];
-}>;
-
-
-export type AcceptInviteMutation = (
-  { __typename?: 'mutation_root' }
-  & { invite?: Maybe<(
-    { __typename?: 'InviteAcceptResponse' }
-    & { team?: Maybe<(
-      { __typename?: 'team' }
-      & Pick<Team, 'id'>
-    )> }
   )> }
 );
 
@@ -9249,13 +8808,6 @@ export type DownloadUrlResponseKeySpecifier = ('downloadUrl' | DownloadUrlRespon
 export type DownloadUrlResponseFieldPolicy = {
 	downloadUrl?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type InviteAcceptResponseKeySpecifier = ('invite' | 'invite_id' | 'team' | 'team_id' | InviteAcceptResponseKeySpecifier)[];
-export type InviteAcceptResponseFieldPolicy = {
-	invite?: FieldPolicy<any> | FieldReadFunction<any>,
-	invite_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	team?: FieldPolicy<any> | FieldReadFunction<any>,
-	team_id?: FieldPolicy<any> | FieldReadFunction<any>
-};
 export type LookupTeamNameResponseKeySpecifier = ('inviter_name' | 'team_name' | LookupTeamNameResponseKeySpecifier)[];
 export type LookupTeamNameResponseFieldPolicy = {
 	inviter_name?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9620,9 +9172,8 @@ export type message_type_mutation_responseFieldPolicy = {
 	affected_rows?: FieldPolicy<any> | FieldReadFunction<any>,
 	returning?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type mutation_rootKeySpecifier = ('accept_invite' | 'delete_account' | 'delete_account_by_pk' | 'delete_attachment' | 'delete_attachment_by_pk' | 'delete_full_text_search' | 'delete_last_seen_message' | 'delete_last_seen_message_by_pk' | 'delete_membership_status' | 'delete_membership_status_by_pk' | 'delete_message' | 'delete_message_by_pk' | 'delete_message_reaction' | 'delete_message_reaction_by_pk' | 'delete_message_type' | 'delete_message_type_by_pk' | 'delete_room' | 'delete_room_by_pk' | 'delete_room_invites' | 'delete_room_invites_by_pk' | 'delete_room_member' | 'delete_room_member_by_pk' | 'delete_space' | 'delete_space_by_pk' | 'delete_space_member' | 'delete_space_member_by_pk' | 'delete_team' | 'delete_team_by_pk' | 'delete_team_invitation' | 'delete_team_invitation_by_pk' | 'delete_team_member' | 'delete_team_member_by_pk' | 'delete_topic' | 'delete_topic_by_pk' | 'delete_topic_member' | 'delete_topic_member_by_pk' | 'delete_transcription' | 'delete_transcription_by_pk' | 'delete_transcription_status' | 'delete_transcription_status_by_pk' | 'delete_user' | 'delete_user_by_pk' | 'delete_whitelist' | 'delete_whitelist_by_pk' | 'insert_account' | 'insert_account_one' | 'insert_attachment' | 'insert_attachment_one' | 'insert_full_text_search' | 'insert_full_text_search_one' | 'insert_last_seen_message' | 'insert_last_seen_message_one' | 'insert_membership_status' | 'insert_membership_status_one' | 'insert_message' | 'insert_message_one' | 'insert_message_reaction' | 'insert_message_reaction_one' | 'insert_message_type' | 'insert_message_type_one' | 'insert_room' | 'insert_room_invites' | 'insert_room_invites_one' | 'insert_room_member' | 'insert_room_member_one' | 'insert_room_one' | 'insert_space' | 'insert_space_member' | 'insert_space_member_one' | 'insert_space_one' | 'insert_team' | 'insert_team_invitation' | 'insert_team_invitation_one' | 'insert_team_member' | 'insert_team_member_one' | 'insert_team_one' | 'insert_topic' | 'insert_topic_member' | 'insert_topic_member_one' | 'insert_topic_one' | 'insert_transcription' | 'insert_transcription_one' | 'insert_transcription_status' | 'insert_transcription_status_one' | 'insert_user' | 'insert_user_one' | 'insert_whitelist' | 'insert_whitelist_one' | 'update_account' | 'update_account_by_pk' | 'update_attachment' | 'update_attachment_by_pk' | 'update_full_text_search' | 'update_last_seen_message' | 'update_last_seen_message_by_pk' | 'update_membership_status' | 'update_membership_status_by_pk' | 'update_message' | 'update_message_by_pk' | 'update_message_reaction' | 'update_message_reaction_by_pk' | 'update_message_type' | 'update_message_type_by_pk' | 'update_room' | 'update_room_by_pk' | 'update_room_invites' | 'update_room_invites_by_pk' | 'update_room_member' | 'update_room_member_by_pk' | 'update_space' | 'update_space_by_pk' | 'update_space_member' | 'update_space_member_by_pk' | 'update_team' | 'update_team_by_pk' | 'update_team_invitation' | 'update_team_invitation_by_pk' | 'update_team_member' | 'update_team_member_by_pk' | 'update_topic' | 'update_topic_by_pk' | 'update_topic_member' | 'update_topic_member_by_pk' | 'update_transcription' | 'update_transcription_by_pk' | 'update_transcription_status' | 'update_transcription_status_by_pk' | 'update_user' | 'update_user_by_pk' | 'update_whitelist' | 'update_whitelist_by_pk' | 'upgrade_current_user' | mutation_rootKeySpecifier)[];
+export type mutation_rootKeySpecifier = ('delete_account' | 'delete_account_by_pk' | 'delete_attachment' | 'delete_attachment_by_pk' | 'delete_full_text_search' | 'delete_last_seen_message' | 'delete_last_seen_message_by_pk' | 'delete_membership_status' | 'delete_membership_status_by_pk' | 'delete_message' | 'delete_message_by_pk' | 'delete_message_reaction' | 'delete_message_reaction_by_pk' | 'delete_message_type' | 'delete_message_type_by_pk' | 'delete_room' | 'delete_room_by_pk' | 'delete_room_member' | 'delete_room_member_by_pk' | 'delete_space' | 'delete_space_by_pk' | 'delete_space_member' | 'delete_space_member_by_pk' | 'delete_team' | 'delete_team_by_pk' | 'delete_team_invitation' | 'delete_team_invitation_by_pk' | 'delete_team_member' | 'delete_team_member_by_pk' | 'delete_topic' | 'delete_topic_by_pk' | 'delete_topic_member' | 'delete_topic_member_by_pk' | 'delete_transcription' | 'delete_transcription_by_pk' | 'delete_transcription_status' | 'delete_transcription_status_by_pk' | 'delete_user' | 'delete_user_by_pk' | 'delete_whitelist' | 'delete_whitelist_by_pk' | 'insert_account' | 'insert_account_one' | 'insert_attachment' | 'insert_attachment_one' | 'insert_full_text_search' | 'insert_full_text_search_one' | 'insert_last_seen_message' | 'insert_last_seen_message_one' | 'insert_membership_status' | 'insert_membership_status_one' | 'insert_message' | 'insert_message_one' | 'insert_message_reaction' | 'insert_message_reaction_one' | 'insert_message_type' | 'insert_message_type_one' | 'insert_room' | 'insert_room_member' | 'insert_room_member_one' | 'insert_room_one' | 'insert_space' | 'insert_space_member' | 'insert_space_member_one' | 'insert_space_one' | 'insert_team' | 'insert_team_invitation' | 'insert_team_invitation_one' | 'insert_team_member' | 'insert_team_member_one' | 'insert_team_one' | 'insert_topic' | 'insert_topic_member' | 'insert_topic_member_one' | 'insert_topic_one' | 'insert_transcription' | 'insert_transcription_one' | 'insert_transcription_status' | 'insert_transcription_status_one' | 'insert_user' | 'insert_user_one' | 'insert_whitelist' | 'insert_whitelist_one' | 'update_account' | 'update_account_by_pk' | 'update_attachment' | 'update_attachment_by_pk' | 'update_full_text_search' | 'update_last_seen_message' | 'update_last_seen_message_by_pk' | 'update_membership_status' | 'update_membership_status_by_pk' | 'update_message' | 'update_message_by_pk' | 'update_message_reaction' | 'update_message_reaction_by_pk' | 'update_message_type' | 'update_message_type_by_pk' | 'update_room' | 'update_room_by_pk' | 'update_room_member' | 'update_room_member_by_pk' | 'update_space' | 'update_space_by_pk' | 'update_space_member' | 'update_space_member_by_pk' | 'update_team' | 'update_team_by_pk' | 'update_team_invitation' | 'update_team_invitation_by_pk' | 'update_team_member' | 'update_team_member_by_pk' | 'update_topic' | 'update_topic_by_pk' | 'update_topic_member' | 'update_topic_member_by_pk' | 'update_transcription' | 'update_transcription_by_pk' | 'update_transcription_status' | 'update_transcription_status_by_pk' | 'update_user' | 'update_user_by_pk' | 'update_whitelist' | 'update_whitelist_by_pk' | 'upgrade_current_user' | mutation_rootKeySpecifier)[];
 export type mutation_rootFieldPolicy = {
-	accept_invite?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_account?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_account_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_attachment?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9640,8 +9191,6 @@ export type mutation_rootFieldPolicy = {
 	delete_message_type_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_room?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_room_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
-	delete_room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	delete_room_invites_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_room_member?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_room_member_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	delete_space?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9683,8 +9232,6 @@ export type mutation_rootFieldPolicy = {
 	insert_message_type?: FieldPolicy<any> | FieldReadFunction<any>,
 	insert_message_type_one?: FieldPolicy<any> | FieldReadFunction<any>,
 	insert_room?: FieldPolicy<any> | FieldReadFunction<any>,
-	insert_room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	insert_room_invites_one?: FieldPolicy<any> | FieldReadFunction<any>,
 	insert_room_member?: FieldPolicy<any> | FieldReadFunction<any>,
 	insert_room_member_one?: FieldPolicy<any> | FieldReadFunction<any>,
 	insert_room_one?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9727,8 +9274,6 @@ export type mutation_rootFieldPolicy = {
 	update_message_type_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	update_room?: FieldPolicy<any> | FieldReadFunction<any>,
 	update_room_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
-	update_room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	update_room_invites_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	update_room_member?: FieldPolicy<any> | FieldReadFunction<any>,
 	update_room_member_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	update_space?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9755,7 +9300,7 @@ export type mutation_rootFieldPolicy = {
 	update_whitelist_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	upgrade_current_user?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type query_rootKeySpecifier = ('account' | 'account_aggregate' | 'account_by_pk' | 'attachment' | 'attachment_aggregate' | 'attachment_by_pk' | 'full_text_search' | 'full_text_search_aggregate' | 'get_download_url' | 'get_upload_url' | 'last_seen_message' | 'last_seen_message_aggregate' | 'last_seen_message_by_pk' | 'lookup_team_name' | 'membership_status' | 'membership_status_aggregate' | 'membership_status_by_pk' | 'message' | 'message_aggregate' | 'message_by_pk' | 'message_reaction' | 'message_reaction_aggregate' | 'message_reaction_by_pk' | 'message_type' | 'message_type_aggregate' | 'message_type_by_pk' | 'room' | 'room_aggregate' | 'room_by_pk' | 'room_invites' | 'room_invites_aggregate' | 'room_invites_by_pk' | 'room_last_posted_message' | 'room_last_posted_message_aggregate' | 'room_member' | 'room_member_aggregate' | 'room_member_by_pk' | 'search_full_text' | 'search_full_text_aggregate' | 'search_full_text_topic' | 'search_full_text_topic_aggregate' | 'space' | 'space_aggregate' | 'space_by_pk' | 'space_member' | 'space_member_aggregate' | 'space_member_by_pk' | 'team' | 'team_aggregate' | 'team_by_pk' | 'team_invitation' | 'team_invitation_aggregate' | 'team_invitation_by_pk' | 'team_member' | 'team_member_aggregate' | 'team_member_by_pk' | 'topic' | 'topic_aggregate' | 'topic_by_pk' | 'topic_member' | 'topic_member_aggregate' | 'topic_member_by_pk' | 'transcription' | 'transcription_aggregate' | 'transcription_by_pk' | 'transcription_full_text' | 'transcription_full_text_aggregate' | 'transcription_status' | 'transcription_status_aggregate' | 'transcription_status_by_pk' | 'unread_messages' | 'unread_messages_aggregate' | 'user' | 'user_aggregate' | 'user_by_pk' | 'whitelist' | 'whitelist_aggregate' | 'whitelist_by_pk' | query_rootKeySpecifier)[];
+export type query_rootKeySpecifier = ('account' | 'account_aggregate' | 'account_by_pk' | 'attachment' | 'attachment_aggregate' | 'attachment_by_pk' | 'full_text_search' | 'full_text_search_aggregate' | 'get_download_url' | 'get_upload_url' | 'last_seen_message' | 'last_seen_message_aggregate' | 'last_seen_message_by_pk' | 'lookup_team_name' | 'membership_status' | 'membership_status_aggregate' | 'membership_status_by_pk' | 'message' | 'message_aggregate' | 'message_by_pk' | 'message_reaction' | 'message_reaction_aggregate' | 'message_reaction_by_pk' | 'message_type' | 'message_type_aggregate' | 'message_type_by_pk' | 'room' | 'room_aggregate' | 'room_by_pk' | 'room_last_posted_message' | 'room_last_posted_message_aggregate' | 'room_member' | 'room_member_aggregate' | 'room_member_by_pk' | 'search_full_text' | 'search_full_text_aggregate' | 'search_full_text_topic' | 'search_full_text_topic_aggregate' | 'space' | 'space_aggregate' | 'space_by_pk' | 'space_member' | 'space_member_aggregate' | 'space_member_by_pk' | 'team' | 'team_aggregate' | 'team_by_pk' | 'team_invitation' | 'team_invitation_aggregate' | 'team_invitation_by_pk' | 'team_member' | 'team_member_aggregate' | 'team_member_by_pk' | 'topic' | 'topic_aggregate' | 'topic_by_pk' | 'topic_member' | 'topic_member_aggregate' | 'topic_member_by_pk' | 'transcription' | 'transcription_aggregate' | 'transcription_by_pk' | 'transcription_full_text' | 'transcription_full_text_aggregate' | 'transcription_status' | 'transcription_status_aggregate' | 'transcription_status_by_pk' | 'unread_messages' | 'unread_messages_aggregate' | 'user' | 'user_aggregate' | 'user_by_pk' | 'whitelist' | 'whitelist_aggregate' | 'whitelist_by_pk' | query_rootKeySpecifier)[];
 export type query_rootFieldPolicy = {
 	account?: FieldPolicy<any> | FieldReadFunction<any>,
 	account_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9786,9 +9331,6 @@ export type query_rootFieldPolicy = {
 	room?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_last_posted_message?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_last_posted_message_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_member?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9836,7 +9378,7 @@ export type query_rootFieldPolicy = {
 	whitelist_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	whitelist_by_pk?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type roomKeySpecifier = ('created_at' | 'creator' | 'creator_id' | 'deadline' | 'finished_at' | 'id' | 'is_private' | 'last_posted_message' | 'members' | 'members_aggregate' | 'name' | 'notification_job_id' | 'room_invites' | 'room_invites_aggregate' | 'slug' | 'source_google_calendar_event_id' | 'space' | 'space_id' | 'summary' | 'topics' | 'topics_aggregate' | roomKeySpecifier)[];
+export type roomKeySpecifier = ('created_at' | 'creator' | 'creator_id' | 'deadline' | 'finished_at' | 'id' | 'is_private' | 'last_posted_message' | 'members' | 'members_aggregate' | 'name' | 'notification_job_id' | 'slug' | 'source_google_calendar_event_id' | 'space' | 'space_id' | 'summary' | 'topics' | 'topics_aggregate' | roomKeySpecifier)[];
 export type roomFieldPolicy = {
 	created_at?: FieldPolicy<any> | FieldReadFunction<any>,
 	creator?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9850,8 +9392,6 @@ export type roomFieldPolicy = {
 	members_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	notification_job_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	slug?: FieldPolicy<any> | FieldReadFunction<any>,
 	source_google_calendar_event_id?: FieldPolicy<any> | FieldReadFunction<any>,
 	space?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -9870,54 +9410,6 @@ export type room_aggregate_fieldsFieldPolicy = {
 	count?: FieldPolicy<any> | FieldReadFunction<any>,
 	max?: FieldPolicy<any> | FieldReadFunction<any>,
 	min?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invitesKeySpecifier = ('code' | 'created_at' | 'email' | 'id' | 'inviter' | 'inviter_id' | 'room' | 'room_id' | 'used_at' | room_invitesKeySpecifier)[];
-export type room_invitesFieldPolicy = {
-	code?: FieldPolicy<any> | FieldReadFunction<any>,
-	created_at?: FieldPolicy<any> | FieldReadFunction<any>,
-	email?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	inviter?: FieldPolicy<any> | FieldReadFunction<any>,
-	inviter_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	room?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	used_at?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invites_aggregateKeySpecifier = ('aggregate' | 'nodes' | room_invites_aggregateKeySpecifier)[];
-export type room_invites_aggregateFieldPolicy = {
-	aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
-	nodes?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invites_aggregate_fieldsKeySpecifier = ('count' | 'max' | 'min' | room_invites_aggregate_fieldsKeySpecifier)[];
-export type room_invites_aggregate_fieldsFieldPolicy = {
-	count?: FieldPolicy<any> | FieldReadFunction<any>,
-	max?: FieldPolicy<any> | FieldReadFunction<any>,
-	min?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invites_max_fieldsKeySpecifier = ('code' | 'created_at' | 'email' | 'id' | 'inviter_id' | 'room_id' | 'used_at' | room_invites_max_fieldsKeySpecifier)[];
-export type room_invites_max_fieldsFieldPolicy = {
-	code?: FieldPolicy<any> | FieldReadFunction<any>,
-	created_at?: FieldPolicy<any> | FieldReadFunction<any>,
-	email?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	inviter_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	used_at?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invites_min_fieldsKeySpecifier = ('code' | 'created_at' | 'email' | 'id' | 'inviter_id' | 'room_id' | 'used_at' | room_invites_min_fieldsKeySpecifier)[];
-export type room_invites_min_fieldsFieldPolicy = {
-	code?: FieldPolicy<any> | FieldReadFunction<any>,
-	created_at?: FieldPolicy<any> | FieldReadFunction<any>,
-	email?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	inviter_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_id?: FieldPolicy<any> | FieldReadFunction<any>,
-	used_at?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type room_invites_mutation_responseKeySpecifier = ('affected_rows' | 'returning' | room_invites_mutation_responseKeySpecifier)[];
-export type room_invites_mutation_responseFieldPolicy = {
-	affected_rows?: FieldPolicy<any> | FieldReadFunction<any>,
-	returning?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type room_last_posted_messageKeySpecifier = ('last_posted_message_time' | 'room' | 'room_id' | room_last_posted_messageKeySpecifier)[];
 export type room_last_posted_messageFieldPolicy = {
@@ -10091,7 +9583,7 @@ export type space_mutation_responseFieldPolicy = {
 	affected_rows?: FieldPolicy<any> | FieldReadFunction<any>,
 	returning?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type subscription_rootKeySpecifier = ('account' | 'account_aggregate' | 'account_by_pk' | 'attachment' | 'attachment_aggregate' | 'attachment_by_pk' | 'full_text_search' | 'full_text_search_aggregate' | 'get_download_url' | 'get_upload_url' | 'last_seen_message' | 'last_seen_message_aggregate' | 'last_seen_message_by_pk' | 'lookup_team_name' | 'membership_status' | 'membership_status_aggregate' | 'membership_status_by_pk' | 'message' | 'message_aggregate' | 'message_by_pk' | 'message_reaction' | 'message_reaction_aggregate' | 'message_reaction_by_pk' | 'message_type' | 'message_type_aggregate' | 'message_type_by_pk' | 'room' | 'room_aggregate' | 'room_by_pk' | 'room_invites' | 'room_invites_aggregate' | 'room_invites_by_pk' | 'room_last_posted_message' | 'room_last_posted_message_aggregate' | 'room_member' | 'room_member_aggregate' | 'room_member_by_pk' | 'search_full_text' | 'search_full_text_aggregate' | 'search_full_text_topic' | 'search_full_text_topic_aggregate' | 'space' | 'space_aggregate' | 'space_by_pk' | 'space_member' | 'space_member_aggregate' | 'space_member_by_pk' | 'team' | 'team_aggregate' | 'team_by_pk' | 'team_invitation' | 'team_invitation_aggregate' | 'team_invitation_by_pk' | 'team_member' | 'team_member_aggregate' | 'team_member_by_pk' | 'topic' | 'topic_aggregate' | 'topic_by_pk' | 'topic_member' | 'topic_member_aggregate' | 'topic_member_by_pk' | 'transcription' | 'transcription_aggregate' | 'transcription_by_pk' | 'transcription_full_text' | 'transcription_full_text_aggregate' | 'transcription_status' | 'transcription_status_aggregate' | 'transcription_status_by_pk' | 'unread_messages' | 'unread_messages_aggregate' | 'user' | 'user_aggregate' | 'user_by_pk' | 'whitelist' | 'whitelist_aggregate' | 'whitelist_by_pk' | subscription_rootKeySpecifier)[];
+export type subscription_rootKeySpecifier = ('account' | 'account_aggregate' | 'account_by_pk' | 'attachment' | 'attachment_aggregate' | 'attachment_by_pk' | 'full_text_search' | 'full_text_search_aggregate' | 'get_download_url' | 'get_upload_url' | 'last_seen_message' | 'last_seen_message_aggregate' | 'last_seen_message_by_pk' | 'lookup_team_name' | 'membership_status' | 'membership_status_aggregate' | 'membership_status_by_pk' | 'message' | 'message_aggregate' | 'message_by_pk' | 'message_reaction' | 'message_reaction_aggregate' | 'message_reaction_by_pk' | 'message_type' | 'message_type_aggregate' | 'message_type_by_pk' | 'room' | 'room_aggregate' | 'room_by_pk' | 'room_last_posted_message' | 'room_last_posted_message_aggregate' | 'room_member' | 'room_member_aggregate' | 'room_member_by_pk' | 'search_full_text' | 'search_full_text_aggregate' | 'search_full_text_topic' | 'search_full_text_topic_aggregate' | 'space' | 'space_aggregate' | 'space_by_pk' | 'space_member' | 'space_member_aggregate' | 'space_member_by_pk' | 'team' | 'team_aggregate' | 'team_by_pk' | 'team_invitation' | 'team_invitation_aggregate' | 'team_invitation_by_pk' | 'team_member' | 'team_member_aggregate' | 'team_member_by_pk' | 'topic' | 'topic_aggregate' | 'topic_by_pk' | 'topic_member' | 'topic_member_aggregate' | 'topic_member_by_pk' | 'transcription' | 'transcription_aggregate' | 'transcription_by_pk' | 'transcription_full_text' | 'transcription_full_text_aggregate' | 'transcription_status' | 'transcription_status_aggregate' | 'transcription_status_by_pk' | 'unread_messages' | 'unread_messages_aggregate' | 'user' | 'user_aggregate' | 'user_by_pk' | 'whitelist' | 'whitelist_aggregate' | 'whitelist_by_pk' | subscription_rootKeySpecifier)[];
 export type subscription_rootFieldPolicy = {
 	account?: FieldPolicy<any> | FieldReadFunction<any>,
 	account_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -10122,9 +9614,6 @@ export type subscription_rootFieldPolicy = {
 	room?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
-	room_invites_by_pk?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_last_posted_message?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_last_posted_message_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	room_member?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -10554,7 +10043,7 @@ export type unread_messages_variance_fieldsKeySpecifier = ('unread_messages' | u
 export type unread_messages_variance_fieldsFieldPolicy = {
 	unread_messages?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type userKeySpecifier = ('avatar_url' | 'created_at' | 'created_rooms' | 'created_rooms_aggregate' | 'created_team_invitations' | 'created_team_invitations_aggregate' | 'current_team' | 'current_team_id' | 'email' | 'email_verified' | 'id' | 'invites' | 'invites_aggregate' | 'messages' | 'messages_aggregate' | 'name' | 'owned_teams' | 'owned_teams_aggregate' | 'rooms' | 'rooms_aggregate' | 'space_memberships' | 'space_memberships_aggregate' | 'team_memberships' | 'team_memberships_aggregate' | 'topic_memberships' | 'topic_memberships_aggregate' | userKeySpecifier)[];
+export type userKeySpecifier = ('avatar_url' | 'created_at' | 'created_rooms' | 'created_rooms_aggregate' | 'created_team_invitations' | 'created_team_invitations_aggregate' | 'current_team' | 'current_team_id' | 'email' | 'email_verified' | 'id' | 'messages' | 'messages_aggregate' | 'name' | 'owned_teams' | 'owned_teams_aggregate' | 'rooms' | 'rooms_aggregate' | 'space_memberships' | 'space_memberships_aggregate' | 'team_memberships' | 'team_memberships_aggregate' | 'topic_memberships' | 'topic_memberships_aggregate' | userKeySpecifier)[];
 export type userFieldPolicy = {
 	avatar_url?: FieldPolicy<any> | FieldReadFunction<any>,
 	created_at?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -10567,8 +10056,6 @@ export type userFieldPolicy = {
 	email?: FieldPolicy<any> | FieldReadFunction<any>,
 	email_verified?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
-	invites?: FieldPolicy<any> | FieldReadFunction<any>,
-	invites_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	messages?: FieldPolicy<any> | FieldReadFunction<any>,
 	messages_aggregate?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -10655,10 +10142,6 @@ export type TypedTypePolicies = TypePolicies & {
 	DownloadUrlResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | DownloadUrlResponseKeySpecifier | (() => undefined | DownloadUrlResponseKeySpecifier),
 		fields?: DownloadUrlResponseFieldPolicy,
-	},
-	InviteAcceptResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | InviteAcceptResponseKeySpecifier | (() => undefined | InviteAcceptResponseKeySpecifier),
-		fields?: InviteAcceptResponseFieldPolicy,
 	},
 	LookupTeamNameResponse?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | LookupTeamNameResponseKeySpecifier | (() => undefined | LookupTeamNameResponseKeySpecifier),
@@ -10883,30 +10366,6 @@ export type TypedTypePolicies = TypePolicies & {
 	room_aggregate_fields?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | room_aggregate_fieldsKeySpecifier | (() => undefined | room_aggregate_fieldsKeySpecifier),
 		fields?: room_aggregate_fieldsFieldPolicy,
-	},
-	room_invites?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invitesKeySpecifier | (() => undefined | room_invitesKeySpecifier),
-		fields?: room_invitesFieldPolicy,
-	},
-	room_invites_aggregate?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invites_aggregateKeySpecifier | (() => undefined | room_invites_aggregateKeySpecifier),
-		fields?: room_invites_aggregateFieldPolicy,
-	},
-	room_invites_aggregate_fields?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invites_aggregate_fieldsKeySpecifier | (() => undefined | room_invites_aggregate_fieldsKeySpecifier),
-		fields?: room_invites_aggregate_fieldsFieldPolicy,
-	},
-	room_invites_max_fields?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invites_max_fieldsKeySpecifier | (() => undefined | room_invites_max_fieldsKeySpecifier),
-		fields?: room_invites_max_fieldsFieldPolicy,
-	},
-	room_invites_min_fields?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invites_min_fieldsKeySpecifier | (() => undefined | room_invites_min_fieldsKeySpecifier),
-		fields?: room_invites_min_fieldsFieldPolicy,
-	},
-	room_invites_mutation_response?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | room_invites_mutation_responseKeySpecifier | (() => undefined | room_invites_mutation_responseKeySpecifier),
-		fields?: room_invites_mutation_responseFieldPolicy,
 	},
 	room_last_posted_message?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | room_last_posted_messageKeySpecifier | (() => undefined | room_last_posted_messageKeySpecifier),

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -23,17 +23,6 @@ type DownloadUrlResponse {
   downloadUrl: String!
 }
 
-input InviteAcceptCommand {
-  code: String!
-}
-
-type InviteAcceptResponse {
-  invite: room_invites
-  invite_id: ID!
-  team: team
-  team_id: ID!
-}
-
 type LookupTeamNameResponse {
   inviter_name: String!
   team_name: String!
@@ -2433,11 +2422,6 @@ mutation root
 """
 type mutation_root {
   """
-  perform the action: "accept_invite"
-  """
-  accept_invite(token: String!): InviteAcceptResponse
-
-  """
   delete data from the table: "account"
   """
   delete_account(
@@ -2566,21 +2550,6 @@ type mutation_root {
   delete single row from the table: "room"
   """
   delete_room_by_pk(id: uuid!): room
-
-  """
-  delete data from the table: "room_invites"
-  """
-  delete_room_invites(
-    """
-    filter the rows which have to be deleted
-    """
-    where: room_invites_bool_exp!
-  ): room_invites_mutation_response
-
-  """
-  delete single row from the table: "room_invites"
-  """
-  delete_room_invites_by_pk(id: uuid!): room_invites
 
   """
   delete data from the table: "room_member"
@@ -3006,36 +2975,6 @@ type mutation_root {
     """
     on_conflict: room_on_conflict
   ): room_mutation_response
-
-  """
-  insert data into the table: "room_invites"
-  """
-  insert_room_invites(
-    """
-    the rows to be inserted
-    """
-    objects: [room_invites_insert_input!]!
-
-    """
-    on conflict condition
-    """
-    on_conflict: room_invites_on_conflict
-  ): room_invites_mutation_response
-
-  """
-  insert a single row into the table: "room_invites"
-  """
-  insert_room_invites_one(
-    """
-    the row to be inserted
-    """
-    object: room_invites_insert_input!
-
-    """
-    on conflict condition
-    """
-    on_conflict: room_invites_on_conflict
-  ): room_invites
 
   """
   insert data into the table: "room_member"
@@ -3684,32 +3623,6 @@ type mutation_root {
     _set: room_set_input
     pk_columns: room_pk_columns_input!
   ): room
-
-  """
-  update data of the table: "room_invites"
-  """
-  update_room_invites(
-    """
-    sets the columns of the filtered rows to the given values
-    """
-    _set: room_invites_set_input
-
-    """
-    filter the rows which have to be updated
-    """
-    where: room_invites_bool_exp!
-  ): room_invites_mutation_response
-
-  """
-  update single row of the table: "room_invites"
-  """
-  update_room_invites_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
-    _set: room_invites_set_input
-    pk_columns: room_invites_pk_columns_input!
-  ): room_invites
 
   """
   update data of the table: "room_member"
@@ -4712,71 +4625,6 @@ type query_root {
   fetch data from the table: "room" using primary key columns
   """
   room_by_pk(id: uuid!): room
-
-  """
-  fetch data from the table: "room_invites"
-  """
-  room_invites(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): [room_invites!]!
-
-  """
-  fetch aggregated fields from the table: "room_invites"
-  """
-  room_invites_aggregate(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): room_invites_aggregate!
-
-  """
-  fetch data from the table: "room_invites" using primary key columns
-  """
-  room_invites_by_pk(id: uuid!): room_invites
 
   """
   fetch data from the table: "room_last_posted_message"
@@ -5961,66 +5809,6 @@ type room {
   ): room_member_aggregate!
   name: String!
   notification_job_id: String
-
-  """
-  An array relationship
-  """
-  room_invites(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): [room_invites!]!
-
-  """
-  An aggregated array relationship
-  """
-  room_invites_aggregate(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): room_invites_aggregate!
   slug: String!
   source_google_calendar_event_id: String
 
@@ -6144,7 +5932,6 @@ input room_bool_exp {
   members: room_member_bool_exp
   name: String_comparison_exp
   notification_job_id: String_comparison_exp
-  room_invites: room_invites_bool_exp
   slug: String_comparison_exp
   source_google_calendar_event_id: String_comparison_exp
   space: space_bool_exp
@@ -6182,322 +5969,12 @@ input room_insert_input {
   members: room_member_arr_rel_insert_input
   name: String
   notification_job_id: String
-  room_invites: room_invites_arr_rel_insert_input
   slug: String
   source_google_calendar_event_id: String
   space: space_obj_rel_insert_input
   space_id: uuid
   summary: String
   topics: topic_arr_rel_insert_input
-}
-
-"""
-columns and relationships of "room_invites"
-"""
-type room_invites {
-  code: uuid!
-  created_at: timestamptz!
-  email: String!
-  id: uuid!
-
-  """
-  An object relationship
-  """
-  inviter: user!
-  inviter_id: uuid!
-
-  """
-  An object relationship
-  """
-  room: room!
-  room_id: uuid!
-  used_at: timestamptz
-}
-
-"""
-aggregated selection of "room_invites"
-"""
-type room_invites_aggregate {
-  aggregate: room_invites_aggregate_fields
-  nodes: [room_invites!]!
-}
-
-"""
-aggregate fields of "room_invites"
-"""
-type room_invites_aggregate_fields {
-  count(columns: [room_invites_select_column!], distinct: Boolean): Int
-  max: room_invites_max_fields
-  min: room_invites_min_fields
-}
-
-"""
-order by aggregate values of table "room_invites"
-"""
-input room_invites_aggregate_order_by {
-  count: order_by
-  max: room_invites_max_order_by
-  min: room_invites_min_order_by
-}
-
-"""
-input type for inserting array relation for remote table "room_invites"
-"""
-input room_invites_arr_rel_insert_input {
-  data: [room_invites_insert_input!]!
-  on_conflict: room_invites_on_conflict
-}
-
-"""
-Boolean expression to filter rows from the table "room_invites". All fields are combined with a logical 'AND'.
-"""
-input room_invites_bool_exp {
-  _and: [room_invites_bool_exp]
-  _not: room_invites_bool_exp
-  _or: [room_invites_bool_exp]
-  code: uuid_comparison_exp
-  created_at: timestamptz_comparison_exp
-  email: String_comparison_exp
-  id: uuid_comparison_exp
-  inviter: user_bool_exp
-  inviter_id: uuid_comparison_exp
-  room: room_bool_exp
-  room_id: uuid_comparison_exp
-  used_at: timestamptz_comparison_exp
-}
-
-"""
-unique or primary key constraints on table "room_invites"
-"""
-enum room_invites_constraint {
-  """
-  unique or primary key constraint
-  """
-  room_invites_code_key
-
-  """
-  unique or primary key constraint
-  """
-  room_invites_pkey
-
-  """
-  unique or primary key constraint
-  """
-  room_invites_room_id_email_key
-}
-
-"""
-input type for inserting data into table "room_invites"
-"""
-input room_invites_insert_input {
-  code: uuid
-  created_at: timestamptz
-  email: String
-  id: uuid
-  inviter: user_obj_rel_insert_input
-  inviter_id: uuid
-  room: room_obj_rel_insert_input
-  room_id: uuid
-  used_at: timestamptz
-}
-
-"""
-aggregate max on columns
-"""
-type room_invites_max_fields {
-  code: uuid
-  created_at: timestamptz
-  email: String
-  id: uuid
-  inviter_id: uuid
-  room_id: uuid
-  used_at: timestamptz
-}
-
-"""
-order by max() on columns of table "room_invites"
-"""
-input room_invites_max_order_by {
-  code: order_by
-  created_at: order_by
-  email: order_by
-  id: order_by
-  inviter_id: order_by
-  room_id: order_by
-  used_at: order_by
-}
-
-"""
-aggregate min on columns
-"""
-type room_invites_min_fields {
-  code: uuid
-  created_at: timestamptz
-  email: String
-  id: uuid
-  inviter_id: uuid
-  room_id: uuid
-  used_at: timestamptz
-}
-
-"""
-order by min() on columns of table "room_invites"
-"""
-input room_invites_min_order_by {
-  code: order_by
-  created_at: order_by
-  email: order_by
-  id: order_by
-  inviter_id: order_by
-  room_id: order_by
-  used_at: order_by
-}
-
-"""
-response of any mutation on the table "room_invites"
-"""
-type room_invites_mutation_response {
-  """
-  number of affected rows by the mutation
-  """
-  affected_rows: Int!
-
-  """
-  data of the affected rows by the mutation
-  """
-  returning: [room_invites!]!
-}
-
-"""
-input type for inserting object relation for remote table "room_invites"
-"""
-input room_invites_obj_rel_insert_input {
-  data: room_invites_insert_input!
-  on_conflict: room_invites_on_conflict
-}
-
-"""
-on conflict condition type for table "room_invites"
-"""
-input room_invites_on_conflict {
-  constraint: room_invites_constraint!
-  update_columns: [room_invites_update_column!]!
-  where: room_invites_bool_exp
-}
-
-"""
-ordering options when selecting data from "room_invites"
-"""
-input room_invites_order_by {
-  code: order_by
-  created_at: order_by
-  email: order_by
-  id: order_by
-  inviter: user_order_by
-  inviter_id: order_by
-  room: room_order_by
-  room_id: order_by
-  used_at: order_by
-}
-
-"""
-primary key columns input for table: "room_invites"
-"""
-input room_invites_pk_columns_input {
-  id: uuid!
-}
-
-"""
-select columns of table "room_invites"
-"""
-enum room_invites_select_column {
-  """
-  column name
-  """
-  code
-
-  """
-  column name
-  """
-  created_at
-
-  """
-  column name
-  """
-  email
-
-  """
-  column name
-  """
-  id
-
-  """
-  column name
-  """
-  inviter_id
-
-  """
-  column name
-  """
-  room_id
-
-  """
-  column name
-  """
-  used_at
-}
-
-"""
-input type for updating data in table "room_invites"
-"""
-input room_invites_set_input {
-  code: uuid
-  created_at: timestamptz
-  email: String
-  id: uuid
-  inviter_id: uuid
-  room_id: uuid
-  used_at: timestamptz
-}
-
-"""
-update columns of table "room_invites"
-"""
-enum room_invites_update_column {
-  """
-  column name
-  """
-  code
-
-  """
-  column name
-  """
-  created_at
-
-  """
-  column name
-  """
-  email
-
-  """
-  column name
-  """
-  id
-
-  """
-  column name
-  """
-  inviter_id
-
-  """
-  column name
-  """
-  room_id
-
-  """
-  column name
-  """
-  used_at
 }
 
 """
@@ -6931,7 +6408,6 @@ input room_order_by {
   members_aggregate: room_member_aggregate_order_by
   name: order_by
   notification_job_id: order_by
-  room_invites_aggregate: room_invites_aggregate_order_by
   slug: order_by
   source_google_calendar_event_id: order_by
   space: space_order_by
@@ -8296,71 +7772,6 @@ type subscription_root {
   fetch data from the table: "room" using primary key columns
   """
   room_by_pk(id: uuid!): room
-
-  """
-  fetch data from the table: "room_invites"
-  """
-  room_invites(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): [room_invites!]!
-
-  """
-  fetch aggregated fields from the table: "room_invites"
-  """
-  room_invites_aggregate(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): room_invites_aggregate!
-
-  """
-  fetch data from the table: "room_invites" using primary key columns
-  """
-  room_invites_by_pk(id: uuid!): room_invites
 
   """
   fetch data from the table: "room_last_posted_message"
@@ -12098,66 +11509,6 @@ type user {
   """
   An array relationship
   """
-  invites(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): [room_invites!]!
-
-  """
-  An aggregated array relationship
-  """
-  invites_aggregate(
-    """
-    distinct select on columns
-    """
-    distinct_on: [room_invites_select_column!]
-
-    """
-    limit the number of rows returned
-    """
-    limit: Int
-
-    """
-    skip the first n rows. Use only with order_by
-    """
-    offset: Int
-
-    """
-    sort the rows by one or more columns
-    """
-    order_by: [room_invites_order_by!]
-
-    """
-    filter the rows returned
-    """
-    where: room_invites_bool_exp
-  ): room_invites_aggregate!
-
-  """
-  An array relationship
-  """
   messages(
     """
     distinct select on columns
@@ -12567,7 +11918,6 @@ input user_bool_exp {
   email: String_comparison_exp
   email_verified: timestamptz_comparison_exp
   id: uuid_comparison_exp
-  invites: room_invites_bool_exp
   messages: message_bool_exp
   name: String_comparison_exp
   owned_teams: team_bool_exp
@@ -12605,7 +11955,6 @@ input user_insert_input {
   email: String
   email_verified: timestamptz
   id: uuid
-  invites: room_invites_arr_rel_insert_input
   messages: message_arr_rel_insert_input
   name: String
   owned_teams: team_arr_rel_insert_input
@@ -12712,7 +12061,6 @@ input user_order_by {
   email: order_by
   email_verified: order_by
   id: order_by
-  invites_aggregate: room_invites_aggregate_order_by
   messages_aggregate: message_aggregate_order_by
   name: order_by
   owned_teams_aggregate: team_aggregate_order_by

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -1,9 +1,3 @@
-type Mutation {
-  accept_invite (
-    token: String!
-  ): InviteAcceptResponse
-}
-
 type Query {
   get_download_url (
     uuid: uuid!
@@ -25,15 +19,6 @@ type Query {
 
 type Mutation {
   upgrade_current_user : UpgradeUserResponse
-}
-
-input InviteAcceptCommand {
-  code : String!
-}
-
-type InviteAcceptResponse {
-  team_id : ID!
-  invite_id : ID!
 }
 
 type UpgradeUserResponse {

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -1,13 +1,4 @@
 actions:
-  - name: accept_invite
-    definition:
-      kind: synchronous
-      handler: "{{HASURA_ACTIONS_WEBHOOK_URL}}"
-      headers:
-        - name: Authorization
-          value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
-    permissions:
-      - role: user
   - name: get_download_url
     definition:
       kind: ""
@@ -47,25 +38,8 @@ actions:
       - role: user
 custom_types:
   enums: []
-  input_objects:
-    - name: InviteAcceptCommand
+  input_objects: []
   objects:
-    - name: InviteAcceptResponse
-      relationships:
-        - remote_table:
-            schema: public
-            name: room_invites
-          name: invite
-          type: object
-          field_mapping:
-            invite_id: id
-        - remote_table:
-            schema: public
-            name: team
-          name: team
-          type: object
-          field_mapping:
-            team_id: id
     - name: UpgradeUserResponse
       relationships:
         - remote_table:

--- a/infrastructure/hasura/metadata/tables.yaml
+++ b/infrastructure/hasura/metadata/tables.yaml
@@ -340,13 +340,6 @@
             name: room_member
           column_mapping:
             id: room_id
-    - name: room_invites
-      using:
-        foreign_key_constraint_on:
-          column: room_id
-          table:
-            schema: public
-            name: room_invites
     - name: topics
       using:
         foreign_key_constraint_on:
@@ -467,43 +460,6 @@
       headers:
         - name: Authorization
           value_from_env: HASURA_EVENTS_WEBHOOK_AUTHORIZATION_HEADER
-- table:
-    schema: public
-    name: room_invites
-  object_relationships:
-    - name: inviter
-      using:
-        foreign_key_constraint_on: inviter_id
-    - name: room
-      using:
-        foreign_key_constraint_on: room_id
-  insert_permissions:
-    - role: user
-      permission:
-        check:
-          room:
-            creator_id:
-              _eq: X-Hasura-User-Id
-        set:
-          inviter_id: x-hasura-User-Id
-        columns:
-          - email
-          - room_id
-        backend_only: false
-  select_permissions:
-    - role: user
-      permission:
-        columns:
-          - used_at
-          - created_at
-          - email
-          - id
-          - inviter_id
-          - room_id
-        filter:
-          room:
-            creator_id:
-              _eq: X-Hasura-User-Id
 - table:
     schema: public
     name: room_last_posted_message
@@ -1256,13 +1212,6 @@
           table:
             schema: public
             name: team_invitation
-    - name: invites
-      using:
-        foreign_key_constraint_on:
-          column: inviter_id
-          table:
-            schema: public
-            name: room_invites
     - name: messages
       using:
         manual_configuration:

--- a/infrastructure/hasura/migrations/1627369211659_drop_table_public_room_invites/up.sql
+++ b/infrastructure/hasura/migrations/1627369211659_drop_table_public_room_invites/up.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."room_invites";


### PR DESCRIPTION
Before proceeding with implementing logic for room invitation, I removed the old unused `room_invites` table. It would be better to have a `room_invitation` table that would look similar to `team_invitation`.