### PR TITLE
fix: scroll to bottom in WebKit (Safari)

### DIFF
--- a/frontend/src/views/topic/ScrollToBottomMonitor.tsx
+++ b/frontend/src/views/topic/ScrollToBottomMonitor.tsx
@@ -32,14 +32,19 @@ export function ScrollToBottomMonitor({ parentRef, getShouldScroll }: Props) {
         return;
       }
 
+      const scrollToBottomOfParent = () => {
+        scrollToBottom(parentNode, behavior);
+      };
+
       if (navigator.userAgent.includes("AppleWebKit")) {
         // Safari schedules ~some sync work which stops bottom scrolling from working
         // This little hack, while not nice, does make it work
+        // TODO: look for real fix if it turns out there is unforeseen negative consequences
         setTimeout(() => {
-          scrollToBottom(parentNode, behavior);
+          scrollToBottomOfParent();
         });
       } else {
-        scrollToBottom(parentNode, behavior);
+        scrollToBottomOfParent();
       }
     },
     [getShouldScroll]


### PR DESCRIPTION
follow up of #277 which didn't work for Safari.

Now unfortunately this has turned into a hacky fix, but I found it really hard to dig using Safari's DevTools and I don't think this has negative consequences apart from setting a bad example. 