### PR TITLE
fix: disallow team_member removal for non-owners

### DIFF
--- a/infrastructure/hasura/metadata/tables.yaml
+++ b/infrastructure/hasura/metadata/tables.yaml
@@ -939,9 +939,8 @@
       permission:
         filter:
           team:
-            memberships:
-              user_id:
-                _eq: X-Hasura-User-Id
+            owner_id:
+              _eq: X-Hasura-User-Id
   event_triggers:
     - name: team_member_updates
       definition:


### PR DESCRIPTION
another tiny PR, related to #272 

Unfortunately I had to manually edit the metadata file, as doing it through hasura's console created all kinds of changes for me (probably due to version divergence, as mentioned on Slack). But it seems to work for me.

To test it, if you are so inclined, do this on `master` and then in this branch:
- have someone in a team, of which you are not the owner
- go to http://localhost:3000/team
- try to remove that person
Or you know, just fire the `delete_team_member_by_pk` mutation manually.