### PR TITLE
fix: correct bundle-analyzer call

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,7 +3,7 @@ process.env.NEXT_PUBLIC_STAGE = process.env.STAGE;
 process.env.NEXT_PUBLIC_SENTRY_RELEASE = process.env.SENTRY_RELEASE;
 /* eslint-disable @typescript-eslint/no-var-requires */
 const withPlugins = require("next-compose-plugins");
-const bundleAnalyzer = require("@next/bundle-analyzer");
+const withBundleAnalyzer = require("@next/bundle-analyzer");
 const withTranspileModules = require("next-transpile-modules");
 const dotenv = require("dotenv");
 const fs = require("fs");
@@ -109,10 +109,9 @@ module.exports = withPlugins(
   [
     //
     [
-      bundleAnalyzer,
-      {
+      withBundleAnalyzer({
         enabled: process.env.ANALYZE === "true",
-      },
+      }),
     ],
     //
     [


### PR DESCRIPTION
Another tiny PR by yours truly. While snooping around, I was curious to see what the bundles look like. Turns out the analyzer call was not working, so I fixed that. I also changed the naming to map to the one in next's docs.

And while I'm here, some random ideas from looking at the output:
- the most glaring one was `emoji-mart` but I got once again outsmarted by you people, and it's already being lazily loaded. Nice!
- `lodash`-imports could be turned into `import get from "lodash/get"` (as an example). That should lead to some reduction.
- `tip-tap` is biiig. But lazy-loading the editor might degrade UX, since people probably want to put their ideas down quickly when opening the page?
- `react-beautiful-dnd` is another impact maker, but that one seems challenging to do lazily. It'd lead to some remounting and would require making sure the layouts match.
- `icons` _could_ be lazy loaded, but we'd have to make sure the placeholder size matches (not too hard) and missing icons (that come in later) give a bit of a broken-app vibe. So probably not worth it.

Probably not the thing to focus on right now, but I thought I'd give you my notes anyway.