### PR TITLE
fix: topic name flicker through optimistic update

### DIFF
--- a/frontend/src/gql/topics.ts
+++ b/frontend/src/gql/topics.ts
@@ -278,6 +278,10 @@ export const [useUpdateTopicMutation, { mutate: updateTopic }] = createMutation<
         input.slug = slugify(input.name);
       }
     },
+    optimisticResponse({ topicId, input }) {
+      const topic = TopicDetailedInfoFragment.assertRead(topicId);
+      return { __typename: "mutation_root", topic: input.name ? { ...topic, name: input.name } : topic };
+    },
     onOptimisticOrActualResponse(topic) {
       RoomDetailedInfoFragment.update(topic.room.id, (data) => {
         optimisticallySortTopics(data.topics);

--- a/frontend/src/views/RoomView/TopicsList/TopicMenuItem.tsx
+++ b/frontend/src/views/RoomView/TopicsList/TopicMenuItem.tsx
@@ -64,8 +64,8 @@ export const TopicMenuItem = styled<Props>(
 
       const manageWrapperRef = useRef<HTMLElement | null>(null);
 
-      async function handleNewTopicName(newName: string) {
-        await updateTopic({ topicId: topic.id, input: { name: newName } });
+      function handleNewTopicName(newName: string) {
+        updateTopic({ topicId: topic.id, input: { name: newName } });
 
         roomContext.editingNameTopicId = null;
 


### PR DESCRIPTION
It's what I was intending to do in #301 but I gave up because there was no generic utility for it and it got too complicated for a quick-fix. So this is also a little reductive now, only updating the topic name. Would be neat to find time to invest in a more general utility for optimistically updating (or is there one and I missed it?)