### PR TITLE
chore: add more code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 
 /infrastructure/kubernetes @christophwitzko
 /infrastructure/hasura @heikir @Gregoor
-/backend @heikir @christophwitzko @Gregoor @pie6k
+/backend @heikir @christophwitzko @Gregoor @pie6k @omarduarte
 /frontend @heikir @pie6k @RodionChachura @omarduarte @Gregoor


### PR DESCRIPTION
So the idea would be:

By default @heikir @pie6k @RodionChachura @omarduarte @Gregoor are requested for PR reviews UNLESS any of the other rules apply, in which case the mentioned people get review requests.

With `/backend` I went with running `git shortlog -n -s -- backend/` which showed me number of commits and I left it at 4 people to increase the chance of 2 approvals.

Let me know if you want to be added/removed from any of the rules.