### PR TITLE
fix: stop disabling sorting while saving

### DIFF
--- a/frontend/src/views/RoomView/TopicsList/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/index.tsx
@@ -45,7 +45,7 @@ export const TopicsList = observer(function TopicsList({ room, activeTopicId, is
   const spaceId = room.space_id;
   const roomContext = useRoomStoreContext();
 
-  const { topics, moveBetween, moveToStart, moveToEnd, isReordering } = useRoomTopicList(room.id);
+  const { topics, moveBetween, moveToStart, moveToEnd } = useRoomTopicList(room.id);
   const amIMember = isCurrentUserRoomMember(room);
 
   const isEditingAnyMessage = select(() => !!roomContext.editingNameTopicId);
@@ -96,7 +96,7 @@ export const TopicsList = observer(function TopicsList({ room, activeTopicId, is
           <LazyTopicsList
             topics={topics}
             activeTopicId={activeTopicId}
-            isDisabled={isEditingAnyMessage || isReordering}
+            isDisabled={isEditingAnyMessage}
             onMoveBetween={moveBetween}
             onMoveToStart={moveToStart}
             onMoveToEnd={moveToEnd}


### PR DESCRIPTION
Since saving takes long on prod (but not on dev/stage) I just noticed there that sorting is disabled while things are in-flight. And those things could be past-sorts.

This will also be kind of fixed by making updates less expensive, over in #200, but in general we should not block resorting.

This is imo still not perfect as there can be a bit of a flicker when updates come in, but it's better than master, so I think it's worth landing.