### PR TITLE
Add version to healthz endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -65,8 +65,11 @@ function setupGracefulShutdown(server: Server) {
       });
     },
     healthChecks: {
+      verbatim: true,
       "/healthz": async function () {
-        return true;
+        return {
+          version: process.env.SENTRY_RELEASE || "dev",
+        };
       },
     },
   });


### PR DESCRIPTION
This adds more details to the `/healthz` endpoint and makes it easy to find out the currently used backend, frontend, and hasura versions.
```json
{
  "status": "ok",
  "version": "dev",
  "backend": {
    "status": "ok",
    "version": "dev"
  },
  "hasura": {
    "status": "OK",
    "version": "v1.3.3"
  }
}
```

Before that, only the frontend version was visible on the teams page.