### PR TITLE
feat: Aca 596 enter does not submit message in edit

### DIFF
--- a/frontend/src/ui/message/composer/EditMessageEditor.tsx
+++ b/frontend/src/ui/message/composer/EditMessageEditor.tsx
@@ -34,6 +34,9 @@ export const EditMessageEditor = ({ message, onCancelRequest, onSaved }: Props) 
   useShortcut("Escape", onCancelRequest);
   useShortcut("Enter", () => {
     handleSubmit();
+
+    // Don't pass enter to editor as it would insert new line
+    return true;
   });
 
   async function handleSubmit() {

--- a/richEditor/RichEditor.tsx
+++ b/richEditor/RichEditor.tsx
@@ -1,4 +1,4 @@
-import { Editor, EditorContent, Extensions, JSONContent } from "@tiptap/react";
+import { ChainedCommands, Editor, EditorContent, Extensions, JSONContent } from "@tiptap/react";
 import { isEqual } from "lodash";
 import React, { forwardRef, ReactNode, useEffect, useImperativeHandle, useMemo } from "react";
 import styled from "styled-components";
@@ -87,7 +87,7 @@ function getLastSelectableCursorPosition(editor: Editor) {
   return 1;
 }
 
-function getFocusEditorAtEndCommand(editor: Editor) {
+function getFocusEditorAtEndCommand(editor: Editor): ChainedCommands {
   const lastSelectablePosition = getLastSelectableCursorPosition(editor);
 
   return editor.chain().focus(lastSelectablePosition);
@@ -225,7 +225,7 @@ export const RichEditor = forwardRef<Editor, RichEditorProps>(function RichEdito
       return true;
     },
     {
-      isEnabled: isFocused,
+      isEnabled: isFocused && submitMode === "enable",
     }
   );
 


### PR DESCRIPTION
Fixes:
- not working Enter submit shortcut in message edit mode
- fixes bug causing autofocus to put cursor at 'non selectable' part of the content
   - this could result in quite weird behavior like removing entire content when you press backspace