### PR TITLE
Add cleanup ghcr script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,11 +137,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          oras pull ghcr.io/weareacapela/node-modules:$GITHUB_SHA
+          oras pull ghcr.io/weareacapela/node-modules:$GITHUB_SHA | tee oras.log
           tar -xf node_modules.tar && rm node_modules.tar
           echo "cleanup cache..."
-          echo "{}" > manifest-config.json
-          oras push ghcr.io/weareacapela/node-modules:$GITHUB_SHA --manifest-config ./manifest-config.json ./manifest-config.json
+          ./scripts/cleanup-ghcr.sh
+          rm oras.log
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: semantic-release
         uses: go-semantic-release/action@v1
         id: semrel

--- a/scripts/cleanup-ghcr.sh
+++ b/scripts/cleanup-ghcr.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+container_sha=$(cat oras.log | awk '{ print $2 }' | tail -n 1)
+echo "found container sha: $container_sha"
+
+delete_version_url=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/weareacapela/packages/container/node-modules/versions |jq -r ".[] | select(.name==\"$container_sha\") | .url")
+echo "deleting $delete_version_url"
+
+curl -XDELETE -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "$delete_version_url"
+echo "deleted"


### PR DESCRIPTION
During the CI process, the `node_modules` folder is cached in the [GitHub Container registry](https://github.com/weareacapela/monorepo/pkgs/container/node-modules).
This PR introduces a script that will properly clean up the created images in the release step.