### PR TITLE
ACA-632 Add hasura console proxy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "hasura:seeds:create": "func(){ hasura seed create \"$1\" --project infrastructure/hasura --admin-secret dev; }; func",
     "hasura:meta": "hasura metadata apply --project infrastructure/hasura --admin-secret dev",
     "hasura:console": "hasura console --project infrastructure/hasura --admin-secret dev",
+    "hasura:console:proxy": "./scripts/hasura-console-proxy.sh",
     "hasura:update": "yarn hasura:migrations && yarn hasura:seeds && yarn hasura:meta",
     "frontend:gql-types": "tooling gql frontend --watch",
     "lint": "eslint . && prettier --check .",
@@ -77,7 +78,8 @@
       "docker:up:detach": "Start docker infrastructure in detached mode",
       "docker:up": "Start docker infrastructure in interactive mode",
       "docker:stop": "Stop docker infrastructure",
-      "hasura:console": "Start hasura dev console"
+      "hasura:console": "Start hasura dev console",
+      "hasura:console:proxy": "Connect to the staging or production hasura console (yarn hasura:console:proxy [production|staging])"
     }
   },
   "dependencies": {

--- a/scripts/hasura-console-proxy.sh
+++ b/scripts/hasura-console-proxy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+command -v kubectl >/dev/null || {
+  echo "kubectl is not installed. Try to run:"
+  echo "brew install kubectl"
+  exit 1
+}
+
+command -v gcloud >/dev/null || {
+  echo "gcloud is not installed: https://cloud.google.com/sdk/docs/install#mac"
+  exit 1
+}
+
+[[ ! -f "$HOME/.kube/config" ]] && {
+  echo "kubectl config is not found"
+  echo "trying to fetch config..."
+  gcloud container clusters get-credentials cluster-1
+  kubectl version --short
+}
+
+stage="${1:-}"
+[[ -z "$stage" ]] && {
+  echo "stage not set, using staging as default"
+  stage="staging"
+}
+
+[[ "$stage" != "staging" && "$stage" != "production" ]] && {
+  echo "invalid stage: $stage"
+  echo "use either staging or production"
+  exit 1
+}
+
+echo "proxying hasura console for $stage to http://localhost:58080"
+open http://localhost:58080
+kubectl -n $stage port-forward deployment/hasura 58080:8080


### PR DESCRIPTION
Use `yarn hasura:console:proxy [production|staging]` to connect to the production or staging hasura console.