### PR TITLE
Show badge notification only if room participant

### DIFF
--- a/infrastructure/hasura/migrations/1628500848510_modify_unread_messages_view/up.sql
+++ b/infrastructure/hasura/migrations/1628500848510_modify_unread_messages_view/up.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW "public"."unread_messages" AS 
+ SELECT rm.user_id,
+    topic.room_id,
+    topic.id AS topic_id,
+    count(message.id) AS unread_messages
+   FROM (((room_member rm
+     LEFT JOIN topic ON ((topic.room_id = rm.room_id)))
+     LEFT JOIN last_seen_message ON (((last_seen_message.user_id = rm.user_id) AND (last_seen_message.topic_id = topic.id))))
+     LEFT JOIN message ON ((message.topic_id = topic.id)))
+  WHERE ((message.user_id <> rm.user_id) AND ((message.created_at > last_seen_message.seen_at) OR (last_seen_message.seen_at IS NULL)))
+  GROUP BY rm.user_id, topic.room_id, topic.id
+  ORDER BY rm.user_id, topic.room_id, topic.id;


### PR DESCRIPTION
This PR updates the view so that we count unread_messages only if the user is a room participant. Previously we counted all messages inside the space, even if the user wasn't a member of these rooms.

Previously we had
```sql
LEFT JOIN room ON room.space_id = sm.space_id
```
Now we have:
```sql
LEFT JOIN topic ON topic.room_id = rm.room_id
```