### PR TITLE
feat: better log on theme utility function error

### DIFF
--- a/ui/theme/proxy/index.ts
+++ b/ui/theme/proxy/index.ts
@@ -59,10 +59,9 @@ export function buildThemeProxy(baseTheme: Theme) {
             try {
               return fn.call(target, ...args);
             } catch (e) {
+              const pathJoinedByDots = fullPath.join(".");
               throw new Error(
-                `[Theme] Failed to run utility function "theme.${fullPath.join(
-                  "."
-                )}". Possible solution: Add a function call. Example: \`\${theme.${fullPath.join(".")}()}\``
+                `[Theme] Failed to run utility function "theme.${pathJoinedByDots}". Possible solution: Add a function call, e.g. \`\${theme.${pathJoinedByDots}()}\``
               );
             }
           };


### PR DESCRIPTION
Trying to solve this:
>**Gregor:** I'm wondering if the theme meta programming stuff can be made to have better stack traces. Try putting background-color: ${theme.colors.interactive.notification}; (missing fn-call parentheses) in a style and look at the trace to see what I mean. So far I had small enough PRs that it was easy enough to navigate but might get confusing come size and new people

# Here's how the error looks now:

![Screenshot 2021-08-02 at 23 31 53](https://user-images.githubusercontent.com/4765697/127979553-00a35516-2c26-4d96-8b9f-1db72a965ea2.png)

Source of the error can be found at the bottom of the stack trace. Cleaning up the stack trace is up for grabs, let's do it later if it's really annoying.

<img width="1017" alt="Screenshot 2021-08-03 at 11 14 00" src="https://user-images.githubusercontent.com/4765697/127981978-a6eadae6-5671-4cdc-9c4d-aa52ff6880f1.png">

