### PR TITLE
fix: use browser native API for some date/time formatting

### DIFF
--- a/shared/dates/format.ts
+++ b/shared/dates/format.ts
@@ -42,11 +42,7 @@ export function niceFormatDateTime(date: Date, options?: DateFormatOptions): str
 }
 
 export function niceFormatTime(date: Date): string {
-  return format(date, "p");
-}
-
-export function getWeekdayName(date: Date): string {
-  return format(date, "EEEE");
+  return date.toLocaleTimeString(undefined, { timeStyle: "short" });
 }
 
 function isBeforeThisWeek(date: Date): boolean {

--- a/ui/time/DateLabel.tsx
+++ b/ui/time/DateLabel.tsx
@@ -1,13 +1,9 @@
 import styled from "styled-components";
-import { niceFormatDate, niceFormatTime, relativeFormatDate } from "~shared/dates/format";
+import { niceFormatTime, relativeFormatDate } from "~shared/dates/format";
 
 interface Props {
   date: Date;
   className?: string;
-}
-
-export function DateLabel({ date }: Props) {
-  return <UIHolder>{niceFormatDate(date)}</UIHolder>;
 }
 
 export const TimeLabelWithDateTooltip = styled(function TimeLabelWithDateTooltip({ date, className }: Props) {

--- a/ui/time/DateTimeInput.tsx
+++ b/ui/time/DateTimeInput.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import { AnimatePresence } from "framer-motion";
 import React, { useRef } from "react";
 import styled from "styled-components";
@@ -48,7 +47,7 @@ export const DateTimeInput = ({ value, onChange, isReadonly = false, label }: Pr
         cursorType="action"
       >
         <UIHolder isReadonly={isReadonly} onFocus={openPicker} onClick={openPicker}>
-          <TextBody>{format(value, "dd.MM.yyyy, p")}</TextBody>
+          <TextBody>{value.toLocaleString()}</TextBody>
         </UIHolder>
       </FieldWithLabel>
     </>


### PR DESCRIPTION
**Before**
<img width="634" alt="Screenshot 2021-08-10 at 20 21 24" src="https://user-images.githubusercontent.com/4051932/128919018-8ceb7958-5ee1-4abb-9c58-18cd224c6919.png">


**After (dates look like this because my browser is in english, which in MacOS Chrome comes with that formatting)**
<img width="634" alt="Screenshot 2021-08-10 at 20 21 28" src="https://user-images.githubusercontent.com/4051932/128919027-e814edd3-99d5-4074-b10b-0423ef5a6d25.png">


**Note:** I also changed the message time formatting to use browser APIs (I was sad about seeing 12h AM/PM instead of 24h), which respect user's time format preference. While I also wanted to touch date formatting, I did not find a way to get days as ordinal instead of numeric. I might take another stab at it tomorrow, possibly in another PR if this one is already greenlit.