### PR TITLE
dedupe slug names

### DIFF
--- a/infrastructure/hasura/migrations/1628185896213_dedupe-slug-triggers/down.sql
+++ b/infrastructure/hasura/migrations/1628185896213_dedupe-slug-triggers/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER dedupe_space_slug ON space;
+DROP TRIGGER dedupe_room_slug ON room;
+DROP TRIGGER dedupe_topic_slug ON topic;
+
+DROP FUNCTION dedupe_space_slug();
+DROP FUNCTION dedupe_room_slug();
+DROP FUNCTION dedupe_topic_slug();

--- a/infrastructure/hasura/migrations/1628185896213_dedupe-slug-triggers/up.sql
+++ b/infrastructure/hasura/migrations/1628185896213_dedupe-slug-triggers/up.sql
@@ -1,0 +1,67 @@
+CREATE OR REPLACE FUNCTION dedupe_space_slug() RETURNS TRIGGER AS
+$$
+DECLARE
+  i INT := 2;
+  chosen_slug TEXT := NEW.slug;
+BEGIN
+  WHILE EXISTS(SELECT * FROM space WHERE team_id = NEW.team_id AND slug = NEW.slug)
+    LOOP
+      NEW.slug = chosen_slug || '-' || i;
+      i = i + 1;
+    END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dedupe_space_slug
+  BEFORE INSERT
+  ON space
+  FOR EACH ROW
+EXECUTE PROCEDURE dedupe_space_slug();
+
+
+CREATE OR REPLACE FUNCTION dedupe_room_slug() RETURNS TRIGGER AS
+$$
+DECLARE
+  i INT := 2;
+  chosen_slug TEXT := NEW.slug;
+BEGIN
+  WHILE EXISTS(SELECT * FROM room WHERE space_id = NEW.space_id AND slug = NEW.slug)
+    LOOP
+      NEW.slug = chosen_slug || '-' || i;
+      i = i + 1;
+    END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dedupe_room_slug
+  BEFORE INSERT
+  ON room
+  FOR EACH ROW
+EXECUTE PROCEDURE dedupe_room_slug();
+
+
+CREATE OR REPLACE FUNCTION dedupe_topic_slug() RETURNS TRIGGER AS
+$$
+DECLARE
+  i INT := 2;
+  chosen_slug TEXT := NEW.slug;
+BEGIN
+  WHILE EXISTS(SELECT * FROM topic WHERE room_id = NEW.room_id AND slug = NEW.slug)
+    LOOP
+      NEW.slug = chosen_slug || '-' || i;
+      i = i + 1;
+    END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dedupe_topic_slug
+  BEFORE INSERT
+  ON topic
+  FOR EACH ROW
+EXECUTE PROCEDURE dedupe_topic_slug();


### PR DESCRIPTION
After some confusion what this issue was about, I now managed to get it working using on postgres triggers. Unfortunately the pg functions I had to create don't share logic, being generic is hard in pg. But I think that's fine.

So here is what this does:
- when a `space`, `room` or `topic` is created a trigger fires which checks whether a slug with the same already exists within the `team`, `space` or `room` (respectively)
 - if no, just create it as is
 - if yes, add `-2` to the slug and retry (next attempt will be with `-3` and so on)

What this does not do yet:
- change URLs to use slugs
- make room's topic list only create a topic after entering a name (atm it's eager)

**Before:**
https://user-images.githubusercontent.com/4051932/128399111-b8176715-a7ec-48c5-b4e1-0eb6f6722057.mov

**After:**
https://user-images.githubusercontent.com/4051932/128399150-df9f7e84-7aee-4de0-aa90-a4311a8b429a.mov

