### PR TITLE
Add missing region and project to gcloud setup command

### DIFF
--- a/scripts/hasura-console-proxy.sh
+++ b/scripts/hasura-console-proxy.sh
@@ -16,7 +16,7 @@ command -v gcloud >/dev/null || {
 [[ ! -f "$HOME/.kube/config" ]] && {
   echo "kubectl config is not found"
   echo "trying to fetch config..."
-  gcloud container clusters get-credentials cluster-1
+  gcloud container clusters get-credentials cluster-1 --region europe-west1 --project meetnomoreapp
   kubectl version --short
 }
 


### PR DESCRIPTION
This should prevent errors when the project/region is not configured globally.