### PR TITLE
fix: properly manages unread messages ignoring messages created by self

### DIFF
--- a/frontend/src/gql/messages.ts
+++ b/frontend/src/gql/messages.ts
@@ -14,7 +14,7 @@ import {
 import { getUUID } from "~shared/uuid";
 import { AttachmentDetailedInfoFragment } from "./attachments";
 import { ReactionBasicInfoFragment } from "./reactions";
-import { topicMessagesQueryManager } from "./topics";
+import { topicMessagesQueryManager, updateLastSeenMessage } from "./topics";
 import { UserBasicInfoFragment } from "./user";
 import { createFragment, createMutation } from "./utils";
 
@@ -140,6 +140,10 @@ export const [useCreateMessageMutation, { mutate: createMessage }] = createMutat
         }
         current.messages.push(message);
       });
+    },
+    onActualResponse: (message, variables) => {
+      // Each time user sends a new message, automatically mark it as read
+      updateLastSeenMessage({ messageId: message.id, topicId: variables.topicId });
     },
   }
 );

--- a/frontend/src/gql/topics.ts
+++ b/frontend/src/gql/topics.ts
@@ -214,7 +214,7 @@ export const [useRemoveTopicMemberMutation] = createMutation<
   }
 );
 
-export const [useLastSeenMessageMutation] = createMutation<
+export const [useLastSeenMessageMutation, { mutate: updateLastSeenMessage }] = createMutation<
   UpdateLastSeenMessageMutationVariables,
   UpdateLastSeenMessageMutationVariables
 >(

--- a/infrastructure/hasura/migrations/1627569789277_run_sql_migration/up.sql
+++ b/infrastructure/hasura/migrations/1627569789277_run_sql_migration/up.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW "public"."unread_messages" AS 
+ SELECT sm.user_id,
+    room.id AS room_id,
+    topic.id AS topic_id,
+    count(message.id) AS unread_messages
+   FROM ((((space_member sm
+     LEFT JOIN room ON ((room.space_id = sm.space_id)))
+     LEFT JOIN topic ON ((topic.room_id = room.id)))
+     LEFT JOIN last_seen_message ON (((last_seen_message.user_id = sm.user_id) AND (last_seen_message.topic_id = topic.id))))
+     LEFT JOIN message ON ((message.topic_id = topic.id)))
+  WHERE (message.user_id != sm.user_id AND ((message.created_at > last_seen_message.seen_at) OR (last_seen_message.seen_at IS NULL)))
+  GROUP BY sm.user_id, room.id, topic.id
+  ORDER BY sm.user_id, room.id, topic.id;


### PR DESCRIPTION
This PR updates `unread messages` view:

It previously was just checking all messages comparing it with 'last seen message'. It was incorrect as we dont consider 'message created by myself as unread'

It could lead to some race conditions:
- I create a message, but quickly leave the topic
- message is created there, but as I was not in the topic anymore, it is not marked as read after it is created
- thus I start to see unread indicator next to the topic