### PR TITLE
fix: use calendar icon for every calendar event

### DIFF
--- a/frontend/src/views/CalendarView/GoogleCalendarEventsCard.tsx
+++ b/frontend/src/views/CalendarView/GoogleCalendarEventsCard.tsx
@@ -10,6 +10,7 @@ import { openRoomInputPrompt } from "~frontend/rooms/create/openRoomInputPrompt"
 import { niceFormatDateTime } from "~shared/dates/format";
 import { GoogleCalendarEvent } from "~shared/types/googleCalendar";
 import { Button } from "~ui/buttons/Button";
+import { GoogleCalendarIcon } from "~ui/social/GoogleCalendarIcon";
 import { TextH4 } from "~ui/typo";
 
 interface Props {
@@ -65,6 +66,7 @@ export const GoogleCalendarEventsCard = styled(function GoogleCalendarEventsCard
         <UIInfo>
           <UIName spezia medium>
             {event.title}
+            <GoogleCalendarIcon data-tooltip="Connected to Google Calendar event" />
           </UIName>
           {deadline && (
             <UIMeta>
@@ -105,6 +107,9 @@ const UIInfo = styled.div<{}>`
 `;
 
 const UIName = styled(TextH4)<{}>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-weight: bold;
 `;
 


### PR DESCRIPTION
**Before**
<img width="1440" alt="Screenshot 2021-08-10 at 20 00 20" src="https://user-images.githubusercontent.com/4051932/128911439-c646ad8e-8867-4067-9234-e1afc29d4da0.png">

**After**
<img width="1440" alt="Screenshot 2021-08-10 at 20 00 12" src="https://user-images.githubusercontent.com/4051932/128911455-a8e5add0-b9c1-4c10-9c90-7ce853c16b6f.png">
