### PR TITLE
fix: show scroll when participants overflow

### DIFF
--- a/ui/forms/OptionsDropdown/DropdownItem.tsx
+++ b/ui/forms/OptionsDropdown/DropdownItem.tsx
@@ -58,7 +58,7 @@ const UIOption = styled.div<{ isHighlighted: boolean }>`
   align-items: center;
   cursor: pointer;
 
-  border: 1px solid;
+  border: 1px solid transparent;
 
   transition: 0.15s all;
   ${theme.borderRadius.item};

--- a/ui/forms/OptionsDropdown/ItemsDropdown.tsx
+++ b/ui/forms/OptionsDropdown/ItemsDropdown.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode, useRef } from "react";
-import { useClickAway } from "react-use";
-import styled from "styled-components";
+import { useClickAway, useWindowSize } from "react-use";
+import styled, { css } from "styled-components";
 import { useListWithNavigation } from "~shared/hooks/useListWithNavigation";
 import { borderRadius, shadow } from "~ui/baseStyles";
 import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
 import { PopPresenceAnimator } from "~ui/animations";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 import { DropdownItem } from "./DropdownItem";
+import { useBoundingBox } from "~shared/hooks/useBoundingBox";
 
 interface Props<I> {
   items: I[];
@@ -32,7 +33,11 @@ export function ItemsDropdown<I>({
   const { activeItem: highlightedItem, setActiveItem: setHighlightedItem } = useListWithNavigation(items, {
     enableKeyboard: true,
   });
+
+  const { height: windowHeight } = useWindowSize();
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuBoundingBox = useBoundingBox(menuRef);
+
   const selectedItemsKeys = selectedItems.map(keyGetter);
 
   function getIsItemSelected(item: I) {
@@ -47,8 +52,10 @@ export function ItemsDropdown<I>({
     onCloseRequest?.();
   });
 
+  const maxHeight = windowHeight - menuBoundingBox.top - 20;
+
   return (
-    <UIMenu ref={menuRef}>
+    <UIMenu maxHeight={maxHeight} ref={menuRef}>
       {items.map((item) => {
         const itemKey = keyGetter(item);
         const isSelected = getIsItemSelected(item);
@@ -72,7 +79,12 @@ export function ItemsDropdown<I>({
   );
 }
 
-const UIMenu = styled(PopPresenceAnimator)<{}>`
+const UIMenu = styled(PopPresenceAnimator)<{ maxHeight?: number }>`
+  ${({ maxHeight }) =>
+    maxHeight &&
+    css`
+      max-height: ${maxHeight}px;
+    `}
   overflow-y: auto;
   border: 1px solid ${BACKGROUND_ACCENT};
   width: 100%;


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/17750556/128165202-1b265eda-f081-497d-96d9-f5d4312390f8.png)
Now:
* show scroll when overflow.
* remove black border