### PR TITLE
fix: revert "correct" bundle-analyzer call

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -109,9 +109,10 @@ module.exports = withPlugins(
   [
     //
     [
-      withBundleAnalyzer({
+      withBundleAnalyzer,
+      {
         enabled: process.env.ANALYZE === "true",
-      }),
+      },
     ],
     //
     [


### PR DESCRIPTION
with this bundle-analyzer is not working anymore, but at least `.env` loading is. Still trying to figure out what caused the breakage.