### PR TITLE
fix: fixed notifications navigation bug

### DIFF
--- a/frontend/src/views/RoomView/RoomView.tsx
+++ b/frontend/src/views/RoomView/RoomView.tsx
@@ -29,7 +29,8 @@ interface Props {
 
 export function RoomView(props: Props) {
   return (
-    <RoomStoreContext>
+    // Re-create context if re-rendered for a different room
+    <RoomStoreContext key={props.room.id}>
       <RoomViewDisplayer {...props} />
     </RoomStoreContext>
   );
@@ -94,7 +95,7 @@ function RoomViewDisplayer({ room, selectedTopicId, children }: Props) {
           </CollapsePanel>
 
           <CardBase>
-            <TopicsList room={room} activeTopicId={selectedTopicId} isRoomOpen={isRoomOpen} />
+            <TopicsList key={room.id} room={room} activeTopicId={selectedTopicId} isRoomOpen={isRoomOpen} />
           </CardBase>
 
           <UIFlyingCloseRoomToggle>


### PR DESCRIPTION
We had a bit 'interesting' bug with navigation between rooms

I mean direct navigation from room a to room b (without any non-room page in between)

What happened in such case was that `RoomView` was actually not re-mounted, but just updated (it is desired for navigation between topics, bot not between rooms).

It meant eg. room context was 'kept' even tho it made no sense as eg `roomContext.editedTopicId` could point to topic from different room.

This also meant eg this hook in TopicsList

```ts
  useNewItemInArrayEffect(
    topics,
    (topic) => topic.id,
    (newTopic) => {
      runInAction(() => {
        roomContext.newTopicId = newTopic.id;
        roomContext.editingNameTopicId = newTopic.id;
      });
      routes.spaceRoomTopic.push({ topicId: newTopic.id, spaceId: room.space_id, roomId: room.id });
    }
  );
```

was still running. 

As new room receives totally new list of topics, it was picking first new topic and navigating to it, also marking it as a new topic and going to edit mode for it.

Long story short - a lot of mess. 

We did not see this bug before as it was not possible before to navigate directly from one room to other. Notifications center added recently enables that.

The fix is to add `key` to RoomContext making sure its fully re-mounted if room id changes.