### PR TITLE
feat: reuse room and topic page to avoid remounting

### DIFF
--- a/frontend/pages/space/[spaceId]/[roomId]/[topicId].tsx
+++ b/frontend/pages/space/[spaceId]/[roomId]/[topicId].tsx
@@ -1,15 +1,16 @@
-import React from "react";
-import { routes } from "~frontend/routes";
 import { withServerSideAuthRedirect } from "~frontend/authentication/withServerSideAuthRedirect";
-
-import { RoomPage } from "~frontend/rooms/RoomPage";
-
-const Page = () => {
-  const { spaceId, roomId, topicId } = routes.spaceRoomTopic.useParams().route;
-
-  return <RoomPage spaceId={spaceId} roomId={roomId} topicId={topicId} />;
-};
+import { RoomOrTopicPage } from "~frontend/pages/RoomOrTopicPage";
 
 export const getServerSideProps = withServerSideAuthRedirect();
 
-export default Page;
+/**
+ * We're reusing exact same component for both room main page and room single topic page.
+ *
+ * This is to avoid re-mounting the entire page when navigating from /[spaceId]/[roomId] to /[spaceId]/[roomId]/[topicId]
+ *
+ * Both of those pages use exact same component <RoomView />, but only with different props.
+ *
+ * However, if both those pages (index.tsx and [topicId].tsx) export default different function, react will read it as
+ * brand new component and perform remounting.
+ */
+export default RoomOrTopicPage;

--- a/frontend/pages/space/[spaceId]/[roomId]/index.tsx
+++ b/frontend/pages/space/[spaceId]/[roomId]/index.tsx
@@ -1,14 +1,16 @@
-import React from "react";
 import { withServerSideAuthRedirect } from "~frontend/authentication/withServerSideAuthRedirect";
-import { RoomPage } from "~frontend/rooms/RoomPage";
-import { routes } from "~frontend/routes";
-
-const SpaceRoomPage = () => {
-  const { roomId, spaceId } = routes.spaceRoom.useParams().route;
-
-  return <RoomPage spaceId={spaceId} roomId={roomId} topicId={null} />;
-};
+import { RoomOrTopicPage } from "~frontend/pages/RoomOrTopicPage";
 
 export const getServerSideProps = withServerSideAuthRedirect();
 
-export default SpaceRoomPage;
+/**
+ * We're reusing exact same component for both room main page and room single topic page.
+ *
+ * This is to avoid re-mounting the entire page when navigating from /[spaceId]/[roomId] to /[spaceId]/[roomId]/[topicId]
+ *
+ * Both of those pages use exact same component <RoomView />, but only with different props.
+ *
+ * However, if both those pages (index.tsx and [topicId].tsx) export default different function, react will read it as
+ * brand new component and perform remounting.
+ */
+export default RoomOrTopicPage;

--- a/frontend/src/pages/RoomOrTopicPage.tsx
+++ b/frontend/src/pages/RoomOrTopicPage.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { routes } from "~frontend/routes";
+import { RoomPage } from "~frontend/rooms/RoomPage";
+
+export function RoomOrTopicPage() {
+  const topicParams = routes.spaceRoomTopic.useParams()?.route;
+  const roomParams = routes.spaceRoom.useParams()?.route;
+
+  // We're on topic route
+  if (topicParams) {
+    const { spaceId, roomId, topicId } = topicParams;
+    return <RoomPage spaceId={spaceId} roomId={roomId} topicId={topicId} />;
+  }
+
+  // We're on main room route (room has no topics yet)
+  if (roomParams) {
+    const { roomId, spaceId } = roomParams;
+    return <RoomPage spaceId={spaceId} roomId={roomId} topicId={null} />;
+  }
+
+  throw new Error(`RoomOrTopicPage used for other route than single room or single topic`);
+}


### PR DESCRIPTION
We're using exact same component for both room page (in case it has no topics) and for topic page.

As both pages had independend 'page' component eg `export default () => foo`, it meant react was fully remounting the component.

It lead to bad UX in case:
- you create new room
- you go to room page
- you create new topic
- topic is entering edit mode allowing you to change the name
- room page detects new topic and routes to topic page
- topic page is a new component so view is re-mounted
- this leads to lost state + shared store context
- this leads to edit mode being disabled
- you have to click it again to edit the topic name