### PR TITLE
Use prettier for sorting imports

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,4 @@
 singleQuote: false
 printWidth: 120
+plugins:
+  - "./node_modules/prettier-plugin-import-sort"

--- a/backend/src/actions/actionHandlers.ts
+++ b/backend/src/actions/actionHandlers.ts
@@ -1,7 +1,7 @@
 import { getUploadUrl } from "~backend/src/attachments/attachments";
+import { roomInvitationView } from "~backend/src/roomInvitation/roomInvitationView";
 import { lookupTeamName } from "~backend/src/teamInvitation/lookupTeamName";
 import { resendInvitation } from "~backend/src/teamInvitation/resendInvitation";
-import { roomInvitationView } from "~backend/src/roomInvitation/roomInvitationView";
 
 export interface ActionHandler<DataT, ResponseT> {
   actionName: string;

--- a/backend/src/actions/actions.test.ts
+++ b/backend/src/actions/actions.test.ts
@@ -1,6 +1,8 @@
 import { Server } from "http";
+
 import request from "supertest";
 import { v4 as uuid } from "uuid";
+
 import { setupServer } from "../app";
 import { HttpStatus } from "../http";
 import { handlers as fakeHandlers } from "./actionHandlers";

--- a/backend/src/actions/actions.ts
+++ b/backend/src/actions/actions.ts
@@ -1,7 +1,9 @@
 import { Request, Response, Router } from "express";
+
 import logger from "~shared/logger";
+
 import { extractAndAssertBearerToken } from "../authentication";
-import { AuthenticationError, isHttpError, UnprocessableEntityError } from "../errors/errorTypes";
+import { AuthenticationError, UnprocessableEntityError, isHttpError } from "../errors/errorTypes";
 import { HasuraSessionVariables } from "../hasura/session";
 import { ActionHandler, handlers } from "./actionHandlers";
 

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1,5 +1,7 @@
 import { Server } from "http";
+
 import request from "supertest";
+
 import { setupServer } from "./app";
 import { HttpStatus } from "./http";
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,20 +1,24 @@
-import { createTerminus as gracefulShutdown } from "@godaddy/terminus";
-import express, { Application, json } from "express";
 import "express-async-errors"; // patches express to handle errors from async functions, must be right after express
-import securityMiddleware from "helmet";
-import cookieParser from "cookie-parser";
-import { createServer, Server } from "http";
+
+import { Server, createServer } from "http";
 import { promisify } from "util";
+
+import { createTerminus as gracefulShutdown } from "@godaddy/terminus";
+import * as Sentry from "@sentry/node";
+import cookieParser from "cookie-parser";
+import express, { Application, json } from "express";
+import securityMiddleware from "helmet";
+
 import { initializeSecrets } from "~config";
 import logger from "~shared/logger";
+
 import { router as actionRoutes } from "./actions/actions";
+import { router as attachmentsRoutes } from "./attachments/router";
 import { router as authenticationRoutes } from "./authentication";
+import { router as calendarRoutes } from "./calendar/calendar";
+import { errorHandlerMiddleware, notFoundRouteMiddleware } from "./errors/middleware";
 import { router as eventRoutes } from "./events/events";
 import { router as transcriptionRoutes } from "./transcriptions/router";
-import { router as calendarRoutes } from "./calendar/calendar";
-import { router as attachmentsRoutes } from "./attachments/router";
-import { errorHandlerMiddleware, notFoundRouteMiddleware } from "./errors/middleware";
-import * as Sentry from "@sentry/node";
 
 export async function setupServer(): Promise<Server> {
   await initializeSecrets();

--- a/backend/src/attachments/attachments.ts
+++ b/backend/src/attachments/attachments.ts
@@ -1,5 +1,6 @@
 import { ActionHandler } from "~backend/src/actions/actionHandlers";
 import { db } from "~db";
+
 import { getSignedUploadUrl } from "./googleStorage";
 
 interface UploadUrlParams {

--- a/backend/src/attachments/events.ts
+++ b/backend/src/attachments/events.ts
@@ -1,8 +1,9 @@
+import { initializeAttachmentTranscription } from "~backend/src/transcriptions/transcriptionService";
 import { Attachment, db } from "~db";
 import { Message_Type_Enum } from "~gql";
-import { initializeAttachmentTranscription } from "~backend/src/transcriptions/transcriptionService";
-import { HasuraEvent } from "../hasura";
 import { log } from "~shared/logger";
+
+import { HasuraEvent } from "../hasura";
 
 const MESSAGE_TYPES_TO_BE_PROCESSED: Message_Type_Enum[] = ["AUDIO", "VIDEO"];
 

--- a/backend/src/attachments/googleStorage.ts
+++ b/backend/src/attachments/googleStorage.ts
@@ -1,4 +1,5 @@
 import { GetSignedUrlConfig, Storage } from "@google-cloud/storage";
+
 import { assertDefined } from "~shared/assert";
 
 const bucketName = assertDefined(process.env.GOOGLE_STORAGE_BUCKET, "GOOGLE_STORAGE_BUCKET env variable is required");

--- a/backend/src/attachments/router.ts
+++ b/backend/src/attachments/router.ts
@@ -1,9 +1,11 @@
-import { get } from "lodash";
 import { Request, Response, Router } from "express";
 import { verify } from "jsonwebtoken";
-import logger from "~shared/logger";
-import { AuthenticationError, BadRequestError, NotFoundError } from "../errors/errorTypes";
+import { get } from "lodash";
+
 import { db } from "~db";
+import logger from "~shared/logger";
+
+import { AuthenticationError, BadRequestError, NotFoundError } from "../errors/errorTypes";
 import { getSignedDownloadUrl } from "./googleStorage";
 
 export const router = Router();

--- a/backend/src/authentication.ts
+++ b/backend/src/authentication.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+
 import { AuthenticationError } from "./errors/errorTypes";
 
 export const router = Router();

--- a/backend/src/calendar/calendar.ts
+++ b/backend/src/calendar/calendar.ts
@@ -1,12 +1,14 @@
 import { addDays } from "date-fns";
 import { Router } from "express";
+
 import { db } from "~db";
 import { assert } from "~shared/assert";
+import { tryParseStringDate } from "~shared/dates/parseJSONWithDates";
 import { GoogleCalendarEvent, GoogleCalendarEventsAPIRequestBody } from "~shared/types/googleCalendar";
+
 import { createAuthorizedEndpointHandler } from "../endpoints/createEndpointHandler";
 import { AuthenticationError } from "../errors/errorTypes";
 import { fetchSingleCalendarEventsInRange } from "./googleCalendarClient";
-import { tryParseStringDate } from "~shared/dates/parseJSONWithDates";
 
 const TWO_WEEKS_IN_DAYS = 14;
 

--- a/backend/src/calendar/googleCalendarClient.ts
+++ b/backend/src/calendar/googleCalendarClient.ts
@@ -1,7 +1,9 @@
-import { google, calendar_v3 } from "googleapis";
+import { calendar_v3, google } from "googleapis";
+
+import { Account } from "~db";
 import { assert, assertDefined, assertGetAsync } from "~shared/assert";
 import { GoogleCalendarEvent } from "~shared/types/googleCalendar";
-import { Account } from "~db";
+
 import { PublicInternalServerError } from "../errors/errorTypes";
 
 const clientId = assertDefined(process.env.GOOGLE_CLIENT_ID, "GOOGLE_CLIENT_ID is required");

--- a/backend/src/endpoints/createEndpointHandler.ts
+++ b/backend/src/endpoints/createEndpointHandler.ts
@@ -1,7 +1,9 @@
 import { Request, Response } from "express";
+
 import logger from "~shared/logger";
 import { JsonValue } from "~shared/types";
 import { UserTokenData } from "~shared/types/jwtAuth";
+
 import { extractAndAssertBearerToken } from "../authentication";
 import { HttpStatus } from "../http";
 import { verifyAndParseUserJWT } from "../jwt/verifyAndParseJWT";

--- a/backend/src/errors/middleware.ts
+++ b/backend/src/errors/middleware.ts
@@ -1,7 +1,9 @@
 import { Request, Response } from "express";
+
 import { HttpStatus } from "~backend/src/http";
 import logger from "~shared/logger";
-import { HttpError, isHttpError, NotFoundError } from "./errorTypes";
+
+import { HttpError, NotFoundError, isHttpError } from "./errorTypes";
 
 export function notFoundRouteMiddleware(): void {
   throw new NotFoundError();

--- a/backend/src/events/eventHandlers.ts
+++ b/backend/src/events/eventHandlers.ts
@@ -1,17 +1,18 @@
 import {
+  Attachment,
   Message,
+  Notification,
   Room,
+  RoomInvitation,
   RoomMember,
   Space,
   Team,
   TeamInvitation,
-  RoomInvitation,
+  TeamMember,
   Topic,
   User,
-  Attachment,
-  TeamMember,
-  Notification,
 } from "~db";
+
 import { createHasuraEventsHandler } from "../hasura";
 
 export const hasuraEvents = createHasuraEventsHandler<{

--- a/backend/src/events/events.ts
+++ b/backend/src/events/events.ts
@@ -1,18 +1,20 @@
 import { Request, Response, Router } from "express";
-import { hasuraEvents } from "./eventHandlers";
+
+import { handleAttachmentUpdates } from "~backend/src/attachments/events";
 import { extractAndAssertBearerToken } from "~backend/src/authentication";
 import { AuthenticationError } from "~backend/src/errors/errorTypes";
-import { handleTeamInvitationCreated, handleTeamInvitationDeleted } from "~backend/src/teamInvitation/events";
-import { handleRoomUpdates } from "~backend/src/rooms/events";
-import { handleTeamUpdates } from "~backend/src/teams/events";
 import { handleMessageChanges } from "~backend/src/messages/events";
+import { handleNotificationCreated } from "~backend/src/notifications/events";
+import { handleRoomInvitationCreated, handleRoomMemberCreated } from "~backend/src/roomInvitation/events";
+import { handleRoomUpdates } from "~backend/src/rooms/events";
 import { handleSpaceUpdates } from "~backend/src/spaces/events";
+import { handleTeamInvitationCreated, handleTeamInvitationDeleted } from "~backend/src/teamInvitation/events";
+import { handleTeamMemberDeleted } from "~backend/src/teamMember/events";
+import { handleTeamUpdates } from "~backend/src/teams/events";
 import { handleTopicUpdates } from "~backend/src/topics/events";
 import { handleUserCreated } from "~backend/src/users/events";
-import { handleRoomMemberCreated, handleRoomInvitationCreated } from "~backend/src/roomInvitation/events";
-import { handleAttachmentUpdates } from "~backend/src/attachments/events";
-import { handleTeamMemberDeleted } from "~backend/src/teamMember/events";
-import { handleNotificationCreated } from "~backend/src/notifications/events";
+
+import { hasuraEvents } from "./eventHandlers";
 
 export const router = Router();
 

--- a/backend/src/hasura/eventHandlers.ts
+++ b/backend/src/hasura/eventHandlers.ts
@@ -1,9 +1,11 @@
 import { Request, Response } from "express";
+
+import { convertMaybeArrayToArray } from "~shared/array";
+import { isDev } from "~shared/dev";
 import logger from "~shared/logger";
 import { mapGetOrCreate } from "~shared/map";
-import { convertMaybeArrayToArray } from "~shared/array";
-import { RawHasuraEvent, HasuraEvent, normalizeHasuraEvent, getUserIdFromRawHasuraEvent } from "./eventUtils";
-import { isDev } from "~shared/dev";
+
+import { HasuraEvent, RawHasuraEvent, getUserIdFromRawHasuraEvent, normalizeHasuraEvent } from "./eventUtils";
 
 type EntitiesEventsMapBase = Record<string, unknown>;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,9 @@
 process.env.APP = "backend";
+
+import * as Sentry from "@sentry/node";
+
 // We need to load secrets before any configuration is accessed, which is why we are doing lazy imports in this file
 import { initializeSecrets } from "~config";
-import * as Sentry from "@sentry/node";
 
 if (["staging", "production"].includes(process.env.STAGE)) {
   Sentry.init({

--- a/backend/src/jwt/verifyAndParseJWT.ts
+++ b/backend/src/jwt/verifyAndParseJWT.ts
@@ -1,6 +1,7 @@
 import jwt from "jsonwebtoken";
 
 import { UserTokenData } from "~shared/types/jwtAuth";
+
 import { AuthenticationError } from "../errors/errorTypes";
 
 export function verifyAndParseJWT<AssumedData>(token: string) {

--- a/backend/src/localtunnel.ts
+++ b/backend/src/localtunnel.ts
@@ -1,5 +1,7 @@
 import os from "os";
+
 import localtunnel from "localtunnel";
+
 import { assertDefined } from "~shared/assert";
 import { isDev } from "~shared/dev";
 

--- a/backend/src/messages/events.ts
+++ b/backend/src/messages/events.ts
@@ -1,15 +1,17 @@
-import { db, Message, Notification, PrismaPromise } from "~db";
+import { uniqBy } from "lodash";
+
+import { Message, Notification, PrismaPromise, db } from "~db";
 import { Message_Type_Enum } from "~gql";
-import log from "~shared/logger";
+import { getNodesFromContentByType } from "~richEditor/content/helper";
 import { convertMessageContentToPlainText } from "~richEditor/content/plainText";
 import { RichEditorNode } from "~richEditor/content/types";
-import { getNodesFromContentByType } from "~richEditor/content/helper";
+import { assert } from "~shared/assert";
+import log from "~shared/logger";
 import { EditorMentionData } from "~shared/types/editor";
-import { uniqBy } from "lodash";
+
 import { HasuraEvent } from "../hasura";
 import { createNotification } from "../notifications/entity";
 import { updateRoomLastActivityDate } from "../rooms/rooms";
-import { assert } from "~shared/assert";
 
 export async function prepareMessagePlainTextData(message: Message) {
   if ((message.type as Message_Type_Enum) !== "TEXT") {

--- a/backend/src/notifications/events.ts
+++ b/backend/src/notifications/events.ts
@@ -1,13 +1,14 @@
-import { db, Notification } from "~db";
-import { AnyNotificationData, isNotificationDataOfType, NotificationData } from "~shared/notifications/types";
+import { Notification, db } from "~db";
+import { assert } from "~shared/assert";
+import { AnyNotificationData, NotificationData, isNotificationDataOfType } from "~shared/notifications/types";
+
+import { UnprocessableEntityError } from "../errors/errorTypes";
+import { HasuraEvent } from "../hasura";
+import { RoomAddedNotification } from "../roomInvitation/RoomAddedNotification";
+import { findRoomById } from "../rooms/rooms";
 import { findUserById, getNormalizedUserName } from "../users/users";
 import { MentionNotification } from "./MentionNotification";
 import { sendNotification } from "./sendNotification";
-import { assert } from "~shared/assert";
-import { HasuraEvent } from "../hasura";
-import { findRoomById } from "../rooms/rooms";
-import { UnprocessableEntityError } from "../errors/errorTypes";
-import { RoomAddedNotification } from "../roomInvitation/RoomAddedNotification";
 
 async function sendMentionEmailNotification(notification: Notification, data: NotificationData<"topicMention">) {
   const {

--- a/backend/src/notifications/sendNotification.ts
+++ b/backend/src/notifications/sendNotification.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_NOTIFICATION_EMAIL, sendEmail } from "~shared/email";
+
 import { Notification } from "./Notification";
 
 export function sendNotification(notification: Notification): Promise<void> {

--- a/backend/src/roomInvitation/events.ts
+++ b/backend/src/roomInvitation/events.ts
@@ -1,10 +1,11 @@
-import { db, RoomMember } from "~db";
-import { RoomInvitation } from "~db";
 import { UnprocessableEntityError } from "~backend/src/errors/errorTypes";
-import { HasuraEvent } from "../hasura";
-import { createNotification } from "../notifications/entity";
 import { findRoomById } from "~backend/src/rooms/rooms";
 import { findUserById } from "~backend/src/users/users";
+import { RoomMember, db } from "~db";
+import { RoomInvitation } from "~db";
+
+import { HasuraEvent } from "../hasura";
+import { createNotification } from "../notifications/entity";
 
 export async function handleRoomMemberCreated({ item: invite, userId }: HasuraEvent<RoomMember>) {
   const { room_id: roomId, user_id: addedUserId } = invite;

--- a/backend/src/roomInvitation/roomInvitationView.ts
+++ b/backend/src/roomInvitation/roomInvitationView.ts
@@ -1,8 +1,9 @@
 import { validate as validateUuid } from "uuid";
-import { db } from "~db";
+
 import { ActionHandler } from "~backend/src/actions/actionHandlers";
 import { NotFoundError, UnprocessableEntityError } from "~backend/src/errors/errorTypes";
 import { getNormalizedUserName } from "~backend/src/users/users";
+import { db } from "~db";
 
 export interface RoomInvitationViewActionInputs {
   token: string;

--- a/backend/src/rooms/events.ts
+++ b/backend/src/rooms/events.ts
@@ -1,5 +1,6 @@
-import { db, Room } from "~db";
+import { Room, db } from "~db";
 import logger from "~shared/logger";
+
 import { HasuraEvent } from "../hasura";
 import { createNotification } from "../notifications/entity";
 import { addRoomParticipant, getIfParticipantExists, updateRoomLastActivityDate } from "./rooms";

--- a/backend/src/rooms/rooms.ts
+++ b/backend/src/rooms/rooms.ts
@@ -1,4 +1,4 @@
-import { db, Room, RoomMember } from "~db";
+import { Room, RoomMember, db } from "~db";
 
 export async function findRoomById(roomId: string): Promise<Room | null> {
   return await db.room.findUnique({

--- a/backend/src/spaces/events.ts
+++ b/backend/src/spaces/events.ts
@@ -1,5 +1,6 @@
 import { Space } from "~db";
 import logger from "~shared/logger";
+
 import { UnprocessableEntityError } from "../errors/errorTypes";
 import { HasuraEvent } from "../hasura";
 import { addSpaceMember, getSpaceHasMember } from "./helpers";

--- a/backend/src/spaces/helpers.ts
+++ b/backend/src/spaces/helpers.ts
@@ -1,4 +1,4 @@
-import { db, SpaceMember } from "~db";
+import { SpaceMember, db } from "~db";
 
 export async function getSpaceHasMember(spaceId: string, memberId: string): Promise<boolean> {
   const entry = await db.space_member.findFirst({

--- a/backend/src/teamInvitation/events.ts
+++ b/backend/src/teamInvitation/events.ts
@@ -1,4 +1,5 @@
-import { db, TeamInvitation } from "~db";
+import { TeamInvitation, db } from "~db";
+
 import { HasuraEvent } from "../hasura";
 import { sendInviteNotification } from "./sendInviteNotification";
 

--- a/backend/src/teamInvitation/lookupTeamName.ts
+++ b/backend/src/teamInvitation/lookupTeamName.ts
@@ -1,8 +1,10 @@
 import { validate as validateUuid } from "uuid";
+
+import { getNormalizedUserName } from "~backend/src/users/users";
 import { db } from "~db";
+
 import { ActionHandler } from "../actions/actionHandlers";
 import { NotFoundError, UnprocessableEntityError } from "../errors/errorTypes";
-import { getNormalizedUserName } from "~backend/src/users/users";
 
 export interface LookupTeamNameActionInputs {
   token: string;

--- a/backend/src/teamInvitation/resendInvitation.ts
+++ b/backend/src/teamInvitation/resendInvitation.ts
@@ -1,7 +1,8 @@
-import { db } from "~db";
 import { ActionHandler } from "~backend/src/actions/actionHandlers";
 import { UnprocessableEntityError } from "~backend/src/errors/errorTypes";
+import { db } from "~db";
 import { assert } from "~shared/assert";
+
 import { sendInviteNotification } from "./sendInviteNotification";
 
 export interface ResendInvitationActionInputs {

--- a/backend/src/teamInvitation/sendInviteNotification.ts
+++ b/backend/src/teamInvitation/sendInviteNotification.ts
@@ -1,10 +1,11 @@
-import { db, TeamInvitation } from "~db";
+import { UnprocessableEntityError } from "~backend/src/errors/errorTypes";
+import { sendNotification } from "~backend/src/notifications/sendNotification";
 import { findTeamById } from "~backend/src/teams/helpers";
 import { findUserById, getNormalizedUserName } from "~backend/src/users/users";
-import { UnprocessableEntityError } from "~backend/src/errors/errorTypes";
-import { TeamInvitationNotification } from "./InviteNotification";
-import { sendNotification } from "~backend/src/notifications/sendNotification";
+import { TeamInvitation, db } from "~db";
 import logger from "~shared/logger";
+
+import { TeamInvitationNotification } from "./InviteNotification";
 
 export const sendInviteNotification = async (invite: TeamInvitation, userId: string | null) => {
   const { email, inviting_user_id: invitingUserId, team_id: teamId } = invite;

--- a/backend/src/teamMember/events.ts
+++ b/backend/src/teamMember/events.ts
@@ -1,4 +1,5 @@
-import { db, TeamMember } from "~db";
+import { TeamMember, db } from "~db";
+
 import { HasuraEvent } from "../hasura";
 
 export async function handleTeamMemberDeleted({ item: teamMember }: HasuraEvent<TeamMember>) {

--- a/backend/src/teams/events.ts
+++ b/backend/src/teams/events.ts
@@ -1,5 +1,6 @@
 import { Team } from "~db";
 import logger from "~shared/logger";
+
 import { UnprocessableEntityError } from "../errors/errorTypes";
 import { HasuraEvent } from "../hasura";
 import { addTeamMember, getHasTeamMember } from "./helpers";

--- a/backend/src/teams/helpers.ts
+++ b/backend/src/teams/helpers.ts
@@ -1,4 +1,4 @@
-import { db, TeamMember } from "~db";
+import { TeamMember, db } from "~db";
 
 export async function getHasTeamMember(teamId: string, memberId: string): Promise<boolean> {
   const entry = await db.team_member.findFirst({

--- a/backend/src/testSupport/setupTests.ts
+++ b/backend/src/testSupport/setupTests.ts
@@ -1,5 +1,7 @@
 import "~config";
+
 import { db } from "~db";
+
 import { cleanupDatabase } from "./testDatabaseUtils";
 
 beforeEach(async () => {

--- a/backend/src/topics/events.ts
+++ b/backend/src/topics/events.ts
@@ -1,4 +1,5 @@
-import { db, Topic } from "~db";
+import { Topic, db } from "~db";
+
 import { HasuraEvent } from "../hasura";
 import { createNotification } from "../notifications/entity";
 import { updateRoomLastActivityDate } from "../rooms/rooms";

--- a/backend/src/transcriptions/router.ts
+++ b/backend/src/transcriptions/router.ts
@@ -1,5 +1,7 @@
 import { Request, Response, Router } from "express";
+
 import logger from "~shared/logger";
+
 import { BadRequestError } from "../errors/errorTypes";
 import { SonixMediaResponse } from "./sonixClient";
 import { handleAttachementTranscriptionStatusUpdate } from "./transcriptionService";

--- a/backend/src/transcriptions/sonixClient.ts
+++ b/backend/src/transcriptions/sonixClient.ts
@@ -1,8 +1,11 @@
-import axios, { Method } from "axios";
 import querystring from "querystring";
+
+import axios, { Method } from "axios";
+
 import { assert, assertDefined } from "~shared/assert";
 import { isDev } from "~shared/dev";
 import { SonixTranscriptData } from "~shared/types/transcript";
+
 import { getDevPublicTunnel } from "../localtunnel";
 import { SonixCustomData } from "./customData";
 

--- a/backend/src/transcriptions/transcriptionService.ts
+++ b/backend/src/transcriptions/transcriptionService.ts
@@ -1,8 +1,9 @@
-import { Attachment, db, Prisma } from "~db";
+import { Attachment, Prisma, db } from "~db";
 import { assert } from "~shared/assert";
+
 import { getSignedDownloadUrl } from "../attachments/googleStorage";
 import { SonixCustomData } from "./customData";
-import { requestSonixMediaTranscript, SonixMediaResponse, fetchSonixTranscriptForMedia } from "./sonixClient";
+import { SonixMediaResponse, fetchSonixTranscriptForMedia, requestSonixMediaTranscript } from "./sonixClient";
 
 export async function initializeAttachmentTranscription(attachment: Attachment) {
   const attachmentUrl = await getSignedDownloadUrl(attachment.id, attachment.mime_type);

--- a/backend/src/users/events.ts
+++ b/backend/src/users/events.ts
@@ -1,7 +1,7 @@
-import { db, User } from "~db";
 import { HasuraEvent } from "~backend/src/hasura";
-import { trackBackendUserEvent } from "~shared/backendAnalytics";
 import { addTeamMember } from "~backend/src/teams/helpers";
+import { User, db } from "~db";
+import { trackBackendUserEvent } from "~shared/backendAnalytics";
 
 export async function handleUserCreated({ item: user }: HasuraEvent<User>) {
   await acceptAllNewUserInvitations(user);

--- a/backend/src/users/users.ts
+++ b/backend/src/users/users.ts
@@ -1,4 +1,4 @@
-import { db, User } from "~db";
+import { User, db } from "~db";
 
 // TODO: Not used?
 export async function updateUser(user: User): Promise<User> {

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+
 import { extractAndAssertBearerToken } from "./authentication";
 import { AuthenticationError } from "./errors/errorTypes";
 

--- a/config/dotenv.ts
+++ b/config/dotenv.ts
@@ -1,5 +1,7 @@
-import dotenv from "dotenv";
 import path from "path";
+
+import dotenv from "dotenv";
+
 import { assertDefined } from "~shared/assert";
 
 function getDotEnvPath() {

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,5 +1,6 @@
-import { warn } from "~shared/logger";
 import "./dotenv";
+
+import { warn } from "~shared/logger";
 
 let isLoaded = false;
 let loadingPromise: Promise<void> | null = null;

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+
 import { assert } from "~shared/assert";
 
 export type {

--- a/e2e/helper/base-test.ts
+++ b/e2e/helper/base-test.ts
@@ -1,7 +1,8 @@
-import { get } from "lodash";
 import { test as rootTest } from "@playwright/test";
+import { get } from "lodash";
+
 import { domain } from "./constants";
-import type { setupDatabase, TestUser } from "./db";
+import type { TestUser, setupDatabase } from "./db";
 
 type Await<T> = T extends PromiseLike<infer U> ? U : T;
 

--- a/e2e/helper/db.ts
+++ b/e2e/helper/db.ts
@@ -1,6 +1,8 @@
 import "~config";
+
 import { PrismaClient } from "@prisma/client";
 import { sign } from "jsonwebtoken";
+
 import { user } from ".prisma/client";
 
 const prismaDatabaseUrl = `postgresql://${process.env.DB_USER}:${encodeURIComponent(process.env.DB_PASSWORD)}@${

--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -1,5 +1,6 @@
-import { test } from "./helper/base-test";
 import { basePath } from "~e2e/helper/constants";
+
+import { test } from "./helper/base-test";
 
 test("find login button", async ({ page }) => {
   await page.goto(basePath);

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,27 +1,29 @@
 // Polyfill for :focus-visible pseudo-selector.
 import "focus-visible";
-import { useEffect } from "react";
+
+import * as Sentry from "@sentry/nextjs";
 import { AnimatePresence, MotionConfig } from "framer-motion";
 import { Session } from "next-auth";
-import { getSession, Provider as SessionProvider } from "next-auth/client";
+import { Provider as SessionProvider, getSession } from "next-auth/client";
 import { AppContext, AppProps } from "next/app";
 import Head from "next/head";
+import { useEffect } from "react";
 import { createGlobalStyle } from "styled-components";
+import { ThemeProvider } from "styled-components";
+
+import { AnalyticsManager } from "~frontend/analytics/AnalyticsProvider";
 import { ApolloClientProvider as ApolloProvider, readTokenFromRequest } from "~frontend/apollo/client";
 import { getUserFromRequest } from "~frontend/authentication/request";
-import { global } from "~frontend/styles/global";
-import { renderWithPageLayout } from "~frontend/utils/pageLayout";
 import initializeUserbackPlugin from "~frontend/scripts/userback";
-import { PresenceAnimator } from "~ui/PresenceAnimator";
-import { PromiseUIRenderer } from "~ui/createPromiseUI";
-import { POP_ANIMATION_CONFIG } from "~ui/animations";
-import { TooltipsRenderer } from "~ui/popovers/TooltipsRenderer";
-import { ToastsRenderer } from "~ui/toasts/ToastsRenderer";
-import { AnalyticsManager } from "~frontend/analytics/AnalyticsProvider";
-import { ThemeProvider } from "styled-components";
-import * as Sentry from "@sentry/nextjs";
-import { getTheme } from "~ui/theme";
+import { global } from "~frontend/styles/global";
 import { CurrentTeamIdProvider } from "~frontend/team/CurrentTeamIdProvider";
+import { renderWithPageLayout } from "~frontend/utils/pageLayout";
+import { POP_ANIMATION_CONFIG } from "~ui/animations";
+import { PromiseUIRenderer } from "~ui/createPromiseUI";
+import { TooltipsRenderer } from "~ui/popovers/TooltipsRenderer";
+import { PresenceAnimator } from "~ui/PresenceAnimator";
+import { getTheme } from "~ui/theme";
+import { ToastsRenderer } from "~ui/toasts/ToastsRenderer";
 
 const stage = process.env.STAGE || process.env.NEXT_PUBLIC_STAGE;
 if (["staging", "production"].includes(stage)) {

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,6 +1,6 @@
 import Document, { DocumentContext, DocumentInitialProps, Head, Html, Main, NextScript } from "next/document";
-
 import { ServerStyleSheet } from "styled-components";
+
 import { clearApolloCache, getApolloClient, readTokenFromRequest } from "~frontend/apollo/client";
 import { ApolloInitialState, prefetchRecordedQueries, startRecordingUsedQueries } from "~frontend/gql/utils/hydration";
 

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -3,12 +3,13 @@ import { NextApiRequest, NextApiResponse } from "next";
 import NextAuth, { NextAuthOptions, User as ProviderUser } from "next-auth";
 import { AdapterInstance } from "next-auth/adapters";
 import Providers from "next-auth/providers";
+
 import { initializeSecrets } from "~config";
-import { Account, db, User } from "~db";
+import { Account, User, db } from "~db";
 import { assert } from "~shared/assert";
-import { DEFAULT_NOTIFICATION_EMAIL, sendEmail } from "~shared/email";
-import { DEFAULT_ROLE, ALLOWED_ROLES } from "~shared/roles";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
+import { DEFAULT_NOTIFICATION_EMAIL, sendEmail } from "~shared/email";
+import { ALLOWED_ROLES, DEFAULT_ROLE } from "~shared/roles";
 
 /**
  * In this file we manage authorization integration using next-auth.

--- a/frontend/pages/invites/[inviteCode].tsx
+++ b/frontend/pages/invites/[inviteCode].tsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useRoomInvitationViewQuery } from "~frontend/gql/roomInvitations";
+import { lookupTeamName } from "~frontend/gql/teams";
 import { routes } from "~frontend/router";
 import { LoginOptionsView } from "~frontend/views/LoginOptionsView";
 import { WindowView } from "~frontend/views/WindowView";
 import { assert } from "~shared/assert";
-import { lookupTeamName } from "~frontend/gql/teams";
-import { useRoomInvitationViewQuery } from "~frontend/gql/roomInvitations";
 
 export default function InvitePage() {
   const user = useCurrentUser();

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,6 +1,8 @@
-import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
+
+import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { DEFAULT_REDIRECT_URL } from "~frontend/config";
 import { LoginOptionsView } from "~frontend/views/LoginOptionsView";

--- a/frontend/pages/logout.tsx
+++ b/frontend/pages/logout.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
 import { signOut } from "next-auth/client";
+import { useEffect } from "react";
+
 import { trackEvent } from "~frontend/analytics/tracking";
 
 export default function LogoutPage() {

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+
 import { LogoutButton } from "~frontend/authentication/logout";
 import { withServerSideAuthRedirect } from "~frontend/authentication/withServerSideAuthRedirect";
-import { UIContentWrapper } from "~frontend/ui/UIContentWrapper";
 import { MainLayout } from "~frontend/MainLayout";
+import { UIContentWrapper } from "~frontend/ui/UIContentWrapper";
 import { assignPageLayout } from "~frontend/utils/pageLayout";
 
 export const getServerSideProps = withServerSideAuthRedirect();

--- a/frontend/pages/space/[spaceId]/[roomId]/summary.tsx
+++ b/frontend/pages/space/[spaceId]/[roomId]/summary.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { routes } from "~frontend/router";
+
 import { withServerSideAuthRedirect } from "~frontend/authentication/withServerSideAuthRedirect";
 import { AppLayout } from "~frontend/layouts/AppLayout";
+import { useRoomWithClientErrorRedirects } from "~frontend/rooms/useRoomWithClientErrorRedirects";
+import { routes } from "~frontend/router";
 import { assignPageLayout } from "~frontend/utils/pageLayout";
 import { RoomSummaryView } from "~frontend/views/RoomView/RoomSummaryView";
-import { useRoomWithClientErrorRedirects } from "~frontend/rooms/useRoomWithClientErrorRedirects";
 
 const Page = () => {
   const { roomId, spaceId } = routes.spaceRoomSummary.useAssertParams().route;

--- a/frontend/pages/space/[spaceId]/index.tsx
+++ b/frontend/pages/space/[spaceId]/index.tsx
@@ -1,6 +1,6 @@
-import { routes } from "~frontend/router";
 import { withServerSideAuthRedirect } from "~frontend/authentication/withServerSideAuthRedirect";
 import { AppLayout } from "~frontend/layouts/AppLayout";
+import { routes } from "~frontend/router";
 import { assignPageLayout } from "~frontend/utils/pageLayout";
 import { SpaceView } from "~frontend/views/SpaceView";
 

--- a/frontend/pages/team.tsx
+++ b/frontend/pages/team.tsx
@@ -1,6 +1,5 @@
 import { AppLayout } from "~frontend/layouts/AppLayout";
 import { assignPageLayout } from "~frontend/utils/pageLayout";
-
 import { PageMeta } from "~frontend/utils/PageMeta";
 import { TeamMembersView } from "~frontend/views/TeamMembersView";
 

--- a/frontend/router/RouteLink.tsx
+++ b/frontend/router/RouteLink.tsx
@@ -1,7 +1,8 @@
-import { ReactChild, isValidElement, ReactElement } from "react";
+import NextLink from "next/link";
+import { ReactChild, ReactElement, isValidElement } from "react";
+
 import { Route } from "./create";
 import { fillParamsInUrl } from "./utils";
-import NextLink from "next/link";
 
 interface Props<P> {
   route: Route<P>;

--- a/frontend/router/create.tsx
+++ b/frontend/router/create.tsx
@@ -1,8 +1,9 @@
 import { pick } from "lodash";
 import router, { NextRouter, useRouter } from "next/router";
-import { assertDefined } from "~shared/assert";
 
+import { assertDefined } from "~shared/assert";
 import { groupByFilter } from "~shared/groupByFilter";
+
 import { InferParamsFromDefinition, RouteParamsDefinition } from "./params";
 import { fillParamsInUrl } from "./utils";
 

--- a/frontend/router/index.ts
+++ b/frontend/router/index.ts
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
+
 import { createRoute } from "./create";
+
 export { RouteLink } from "./RouteLink";
 
 export const routes = {

--- a/frontend/routes/create.tsx
+++ b/frontend/routes/create.tsx
@@ -1,9 +1,9 @@
 import { pick } from "lodash";
 import NextLink from "next/link";
 import router, { NextRouter, useRouter } from "next/router";
-
 import { ComponentType } from "react";
 import { ReactNode } from "react";
+
 import { groupByFilter } from "~shared/groupByFilter";
 
 type RouteParamValueType = "string" | "number";

--- a/frontend/src/MainLayout.tsx
+++ b/frontend/src/MainLayout.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from "react";
 import styled from "styled-components";
+
 import { SidebarLayout } from "./ui/Layout";
 import { NavLink } from "./ui/NavLink";
 

--- a/frontend/src/analytics/AnalyticsProvider.tsx
+++ b/frontend/src/analytics/AnalyticsProvider.tsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { fetchTeamBasicInfoQuery } from "~frontend/gql/teams";
-import { identifyUser, identifyUserGroup } from "./tracking";
-import { SegmentScript } from "./SegmentScript";
-import { ErrorBoundary } from "~ui/ErrorBoundary";
-import { ClientSideOnly } from "~ui/ClientSideOnly";
 import { useCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { ClientSideOnly } from "~ui/ClientSideOnly";
+import { ErrorBoundary } from "~ui/ErrorBoundary";
+
+import { SegmentScript } from "./SegmentScript";
+import { identifyUser, identifyUserGroup } from "./tracking";
 
 export function AnalyticsManager() {
   const [isSegmentLoaded, setIsSegmentLoaded] = useState(false);

--- a/frontend/src/analytics/SegmentScript.tsx
+++ b/frontend/src/analytics/SegmentScript.tsx
@@ -1,6 +1,7 @@
 import snippet from "@segment/snippet";
 import Script from "next/script";
 import { memo } from "react";
+
 import { useConst } from "~shared/hooks/useConst";
 
 const segmentApiKey = process.env.NEXT_PUBLIC_SEGMENT_API_KEY;

--- a/frontend/src/analytics/tracking.ts
+++ b/frontend/src/analytics/tracking.ts
@@ -1,4 +1,4 @@
-import { AnalyticsUserProfile, AnalyticsGroupsMap, AnalyticsEventsMap } from "~shared/types/analytics";
+import { AnalyticsEventsMap, AnalyticsGroupsMap, AnalyticsUserProfile } from "~shared/types/analytics";
 
 export function identifyUser(userProfile: AnalyticsUserProfile) {
   if (window.analytics) {

--- a/frontend/src/apollo/apollo.test.tsx
+++ b/frontend/src/apollo/apollo.test.tsx
@@ -4,9 +4,11 @@ import { graphql, rest } from "msw";
 import { setupServer } from "msw/node";
 import { Provider } from "next-auth/client";
 import { PropsWithChildren } from "react";
+
 import { GoogleLoginButton } from "~frontend/authentication/GoogleLoginButton";
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useSpaceRoomsQuery } from "~frontend/gql/rooms";
+
 import { ApolloClientProvider as ApolloProvider } from "./client";
 
 jest.mock(

--- a/frontend/src/apollo/client.tsx
+++ b/frontend/src/apollo/client.tsx
@@ -1,3 +1,5 @@
+import { IncomingMessage } from "http";
+
 import {
   ApolloClient,
   ApolloLink,
@@ -10,20 +12,21 @@ import {
 import { onError } from "@apollo/client/link/error";
 import { WebSocketLink } from "@apollo/client/link/ws";
 import { getMainDefinition } from "@apollo/client/utilities";
+import { LocalStorageWrapper, persistCache } from "apollo3-cache-persist";
 import { GraphQLError } from "graphql";
-import { IncomingMessage } from "http";
 import { memoize } from "lodash";
 import { NextApiRequest } from "next";
 import React, { ReactNode } from "react";
-import { readCurrentToken, TOKEN_COOKIE_NAME } from "~frontend/authentication/cookie";
+
+import { TOKEN_COOKIE_NAME, readCurrentToken } from "~frontend/authentication/cookie";
 import { getApolloInitialState } from "~frontend/gql/utils/hydration";
 import { readAppInitialPropByName } from "~frontend/utils/next";
 import { TypedTypePolicies } from "~gql";
 import { assertDefined } from "~shared/assert";
 import { useConst } from "~shared/hooks/useConst";
 import { addToast } from "~ui/toasts/data";
+
 import { createDateParseLink } from "./dateStringParseLink";
-import { persistCache, LocalStorageWrapper } from "apollo3-cache-persist";
 
 const mergeUsingIncoming: FieldMergeFunction<unknown, unknown> = (old, fresh) => fresh;
 

--- a/frontend/src/apollo/dateStringParseLink.tsx
+++ b/frontend/src/apollo/dateStringParseLink.tsx
@@ -2,6 +2,7 @@ import { ApolloLink, FetchResult, Observable } from "@apollo/client";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { DocumentNode } from "graphql";
 import { isArray, isObject, mapValues } from "lodash";
+
 import { tryParseStringDate } from "~shared/dates/parseJSONWithDates";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/authentication/EmailLoginButton.tsx
+++ b/frontend/src/authentication/EmailLoginButton.tsx
@@ -1,7 +1,8 @@
 import { signIn } from "next-auth/client";
 import React, { ReactNode } from "react";
-import { emailInputValidator } from "~shared/validation/inputValidation";
+
 import { openUIPrompt } from "~frontend/utils/prompt";
+import { emailInputValidator } from "~shared/validation/inputValidation";
 import { Button } from "~ui/buttons/Button";
 
 export const EmailLoginButton = ({

--- a/frontend/src/authentication/GoogleLoginButton.tsx
+++ b/frontend/src/authentication/GoogleLoginButton.tsx
@@ -1,5 +1,6 @@
 import { signIn } from "next-auth/client";
 import React, { ReactNode } from "react";
+
 import { Button } from "~ui/buttons/Button";
 
 export const GoogleLoginButton = ({

--- a/frontend/src/authentication/cookie.ts
+++ b/frontend/src/authentication/cookie.ts
@@ -1,4 +1,5 @@
 import Cookie from "js-cookie";
+
 import { assertDefined } from "~shared/assert";
 import { parseJWTWithoutValidation } from "~shared/jwt";
 import { UserTokenData } from "~shared/types/jwtAuth";

--- a/frontend/src/authentication/logout.tsx
+++ b/frontend/src/authentication/logout.tsx
@@ -1,5 +1,6 @@
 import { signOut } from "next-auth/client";
 import React, { useState } from "react";
+
 import { Button } from "~ui/buttons/Button";
 
 interface Logout {

--- a/frontend/src/authentication/request.ts
+++ b/frontend/src/authentication/request.ts
@@ -1,7 +1,9 @@
-import { NextApiRequest } from "next";
-import { parseJWTWithoutValidation } from "~shared/jwt";
-import { Session } from "next-auth";
 import { IncomingMessage } from "http";
+
+import { NextApiRequest } from "next";
+import { Session } from "next-auth";
+
+import { parseJWTWithoutValidation } from "~shared/jwt";
 
 type Empty = Record<string, never>;
 

--- a/frontend/src/authentication/useCurrentUser.tsx
+++ b/frontend/src/authentication/useCurrentUser.tsx
@@ -1,6 +1,7 @@
 import { useSession } from "next-auth/client";
-import { UserBasicInfoFragment } from "~gql";
+
 import { convertUserAuthToBasicFragment } from "~frontend/utils/user";
+import { UserBasicInfoFragment } from "~gql";
 import { assertDefined } from "~shared/assert";
 import { UserTokenData } from "~shared/types/jwtAuth";
 

--- a/frontend/src/gql/attachments.ts
+++ b/frontend/src/gql/attachments.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { assert } from "~shared/assert";
+
 import {
   AttachmentDetailedInfoFragment as AttachmentDetailedInfoFragmentType,
   AttachmentQuery,
@@ -11,6 +11,8 @@ import {
   UploadUrlQuery,
   UploadUrlQueryVariables,
 } from "~gql";
+import { assert } from "~shared/assert";
+
 import { MessageDetailedInfoFragment } from "./messages";
 import { createFragment, createMutation, createQuery } from "./utils";
 

--- a/frontend/src/gql/messages.ts
+++ b/frontend/src/gql/messages.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+
 import { assertReadUserDataFromCookie } from "~frontend/authentication/cookie";
 import {
   CreateMessageMutation,
@@ -12,10 +13,11 @@ import {
   UpdateTextMessageMutationVariables,
 } from "~gql";
 import { getUUID } from "~shared/uuid";
+
 import { AttachmentDetailedInfoFragment } from "./attachments";
 import { ReactionBasicInfoFragment } from "./reactions";
 import { topicMessagesQueryManager, updateLastSeenMessage } from "./topics";
-import { convertUserTokenDataToInfoFragment, UserBasicInfoFragment } from "./user";
+import { UserBasicInfoFragment, convertUserTokenDataToInfoFragment } from "./user";
 import { createFragment, createMutation } from "./utils";
 
 export const MessageBasicInfoFragment = createFragment<MessageBasicInfoFragmentType>(

--- a/frontend/src/gql/notifications.tsx
+++ b/frontend/src/gql/notifications.tsx
@@ -1,20 +1,22 @@
 import { gql } from "@apollo/client";
-import { createFragment, createMutation, createQuery } from "./utils";
+
 import {
-  NotificationInfoFragment as NotificationInfoFragmentType,
-  NotificationsQuery,
-  NotificationsQueryVariables,
-  UnreadNotificationsQuery,
-  UnreadNotificationsQueryVariables,
-  MarkNotificationAsReadMutation,
-  MarkNotificationAsReadMutationVariables,
-  RemoveNotificationMutationVariables,
-  RemoveNotificationMutation,
   DeleteAllReadNotificationsMutation,
   DeleteAllReadNotificationsMutationVariables,
   MarkAllNotificationsAsReadMutation,
   MarkAllNotificationsAsReadMutationVariables,
+  MarkNotificationAsReadMutation,
+  MarkNotificationAsReadMutationVariables,
+  NotificationInfoFragment as NotificationInfoFragmentType,
+  NotificationsQuery,
+  NotificationsQueryVariables,
+  RemoveNotificationMutation,
+  RemoveNotificationMutationVariables,
+  UnreadNotificationsQuery,
+  UnreadNotificationsQueryVariables,
 } from "~gql";
+
+import { createFragment, createMutation, createQuery } from "./utils";
 
 const NotificationInfoFragment = createFragment<NotificationInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/reactions.ts
+++ b/frontend/src/gql/reactions.ts
@@ -1,14 +1,16 @@
 import { gql } from "@apollo/client";
+
 import {
-  ReactionBasicInfoFragment as ReactionBasicInfoFragmentType,
   AddMessageReactionMutation,
   AddMessageReactionMutationVariables,
+  ReactionBasicInfoFragment as ReactionBasicInfoFragmentType,
   RemoveMessageReactionMutation,
   RemoveMessageReactionMutationVariables,
 } from "~gql";
-import { createFragment, createMutation } from "./utils";
-import { UserBasicInfoFragment } from "./user";
+
 import { MessageDetailedInfoFragment } from "./messages";
+import { UserBasicInfoFragment } from "./user";
+import { createFragment, createMutation } from "./utils";
 
 export const ReactionBasicInfoFragment = createFragment<ReactionBasicInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/roomInvitations.ts
+++ b/frontend/src/gql/roomInvitations.ts
@@ -1,16 +1,18 @@
 import { gql } from "@apollo/client";
+
 import {
   CreateRoomInvitationMutation,
   CreateRoomInvitationMutationVariables,
-  RoomInvitationBasicInfoFragment as RoomInvitationBasicInfoFragmentType,
   RemoveRoomInvitationMutation,
   RemoveRoomInvitationMutationVariables,
+  RoomInvitationBasicInfoFragment as RoomInvitationBasicInfoFragmentType,
   RoomInvitationViewQuery,
   RoomInvitationViewQueryVariables,
 } from "~gql";
-import { createMutation, createFragment, createQuery } from "./utils";
 import { addToast } from "~ui/toasts/data";
+
 import { RoomDetailedInfoFragment } from "./rooms";
+import { createFragment, createMutation, createQuery } from "./utils";
 
 export const RoomInvitationBasicInfoFragment = createFragment<RoomInvitationBasicInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/rooms.ts
+++ b/frontend/src/gql/rooms.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { updateHomeviewQuery } from "~frontend/views/HomeView/query";
 import {
@@ -29,16 +30,17 @@ import {
   UpdateRoomMutation,
   UpdateRoomMutationVariables,
 } from "~gql";
+import { assert } from "~shared/assert";
 import { slugify } from "~shared/slugify";
 import { getUUID } from "~shared/uuid";
 import { addToast } from "~ui/toasts/data";
+
 import { RoomInvitationBasicInfoFragment } from "./roomInvitations";
 import { SpaceDetailedInfoFragment } from "./spaces";
 import { TopicDetailedInfoFragment } from "./topics";
 import { UserBasicInfoFragment } from "./user";
 import { createFragment, createMutation, createQuery } from "./utils";
 import { getUpdatedDataWithInput } from "./utils/updateWithInput";
-import { assert } from "~shared/assert";
 
 export const PrivateRoomInfoFragment = createFragment<PrivateRoomInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/search.ts
+++ b/frontend/src/gql/search.ts
@@ -1,6 +1,8 @@
 import { gql } from "@apollo/client";
-import { createQuery } from "./utils";
+
 import { SearchResultsQuery, SearchResultsQueryVariables } from "~gql";
+
+import { createQuery } from "./utils";
 
 export const [useFullTextSearchQuery] = createQuery<SearchResultsQuery, SearchResultsQueryVariables>(
   () => gql`

--- a/frontend/src/gql/spaces.ts
+++ b/frontend/src/gql/spaces.ts
@@ -1,34 +1,36 @@
 import { gql } from "@apollo/client";
-import { addToast } from "~ui/toasts/data";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import {
+  AddSpaceMemberMutation,
+  AddSpaceMemberMutationVariables,
   CreateSpaceMutation,
   CreateSpaceMutationVariables,
+  DeleteSpaceMutation,
+  DeleteSpaceMutationVariables,
+  EditSpaceMutation,
+  EditSpaceMutationVariables,
+  RemoveSpaceMemberMutation,
+  RemoveSpaceMemberMutationVariables,
+  SingleSpaceQuery,
+  SingleSpaceQueryVariables,
+  SpaceBasicInfoFragment as SpaceBasicInfoFragmentType,
+  SpaceDetailedInfoFragment as SpaceDetailedInfoFragmentType,
   SpacesQuery,
   SpacesQueryVariables,
   TeamSpacesQuery,
   TeamSpacesQueryVariables,
-  SingleSpaceQuery,
-  SingleSpaceQueryVariables,
-  AddSpaceMemberMutation,
-  AddSpaceMemberMutationVariables,
-  RemoveSpaceMemberMutation,
-  RemoveSpaceMemberMutationVariables,
-  EditSpaceMutation,
-  EditSpaceMutationVariables,
-  DeleteSpaceMutation,
-  DeleteSpaceMutationVariables,
-  SpaceDetailedInfoFragment as SpaceDetailedInfoFragmentType,
-  SpaceBasicInfoFragment as SpaceBasicInfoFragmentType,
 } from "~gql";
-import { RoomBasicInfoFragment, RoomDetailedInfoFragment } from "./rooms";
-import { UserBasicInfoFragment } from "./user";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { createFragment, createMutation, createQuery } from "./utils";
-import { TeamDetailedInfoFragment } from "./teams";
-import { getUUID } from "~shared/uuid";
 import { slugify } from "~shared/slugify";
+import { getUUID } from "~shared/uuid";
+import { addToast } from "~ui/toasts/data";
+
+import { RoomBasicInfoFragment, RoomDetailedInfoFragment } from "./rooms";
+import { TeamDetailedInfoFragment } from "./teams";
+import { UserBasicInfoFragment } from "./user";
+import { createFragment, createMutation, createQuery } from "./utils";
 import { getUpdatedDataWithInput } from "./utils/updateWithInput";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 
 export const SpaceBasicInfoFragment = createFragment<SpaceBasicInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/teams.ts
+++ b/frontend/src/gql/teams.ts
@@ -1,34 +1,36 @@
 import { gql } from "@apollo/client";
+
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import {
-  CreateTeamMutation,
-  CreateTeamMutationVariables,
-  TeamsQuery,
-  TeamsQueryVariables,
-  TeamDetailsQuery,
-  TeamDetailsQueryVariables,
   CreateTeamInvitationMutation,
   CreateTeamInvitationMutationVariables,
-  TeamBasicInfoQuery,
-  TeamBasicInfoQueryVariables,
-  TeamBasicInfoFragment as TeamBasicInfoFragmentType,
-  TeamInvitationBasicInfoFragment as TeamInvitationBasicInfoFragmentType,
-  TeamDetailedInfoFragment as TeamDetailedInfoFragmentType,
-  UserBasicInfoFragment as UserBasicInfoFragmentType,
+  CreateTeamMutation,
+  CreateTeamMutationVariables,
+  LookupTeamNameQuery,
+  LookupTeamNameQueryVariables,
   RemoveTeamInvitationMutation,
   RemoveTeamInvitationMutationVariables,
   RemoveTeamMemberMutation,
   RemoveTeamMemberMutationVariables,
-  LookupTeamNameQuery,
-  LookupTeamNameQueryVariables,
   ResendInvitationMutation,
   ResendInvitationMutationVariables,
+  TeamBasicInfoFragment as TeamBasicInfoFragmentType,
+  TeamBasicInfoQuery,
+  TeamBasicInfoQueryVariables,
+  TeamDetailedInfoFragment as TeamDetailedInfoFragmentType,
+  TeamDetailsQuery,
+  TeamDetailsQueryVariables,
+  TeamInvitationBasicInfoFragment as TeamInvitationBasicInfoFragmentType,
+  TeamsQuery,
+  TeamsQueryVariables,
+  UserBasicInfoFragment as UserBasicInfoFragmentType,
 } from "~gql";
-import { createFragment, createMutation, createQuery } from "./utils";
+import { slugify } from "~shared/slugify";
+import { addToast } from "~ui/toasts/data";
+
 import { SpaceBasicInfoFragment } from "./spaces";
 import { UserBasicInfoFragment } from "./user";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
-import { addToast } from "~ui/toasts/data";
-import { slugify } from "~shared/slugify";
+import { createFragment, createMutation, createQuery } from "./utils";
 
 export const TeamBasicInfoFragment = createFragment<TeamBasicInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/topics.ts
+++ b/frontend/src/gql/topics.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { gql } from "@apollo/client";
-import { slugify } from "~shared/slugify";
-import { getUUID } from "~shared/uuid";
+
 import {
   AddTopicMemberMutation,
   AddTopicMemberMutationVariables,
@@ -24,13 +23,16 @@ import {
   UpdateTopicMutation,
   UpdateTopicMutationVariables,
 } from "~gql";
+import { assert } from "~shared/assert";
+import { slugify } from "~shared/slugify";
+import { getUUID } from "~shared/uuid";
 import { addToast } from "~ui/toasts/data";
+
 import { MessageFeedInfoFragment } from "./messages";
 import { RoomBasicInfoFragment, RoomDetailedInfoFragment } from "./rooms";
 import { UserBasicInfoFragment } from "./user";
 import { createFragment, createMutation, createQuery } from "./utils";
 import { getUpdatedDataWithInput } from "./utils/updateWithInput";
-import { assert } from "~shared/assert";
 
 function optimisticallySortTopics(topics: TopicDetailedInfoFragmentType[]) {
   topics.sort((t1, t2) => (t1.index > t2.index ? 1 : -1));

--- a/frontend/src/gql/user.ts
+++ b/frontend/src/gql/user.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
-import { createFragment, createMutation, createQuery } from "./utils";
+
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import {
   ChangeCurrentTeamIdMutation,
   ChangeCurrentTeamIdMutationVariables,
@@ -11,8 +12,9 @@ import {
   UserDetailedQueryVariables,
 } from "~gql";
 import { UserTokenData } from "~shared/types/jwtAuth";
+
 import { TeamBasicInfoFragment } from "./teams";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { createFragment, createMutation, createQuery } from "./utils";
 
 export const UserBasicInfoFragment = createFragment<UserBasicInfoFragmentType>(
   () => gql`

--- a/frontend/src/gql/utils/createFragment.ts
+++ b/frontend/src/gql/utils/createFragment.ts
@@ -2,7 +2,9 @@ import { DocumentNode } from "@apollo/client";
 import { FragmentDefinitionNode } from "graphql";
 import produceWithImmer, { Draft } from "immer";
 import { memoize } from "lodash";
+
 import { assert } from "~shared/assert";
+
 import { getCurrentApolloClientHandler } from "./proxy";
 
 /**

--- a/frontend/src/gql/utils/createMutation.ts
+++ b/frontend/src/gql/utils/createMutation.ts
@@ -7,12 +7,14 @@ import {
 } from "@apollo/client";
 import { memoize, merge } from "lodash";
 import { DeepPartial } from "utility-types";
-import { ValueUpdater, updateValue } from "~shared/updateValue";
+
 import { getRenderedApolloClient } from "~frontend/apollo/client";
+import { createPromisesGroup } from "~shared/promiseGroup";
+import { ValueUpdater, updateValue } from "~shared/updateValue";
+
 import { runWithApolloProxy } from "./proxy";
 import { UnwrapQueryData, unwrapQueryData } from "./unwrapQueryData";
-import { addRoleToContext, RequestWithRole } from "./withRole";
-import { createPromisesGroup } from "~shared/promiseGroup";
+import { RequestWithRole, addRoleToContext } from "./withRole";
 
 interface MutationDefinitionOptions<Data, Variables> extends RequestWithRole {
   // This callback is called optionally twice for both optimistic and actual response

--- a/frontend/src/gql/utils/createQuery.ts
+++ b/frontend/src/gql/utils/createQuery.ts
@@ -8,15 +8,17 @@ import {
 } from "@apollo/client";
 import { memoize } from "lodash";
 import { useRef } from "react";
-import { VoidableIfEmpty } from "~shared/types";
-import { reportQueryUsage } from "./hydration";
-import { unwrapQueryData } from "./unwrapQueryData";
-import { getCurrentApolloClientHandler } from "./proxy";
+
 import { getRenderedApolloClient } from "~frontend/apollo/client";
-import { addRoleToContext, RequestWithRole } from "./withRole";
-import { waitForAllRunningMutationsToFinish } from "./createMutation";
 import { useAsyncEffect } from "~shared/hooks/useAsyncEffect";
-import { updateValue, ValueUpdater } from "~shared/updateValue";
+import { VoidableIfEmpty } from "~shared/types";
+import { ValueUpdater, updateValue } from "~shared/updateValue";
+
+import { waitForAllRunningMutationsToFinish } from "./createMutation";
+import { reportQueryUsage } from "./hydration";
+import { getCurrentApolloClientHandler } from "./proxy";
+import { unwrapQueryData } from "./unwrapQueryData";
+import { RequestWithRole, addRoleToContext } from "./withRole";
 
 type QueryDefinitionOptions = RequestWithRole;
 

--- a/frontend/src/gql/utils/proxy.ts
+++ b/frontend/src/gql/utils/proxy.ts
@@ -1,4 +1,5 @@
 import { ApolloCache } from "@apollo/client";
+
 import { getRenderedApolloClient } from "~frontend/apollo/client";
 
 let currentApolloProxy: ApolloCache<unknown> | null = null;

--- a/frontend/src/gql/utils/unwrapQueryData.ts
+++ b/frontend/src/gql/utils/unwrapQueryData.ts
@@ -1,5 +1,6 @@
 import { isPlainObject } from "lodash";
 import { Primitive } from "utility-types";
+
 import { typedKeys } from "~shared/object";
 import { IsUnion } from "~shared/types";
 

--- a/frontend/src/gql/utils/updateWithInput.ts
+++ b/frontend/src/gql/utils/updateWithInput.ts
@@ -1,5 +1,6 @@
 import produce from "immer";
 import { isPlainObject } from "lodash";
+
 import { isNullish } from "~shared/nullish";
 import { typedKeys } from "~shared/object";
 

--- a/frontend/src/gql/utils/withRole.ts
+++ b/frontend/src/gql/utils/withRole.ts
@@ -1,4 +1,5 @@
 import { Context } from "@apollo/client";
+
 import { Role } from "~shared/roles";
 
 export interface RequestWithRole {

--- a/frontend/src/layouts/AppLayout/Breadcrumbs/Breadcrumb.tsx
+++ b/frontend/src/layouts/AppLayout/Breadcrumbs/Breadcrumb.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React, { ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { theme } from "~ui/theme";
 
 export interface Props {

--- a/frontend/src/layouts/AppLayout/Breadcrumbs/index.tsx
+++ b/frontend/src/layouts/AppLayout/Breadcrumbs/index.tsx
@@ -1,12 +1,14 @@
 import React, { Fragment } from "react";
 import styled from "styled-components";
-import { usePathParameter } from "~frontend/utils";
-import { Breadcrumb, Props as BreadcrumbProps } from "./Breadcrumb";
+
 import { useSingleRoomQuery } from "~frontend/gql/rooms";
 import { useSingleSpaceQuery } from "~frontend/gql/spaces";
-import { IconSpaces, IconBox } from "~ui/icons";
 import { routes } from "~frontend/router";
+import { usePathParameter } from "~frontend/utils";
+import { IconBox, IconSpaces } from "~ui/icons";
 import { theme } from "~ui/theme";
+
+import { Breadcrumb, Props as BreadcrumbProps } from "./Breadcrumb";
 
 export const Breadcrumbs = () => {
   const breadcrumbsProps: BreadcrumbProps[] = [

--- a/frontend/src/layouts/AppLayout/NotificationsOpener/NotificationsCenterPopover.tsx
+++ b/frontend/src/layouts/AppLayout/NotificationsOpener/NotificationsCenterPopover.tsx
@@ -1,11 +1,12 @@
 import { useRef } from "react";
 import styled from "styled-components";
-import { UIDropdownPanelBody } from "~ui/popovers/DropdownPanelBody";
-import { TextH3 } from "~ui/typo";
-import { markAllNotificationsAsRead, useNotifications, deleteAllReadNotifications } from "~frontend/gql/notifications";
+
+import { deleteAllReadNotifications, markAllNotificationsAsRead, useNotifications } from "~frontend/gql/notifications";
 import { NotificationsTimeline } from "~frontend/ui/notifications/NotificationLabel/NotificationsTimeline";
-import { theme } from "~ui/theme";
 import { OptionsButtonWithMenu } from "~frontend/ui/options/OptionsButtonWithMenu";
+import { UIDropdownPanelBody } from "~ui/popovers/DropdownPanelBody";
+import { theme } from "~ui/theme";
+import { TextH3 } from "~ui/typo";
 
 export function NotificationsCenterPopover() {
   const holderRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/layouts/AppLayout/NotificationsOpener/index.tsx
+++ b/frontend/src/layouts/AppLayout/NotificationsOpener/index.tsx
@@ -1,14 +1,16 @@
 import { AnimatePresence } from "framer-motion";
-import { useRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+import { useUnreadNotifications } from "~frontend/gql/notifications";
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { borderRadius } from "~ui/baseStyles";
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
-import { NOTIFICATION_COLOR } from "~ui/theme/colors/base";
 import { IconActivity } from "~ui/icons";
 import { Popover } from "~ui/popovers/Popover";
-import { useUnreadNotifications } from "~frontend/gql/notifications";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { NOTIFICATION_COLOR } from "~ui/theme/colors/base";
+
 import { NotificationsCenterPopover } from "./NotificationsCenterPopover";
 
 export function NotificationsOpener() {

--- a/frontend/src/layouts/AppLayout/PageHeader.tsx
+++ b/frontend/src/layouts/AppLayout/PageHeader.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { PopoverMenuOption } from "~ui/popovers/PopoverMenu";
 import { HeroItemTitle } from "~ui/theme/functional";
 

--- a/frontend/src/layouts/AppLayout/PrimaryNavigation/PrimaryNavigationItem.tsx
+++ b/frontend/src/layouts/AppLayout/PrimaryNavigation/PrimaryNavigationItem.tsx
@@ -1,6 +1,7 @@
+import Link from "next/link";
 import React from "react";
 import styled from "styled-components";
-import Link from "next/link";
+
 import { useIsRoutePathActive } from "~frontend/router";
 import { Button } from "~ui/buttons/Button";
 import { activeTransparentButtonStyles } from "~ui/buttons/sharedStyles";

--- a/frontend/src/layouts/AppLayout/PrimaryNavigation/index.tsx
+++ b/frontend/src/layouts/AppLayout/PrimaryNavigation/index.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import styled from "styled-components";
+
+import { IconCalendarDates, IconHome, IconSpaces } from "~ui/icons";
+
 import { PrimaryNavigationItem } from "./PrimaryNavigationItem";
-import { IconHome, IconSpaces, IconCalendarDates } from "~ui/icons";
 
 export const PrimaryNavigation = () => (
   <UINav>

--- a/frontend/src/layouts/AppLayout/Search/index.tsx
+++ b/frontend/src/layouts/AppLayout/Search/index.tsx
@@ -1,6 +1,8 @@
 import { AnimatePresence } from "framer-motion";
 import React, { RefObject } from "react";
 import styled, { css } from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { ScreenCover } from "~frontend/ui/Modal/ScreenCover";
 import { SearchBar } from "~frontend/ui/search/SearchBar";
 import { isMac } from "~frontend/utils/platformDetection";
@@ -11,7 +13,6 @@ import { ClientSideOnly } from "~ui/ClientSideOnly";
 import { IconSearch } from "~ui/icons";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 import { Popover } from "~ui/popovers/Popover";
-import { trackEvent } from "~frontend/analytics/tracking";
 import { theme } from "~ui/theme";
 
 interface Props {

--- a/frontend/src/layouts/AppLayout/SpacedAppLayoutContainer.tsx
+++ b/frontend/src/layouts/AppLayout/SpacedAppLayoutContainer.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { Container } from "~ui/layout/Container";
 
 type TopSpazeSize = "medium" | "large";

--- a/frontend/src/layouts/AppLayout/TeamPicker/index.tsx
+++ b/frontend/src/layouts/AppLayout/TeamPicker/index.tsx
@@ -1,13 +1,14 @@
 import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { createTeam, useTeamsQuery } from "~frontend/gql/teams";
 import { changeCurrentTeamId } from "~frontend/gql/user";
-import { Button } from "~ui/buttons/Button";
 import { openUIPrompt } from "~frontend/utils/prompt";
 import { createLengthValidator } from "~shared/validation/inputValidation";
-import { trackEvent } from "~frontend/analytics/tracking";
-import { addToast } from "~ui/toasts/data";
+import { Button } from "~ui/buttons/Button";
 import { IconEmotionSmile } from "~ui/icons";
+import { addToast } from "~ui/toasts/data";
 
 export function TeamPickerView() {
   const [teams = []] = useTeamsQuery();

--- a/frontend/src/layouts/AppLayout/UserMenu.tsx
+++ b/frontend/src/layouts/AppLayout/UserMenu.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
-import { IconChevronDown } from "~ui/icons";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { routes } from "~frontend/router";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
+import { IconChevronDown } from "~ui/icons";
 import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
-import { routes } from "~frontend/router";
-import { trackEvent } from "~frontend/analytics/tracking";
 
 export function UserMenu() {
   const user = useAssertCurrentUser();

--- a/frontend/src/layouts/AppLayout/index.tsx
+++ b/frontend/src/layouts/AppLayout/index.tsx
@@ -1,20 +1,22 @@
 import Link from "next/link";
 import React, { ReactNode, useEffect, useRef, useState } from "react";
 import styled, { css } from "styled-components";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { routes, useIsAnyRouteActive } from "~frontend/router";
+import { useCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import { SmallLogo } from "~frontend/ui/Logo";
 import { LoginOptionsView } from "~frontend/views/LoginOptionsView";
 import { WindowView } from "~frontend/views/WindowView";
+import { useResizeCallback } from "~shared/hooks/useResizeCallback";
+import { theme } from "~ui/theme";
+
 import { Breadcrumbs } from "./Breadcrumbs";
+import { NotificationsOpener } from "./NotificationsOpener";
 import { PrimaryNavigation } from "./PrimaryNavigation";
 import { TopBarSearchBar } from "./Search";
 import { TeamPickerView } from "./TeamPicker";
 import { UserMenu } from "./UserMenu";
-import { theme } from "~ui/theme";
-import { NotificationsOpener } from "./NotificationsOpener";
-import { useCurrentTeamId } from "~frontend/team/useCurrentTeamId";
-import { useResizeCallback } from "~shared/hooks/useResizeCallback";
 
 interface Props {
   children?: ReactNode;

--- a/frontend/src/message/extensions/mentions.tsx
+++ b/frontend/src/message/extensions/mentions.tsx
@@ -1,12 +1,13 @@
-import { UserBasicInfoFragment } from "~gql";
-import { AutocompletePickerProps } from "~richEditor/autocomplete/component";
+import styled from "styled-components";
+
 import { useCurrentTeamMembers } from "~frontend/gql/teams";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
+import { UserBasicInfoFragment } from "~gql";
 import { createAutocompletePlugin } from "~richEditor/autocomplete";
-import { SelectList } from "~ui/SelectList";
+import { AutocompletePickerProps } from "~richEditor/autocomplete/component";
 import { useSearch } from "~shared/search";
-import styled from "styled-components";
 import { EditorMentionData } from "~shared/types/editor";
+import { SelectList } from "~ui/SelectList";
 
 /**
  * TODO: This type should be moved to `shared/types` when we'll add backend integration that will pick message mentions

--- a/frontend/src/pages/RoomOrTopicPage.tsx
+++ b/frontend/src/pages/RoomOrTopicPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { routes } from "~frontend/router";
+
 import { RoomPage } from "~frontend/rooms/RoomPage";
+import { routes } from "~frontend/router";
 
 export function RoomOrTopicPage() {
   const topicParams = routes.spaceRoomTopic.useParams()?.route;

--- a/frontend/src/requests/create.ts
+++ b/frontend/src/requests/create.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { useState } from "react";
-import { JsonValue } from "~shared/types";
+
 import { readCurrentToken } from "~frontend/authentication/cookie";
 import { useEqualEffect } from "~shared/hooks/useEqualEffect";
+import { JsonValue } from "~shared/types";
 
 export function createBackendRequestSender<Input, Output>(route: string) {
   // Response from the server is sent as JSON which mean Dates will be converted to strings. Reflect it in the result type.

--- a/frontend/src/requests/googleCalendar.ts
+++ b/frontend/src/requests/googleCalendar.ts
@@ -1,5 +1,6 @@
+import { GoogleCalendarEvent, GoogleCalendarEventsAPIRequestBody } from "~shared/types/googleCalendar";
+
 import { createBackendRequestSender } from "./create";
-import { GoogleCalendarEventsAPIRequestBody, GoogleCalendarEvent } from "~shared/types/googleCalendar";
 
 export const googleCalendarEventsApi = createBackendRequestSender<
   GoogleCalendarEventsAPIRequestBody,

--- a/frontend/src/rooms/RoomPage.tsx
+++ b/frontend/src/rooms/RoomPage.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { singleTopicQueryManager, topicMessagesQueryManager } from "~frontend/gql/topics";
 import { useRoomWithClientErrorRedirects } from "~frontend/rooms/useRoomWithClientErrorRedirects";
 import { RoomTopicView } from "~frontend/views/RoomView/RoomTopicView";
+
 import { AppLayout } from "../layouts/AppLayout";
 
 interface Props {

--- a/frontend/src/rooms/create/TeamMembersPicker.tsx
+++ b/frontend/src/rooms/create/TeamMembersPicker.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { UserBasicInfoFragment } from "~gql";
-import { MultipleOptionsDropdown } from "~ui/forms/OptionsDropdown/multiple";
+
 import { useCurrentTeamMembers } from "~frontend/gql/teams";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
-import { IconUsers } from "~ui/icons";
 import { getUserDisplayName } from "~frontend/utils/getUserDisplayName";
+import { UserBasicInfoFragment } from "~gql";
+import { MultipleOptionsDropdown } from "~ui/forms/OptionsDropdown/multiple";
+import { IconUsers } from "~ui/icons";
 
 interface Props {
   selectedMemberIds: string[];

--- a/frontend/src/rooms/create/openRoomInputPrompt.tsx
+++ b/frontend/src/rooms/create/openRoomInputPrompt.tsx
@@ -1,19 +1,21 @@
+import { AnimateSharedLayout } from "framer-motion";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { Modal } from "~frontend/ui/Modal";
+import { SpacePicker } from "~frontend/ui/spaces/SpacePicker";
 import { getRoomDefaultDeadline } from "~frontend/utils/room";
 import { Button } from "~ui/buttons/Button";
 import { createPromiseUI } from "~ui/createPromiseUI";
 import { InputError } from "~ui/forms/InputError";
-import { DateTimeInput } from "~ui/time/DateTimeInput";
 import { TextInput } from "~ui/forms/TextInput";
-import { SpacePicker } from "~frontend/ui/spaces/SpacePicker";
+import { IconCommentText } from "~ui/icons";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { DateTimeInput } from "~ui/time/DateTimeInput";
+
 import { TeamMembersPicker } from "./TeamMembersPicker";
 import { validateRoomCreationInfo } from "./validateRoomCreationInfo";
-import { IconCommentText } from "~ui/icons";
-import { AnimateSharedLayout } from "framer-motion";
-import { useShortcut } from "~ui/keyboard/useShortcut";
 
 interface RoomInputInitialData {
   name?: string;

--- a/frontend/src/rooms/create/validateRoomCreationInfo.ts
+++ b/frontend/src/rooms/create/validateRoomCreationInfo.ts
@@ -1,4 +1,4 @@
-import { createLengthValidator, ValidationResult } from "~shared/validation/inputValidation";
+import { ValidationResult, createLengthValidator } from "~shared/validation/inputValidation";
 
 interface RoomCreateInput {
   roomName: string;

--- a/frontend/src/rooms/editOptions.tsx
+++ b/frontend/src/rooms/editOptions.tsx
@@ -1,14 +1,14 @@
-import { createLengthValidator } from "~shared/validation/inputValidation";
-import { PopoverMenuOption } from "~ui/popovers/PopoverMenu";
-import { RoomBasicInfoFragment, TopicDetailedInfoFragment } from "~gql";
+import { trackEvent } from "~frontend/analytics/tracking";
 import { deleteRoom, getSingleRoomQueryManager, updateRoom } from "~frontend/gql/rooms";
+import { routes } from "~frontend/router";
+import { ModalAnchor } from "~frontend/ui/Modal";
 import { openConfirmPrompt } from "~frontend/utils/confirm";
 import { openUIPrompt } from "~frontend/utils/prompt";
-import { IconCheck, IconEdit, IconTrash, IconUndo, IconLock, IconUnlock } from "~ui/icons";
-import { ModalAnchor } from "~frontend/ui/Modal";
 import { closeOpenTopicsPrompt } from "~frontend/views/RoomView/RoomCloseModal";
-import { routes } from "~frontend/router";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { RoomBasicInfoFragment, TopicDetailedInfoFragment } from "~gql";
+import { createLengthValidator } from "~shared/validation/inputValidation";
+import { IconCheck, IconEdit, IconLock, IconTrash, IconUndo, IconUnlock } from "~ui/icons";
+import { PopoverMenuOption } from "~ui/popovers/PopoverMenu";
 
 export async function handleEditRoomName(room: RoomBasicInfoFragment, anchor?: ModalAnchor) {
   const newName = await openUIPrompt({

--- a/frontend/src/rooms/useRoomTopicList.ts
+++ b/frontend/src/rooms/useRoomTopicList.ts
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
-import { TopicDetailedInfoFragment } from "~gql";
+import { useEffect, useState } from "react";
+
 import { useSingleRoomQuery } from "~frontend/gql/rooms";
 import { useUpdateTopicMutation } from "~frontend/gql/topics";
+import { TopicDetailedInfoFragment } from "~gql";
+
 import { getIndexBetweenCurrentAndLast, getIndexBetweenFirstAndCurrent, getIndexBetweenItems } from "./order";
 
 /*

--- a/frontend/src/rooms/useRoomWithClientErrorRedirects.tsx
+++ b/frontend/src/rooms/useRoomWithClientErrorRedirects.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
+
+import { fetchPrivateRoom, useSingleRoomQuery } from "~frontend/gql/rooms";
 import { routes } from "~frontend/router";
-import { useSingleRoomQuery, fetchPrivateRoom } from "~frontend/gql/rooms";
 import { openForbiddenAccessModal } from "~frontend/utils/accessForbidden";
 import { openNotFoundModal } from "~frontend/utils/notFound";
 

--- a/frontend/src/spaces/useSpaceManager.tsx
+++ b/frontend/src/spaces/useSpaceManager.tsx
@@ -1,18 +1,18 @@
+import { trackEvent } from "~frontend/analytics/tracking";
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import {
+  deleteSpace,
+  useAddSpaceMemberMutation,
+  useEditSpaceMutation,
+  useIsCurrentUserSpaceMember,
+  useRemoveSpaceMemberMutation,
+} from "~frontend/gql/spaces";
+import { routes } from "~frontend/router";
+import { openConfirmPrompt } from "~frontend/utils/confirm";
+import { openUIPrompt } from "~frontend/utils/prompt";
 import { SpaceBasicInfoFragment } from "~gql";
 import { createLengthValidator } from "~shared/validation/inputValidation";
 import { IconSelection } from "~ui/icons";
-import { routes } from "~frontend/router";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import {
-  useEditSpaceMutation,
-  useRemoveSpaceMemberMutation,
-  useAddSpaceMemberMutation,
-  useIsCurrentUserSpaceMember,
-  deleteSpace,
-} from "~frontend/gql/spaces";
-import { openConfirmPrompt } from "~frontend/utils/confirm";
-import { openUIPrompt } from "~frontend/utils/prompt";
-import { trackEvent } from "~frontend/analytics/tracking";
 
 export function useSpaceManager(space: SpaceBasicInfoFragment) {
   const spaceId = space.id;

--- a/frontend/src/team/CurrentTeamIdProvider.tsx
+++ b/frontend/src/team/CurrentTeamIdProvider.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren, useEffect, useState } from "react";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { userDetailedInfoQuery } from "~frontend/gql/user";
+
 import { CurrentTeamIdContext } from "./CurrentTeamIdContext";
 
 /*

--- a/frontend/src/team/useCurrentTeamId.tsx
+++ b/frontend/src/team/useCurrentTeamId.tsx
@@ -1,5 +1,7 @@
 import { useContext } from "react";
+
 import { assertDefined } from "~shared/assert";
+
 import { CurrentTeamIdContext } from "./CurrentTeamIdContext";
 
 export function useCurrentTeamId() {

--- a/frontend/src/topics/startCreateNewTopicFlow.ts
+++ b/frontend/src/topics/startCreateNewTopicFlow.ts
@@ -1,10 +1,10 @@
-import { createLengthValidator } from "~shared/validation/inputValidation";
+import { RoomBasicInfoFragment } from "~frontend/gql/rooms";
 import { createTopic } from "~frontend/gql/topics";
 import { routes } from "~frontend/router";
 import { ModalAnchor } from "~frontend/ui/Modal";
 import { openUIPrompt } from "~frontend/utils/prompt";
 import { getUUID } from "~shared/uuid";
-import { RoomBasicInfoFragment } from "~frontend/gql/rooms";
+import { createLengthValidator } from "~shared/validation/inputValidation";
 
 interface CreateTopicInput {
   topicId?: string;

--- a/frontend/src/topics/useTopic.ts
+++ b/frontend/src/topics/useTopic.ts
@@ -1,7 +1,7 @@
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { TopicDetailedInfoFragment, Topic_Set_Input } from "~gql";
-import { useDeleteTopicMutation, useUpdateTopicMutation } from "~frontend/gql/topics";
 import { trackEvent } from "~frontend/analytics/tracking";
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useDeleteTopicMutation, useUpdateTopicMutation } from "~frontend/gql/topics";
+import { TopicDetailedInfoFragment, Topic_Set_Input } from "~gql";
 
 function nowAsIsoString(): string {
   return new Date().toISOString();

--- a/frontend/src/ui/Layout.tsx
+++ b/frontend/src/ui/Layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React, { ReactNode } from "react";
 import styled from "styled-components";
+
 import { Logo } from "./Logo";
 
 const UISidebar = styled.div<{}>`

--- a/frontend/src/ui/MembersManager/AddMemberInlineForm/index.tsx
+++ b/frontend/src/ui/MembersManager/AddMemberInlineForm/index.tsx
@@ -1,19 +1,20 @@
+import { AnimatePresence } from "framer-motion";
 import React, { useEffect, useRef, useState } from "react";
 import { useClickAway } from "react-use";
 import styled from "styled-components";
-import { AnimatePresence } from "framer-motion";
-import { UserBasicInfoFragment } from "~gql";
-import { Button } from "~ui/buttons/Button";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { IconPlusSquare, IconSearch } from "~ui/icons";
-import { RoundedTextInput } from "~ui/forms/RoundedTextInput";
-import { useBoundingBox } from "~shared/hooks/useBoundingBox";
-import { Popover } from "~ui/popovers/Popover";
-import { ItemsDropdown } from "~ui/forms/OptionsDropdown/ItemsDropdown";
-import { Avatar } from "~frontend/ui/users/Avatar";
-import { useBoolean } from "~shared/hooks/useBoolean";
-import { useSearch } from "~shared/search";
 import isEmail from "validator/lib/isEmail";
+
+import { Avatar } from "~frontend/ui/users/Avatar";
+import { UserBasicInfoFragment } from "~gql";
+import { useBoolean } from "~shared/hooks/useBoolean";
+import { useBoundingBox } from "~shared/hooks/useBoundingBox";
+import { useSearch } from "~shared/search";
+import { Button } from "~ui/buttons/Button";
+import { ItemsDropdown } from "~ui/forms/OptionsDropdown/ItemsDropdown";
+import { RoundedTextInput } from "~ui/forms/RoundedTextInput";
+import { IconPlusSquare, IconSearch } from "~ui/icons";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { Popover } from "~ui/popovers/Popover";
 
 interface Props {
   users: UserBasicInfoFragment[];

--- a/frontend/src/ui/MembersManager/InvitationPendingIndicator.tsx
+++ b/frontend/src/ui/MembersManager/InvitationPendingIndicator.tsx
@@ -1,9 +1,10 @@
 import styled from "styled-components";
-import { PRIMARY_PURPLE_1, WHITE } from "~ui/theme/colors/base";
-import { IconUserPlus } from "~ui/icons";
-import { borderRadius } from "~ui/baseStyles";
+
 import { UserBasicInfoContainer } from "~frontend/ui/users/UserBasicInfoContainer";
-import { TextMeta12, TextMeta10 } from "~ui/typo";
+import { borderRadius } from "~ui/baseStyles";
+import { IconUserPlus } from "~ui/icons";
+import { PRIMARY_PURPLE_1, WHITE } from "~ui/theme/colors/base";
+import { TextMeta10, TextMeta12 } from "~ui/typo";
 
 interface Props {
   email: string;

--- a/frontend/src/ui/MembersManager/MembersManagerModal.tsx
+++ b/frontend/src/ui/MembersManager/MembersManagerModal.tsx
@@ -1,15 +1,17 @@
 import { useMemo } from "react";
 import styled from "styled-components";
+
 import { useCurrentTeamMembers } from "~frontend/gql/user";
-import { UserBasicInfoFragment } from "~gql";
-import { AddMemberInlineForm } from "./AddMemberInlineForm";
-import { UISelectGridContainer } from "./UISelectGridContainer";
-import { UserBasicInfo } from "~frontend/ui/users/UserBasicInfo";
-import { PanelWithTopbarAndCloseButton } from "./PanelWithTopbarAndCloseButton";
-import { PopPresenceAnimator } from "~ui/animations";
 import { ScreenCover } from "~frontend/ui/Modal/ScreenCover";
+import { UserBasicInfo } from "~frontend/ui/users/UserBasicInfo";
+import { UserBasicInfoFragment } from "~gql";
+import { PopPresenceAnimator } from "~ui/animations";
 import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
+
+import { AddMemberInlineForm } from "./AddMemberInlineForm";
 import { InvitationPendingIndicator } from "./InvitationPendingIndicator";
+import { PanelWithTopbarAndCloseButton } from "./PanelWithTopbarAndCloseButton";
+import { UISelectGridContainer } from "./UISelectGridContainer";
 
 interface Invitation {
   email: string;

--- a/frontend/src/ui/MembersManager/PanelWithTopbarAndCloseButton.tsx
+++ b/frontend/src/ui/MembersManager/PanelWithTopbarAndCloseButton.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 import { theme } from "~ui/theme";

--- a/frontend/src/ui/MembersManager/UISelectGridContainer.tsx
+++ b/frontend/src/ui/MembersManager/UISelectGridContainer.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { theme } from "~ui/theme";
 
 export const UISelectGridContainer = styled.div<{}>`

--- a/frontend/src/ui/Modal/ScreenCover.tsx
+++ b/frontend/src/ui/Modal/ScreenCover.tsx
@@ -1,11 +1,12 @@
 import { ReactNode, useRef } from "react";
 import styled from "styled-components";
+
+import { setColorOpacity } from "~shared/colors";
 import { handleWithStopPropagation } from "~shared/events";
 import { createLocalStorageValueManager } from "~shared/localStorage";
+import { EndFpsMeasurement, startMeasuringFps } from "~shared/performance";
 import { BodyPortal } from "~ui/BodyPortal";
 import { PresenceAnimator, PresenceStyles } from "~ui/PresenceAnimator";
-import { startMeasuringFps, EndFpsMeasurement } from "~shared/performance";
-import { setColorOpacity } from "~shared/colors";
 import { MODAL_BACKGROUND_COLOR } from "~ui/theme/colors/base";
 
 interface Props {

--- a/frontend/src/ui/Modal/index.tsx
+++ b/frontend/src/ui/Modal/index.tsx
@@ -1,12 +1,14 @@
 import { ReactNode, RefObject, useRef } from "react";
 import styled from "styled-components";
+
 import { PopPresenceAnimator } from "~ui/animations";
 import { borderRadius, shadow } from "~ui/baseStyles";
+import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 import { Popover, PopoverPlacement } from "~ui/popovers/Popover";
 import { TextBody, TextH3 } from "~ui/typo";
+
 import { ScreenCover } from "./ScreenCover";
-import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
 
 export interface ModalAnchor {
   ref: RefObject<HTMLElement>;

--- a/frontend/src/ui/NavLink.tsx
+++ b/frontend/src/ui/NavLink.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { borderRadius } from "~ui/baseStyles";
 import { IconCalendar } from "~ui/icons";
 

--- a/frontend/src/ui/NotificationCount.tsx
+++ b/frontend/src/ui/NotificationCount.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { formatNumberWithMaxValue } from "~shared/numbers";
 import { theme } from "~ui/theme";
 

--- a/frontend/src/ui/message/attachment/AttachmentPreview.tsx
+++ b/frontend/src/ui/message/attachment/AttachmentPreview.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+
 import { useAttachmentQuery } from "~frontend/gql/attachments";
 import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { IconTrash } from "~ui/icons";
+
 import { MessageAttachmentDisplayer } from "./MessageAttachmentDisplayer";
 
 interface Props {

--- a/frontend/src/ui/message/attachment/MessageAttachment.tsx
+++ b/frontend/src/ui/message/attachment/MessageAttachment.tsx
@@ -1,9 +1,11 @@
 import { AnimatePresence, AnimateSharedLayout } from "framer-motion";
 import React from "react";
 import styled from "styled-components";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { AttachmentDetailedInfoFragment } from "~gql";
 import { theme } from "~ui/theme";
+
 import { MessageAttachmentActions } from "./MessageAttachmentActions";
 import { MessageAttachmentDisplayer } from "./MessageAttachmentDisplayer";
 

--- a/frontend/src/ui/message/attachment/MessageAttachmentActions.tsx
+++ b/frontend/src/ui/message/attachment/MessageAttachmentActions.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { CornerButtonWrapper } from "~ui/buttons/CornerButtonWrapper";
 import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { IconTrash } from "~ui/icons";

--- a/frontend/src/ui/message/attachment/MessageAttachmentDisplayer.tsx
+++ b/frontend/src/ui/message/attachment/MessageAttachmentDisplayer.tsx
@@ -1,11 +1,13 @@
 import { motion } from "framer-motion";
 import React, { ReactNode } from "react";
 import styled from "styled-components";
-import { AudioPlayer } from "~ui/media/AudioPlayer";
-import { VideoPlayer } from "~ui/media/VideoPlayer";
+
 import { chooseMessageTypeFromMimeType } from "~frontend/utils/chooseMessageType";
 import { AttachmentDetailedInfoFragment } from "~gql";
+import { AudioPlayer } from "~ui/media/AudioPlayer";
+import { VideoPlayer } from "~ui/media/VideoPlayer";
 import { theme } from "~ui/theme";
+
 import { MessageImageAttachment } from "./MessageImageAttachment";
 
 interface AttachmentProps {

--- a/frontend/src/ui/message/attachment/MessageImageAttachment.tsx
+++ b/frontend/src/ui/message/attachment/MessageImageAttachment.tsx
@@ -1,9 +1,10 @@
 import { AnimatePresence, AnimateSharedLayout } from "framer-motion";
 import React from "react";
 import styled from "styled-components";
-import { PopPresenceAnimator } from "~ui/animations";
+
 import { ScreenCover } from "~frontend/ui/Modal/ScreenCover";
 import { useBoolean } from "~shared/hooks/useBoolean";
+import { PopPresenceAnimator } from "~ui/animations";
 import { CornerButtonWrapper } from "~ui/buttons/CornerButtonWrapper";
 import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { IconCross } from "~ui/icons";

--- a/frontend/src/ui/message/composer/CreateNewMessageEditor.tsx
+++ b/frontend/src/ui/message/composer/CreateNewMessageEditor.tsx
@@ -2,7 +2,8 @@ import { observer } from "mobx-react";
 import React, { useRef, useState } from "react";
 import { useList } from "react-use";
 import styled from "styled-components";
-import { select, useAutorun } from "~shared/sharedState";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { bindAttachmentsToMessage } from "~frontend/gql/attachments";
 import { useCreateMessageMutation } from "~frontend/gql/messages";
 import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
@@ -13,10 +14,11 @@ import { Message_Type_Enum } from "~gql";
 import { RichEditorNode } from "~richEditor/content/types";
 import { Editor, getEmptyRichContent } from "~richEditor/RichEditor";
 import { useDependencyChangeEffect } from "~shared/hooks/useChangeEffect";
+import { select, useAutorun } from "~shared/sharedState";
+
 import { EditorAttachmentInfo, uploadFiles } from "./attachments";
 import { MessageContentEditor } from "./MessageContentComposer";
 import { Recorder } from "./Recorder";
-import { trackEvent } from "~frontend/analytics/tracking";
 
 interface Props {
   topicId: string;

--- a/frontend/src/ui/message/composer/EditMessageEditor.tsx
+++ b/frontend/src/ui/message/composer/EditMessageEditor.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from "react";
 import { useList } from "react-use";
 import styled from "styled-components";
-import { MessageDetailedInfoFragment } from "~gql";
-import { Button } from "~ui/buttons/Button";
-import { HStack } from "~ui/Stack";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { bindAttachmentsToMessage, removeAttachment } from "~frontend/gql/attachments";
 import { updateTextMessage } from "~frontend/gql/messages";
+import { MessageDetailedInfoFragment } from "~gql";
+import { isRichEditorContentEmpty } from "~richEditor/content/isEmpty";
+import { RichEditorNode } from "~richEditor/content/types";
+import { makePromiseVoidable } from "~shared/promises";
+import { Button } from "~ui/buttons/Button";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { HStack } from "~ui/Stack";
+
 import { EditorAttachmentInfo, uploadFiles } from "./attachments";
 import { MessageContentEditor } from "./MessageContentComposer";
-import { makePromiseVoidable } from "~shared/promises";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { RichEditorNode } from "~richEditor/content/types";
-import { isRichEditorContentEmpty } from "~richEditor/content/isEmpty";
-import { trackEvent } from "~frontend/analytics/tracking";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/message/composer/MessageContentComposer.tsx
+++ b/frontend/src/ui/message/composer/MessageContentComposer.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import styled from "styled-components";
-import { AttachmentPreview } from "~frontend/ui/message/attachment/AttachmentPreview";
-import { Editor, RichEditor, RichEditorSubmitMode } from "~richEditor/RichEditor";
-import { RichEditorNode } from "~richEditor/content/types";
-import { EditorAttachmentInfo } from "./attachments";
+
 import { messageComposerExtensions } from "~frontend/message/extensions";
+import { AttachmentPreview } from "~frontend/ui/message/attachment/AttachmentPreview";
 import { isRichEditorContentEmpty } from "~richEditor/content/isEmpty";
+import { RichEditorNode } from "~richEditor/content/types";
+import { Editor, RichEditor, RichEditorSubmitMode } from "~richEditor/RichEditor";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
+
+import { EditorAttachmentInfo } from "./attachments";
 
 interface Props {
   autofocusKey?: string;

--- a/frontend/src/ui/message/composer/Recorder/FullScreenCountdown.tsx
+++ b/frontend/src/ui/message/composer/Recorder/FullScreenCountdown.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from "framer-motion";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+
 import { ScreenCover } from "~frontend/ui/Modal/ScreenCover";
 import { createTimeout } from "~shared/time";
 import { PopPresenceAnimator } from "~ui/animations";

--- a/frontend/src/ui/message/composer/Recorder/RecordButton.tsx
+++ b/frontend/src/ui/message/composer/Recorder/RecordButton.tsx
@@ -1,5 +1,6 @@
 import { ButtonHTMLAttributes } from "react";
 import styled from "styled-components";
+
 import { theme } from "~ui/theme";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/frontend/src/ui/message/composer/Recorder/RecorderControls.tsx
+++ b/frontend/src/ui/message/composer/Recorder/RecorderControls.tsx
@@ -1,11 +1,13 @@
 import React, { RefObject, useState } from "react";
 import { useInterval } from "react-use";
 import styled from "styled-components";
+
 import { BodyPortal } from "~ui/BodyPortal";
 import { Button } from "~ui/buttons/Button";
 import { Popover } from "~ui/popovers/Popover";
 import { HStack } from "~ui/Stack";
 import { theme } from "~ui/theme";
+
 import { VideoPreview } from "./VideoPreview";
 
 interface RecorderControlsProps {

--- a/frontend/src/ui/message/composer/Recorder/VideoPreview.tsx
+++ b/frontend/src/ui/message/composer/Recorder/VideoPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import styled, { css } from "styled-components";
+
 import { theme } from "~ui/theme";
 
 interface VideoPreviewParams {

--- a/frontend/src/ui/message/composer/Recorder/index.tsx
+++ b/frontend/src/ui/message/composer/Recorder/index.tsx
@@ -1,15 +1,17 @@
-import React, { useEffect, useState, useRef } from "react";
+import { AnimatePresence } from "framer-motion";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { IconCamera, IconMic, IconMicSlash, IconMonitor, IconVideoCamera } from "~ui/icons";
+import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
 import { FullScreenCountdown } from "./FullScreenCountdown";
 import { MediaSource } from "./MediaSource";
 import { RecordButton } from "./RecordButton";
 import { RecorderControls } from "./RecorderControls";
 import { useReactMediaRecorder } from "./useReactMediaRecorder";
 import { useRecorderErrors } from "./useRecorderErrors";
-import { AnimatePresence } from "framer-motion";
 
 interface RecorderProps {
   className?: string;

--- a/frontend/src/ui/message/composer/Recorder/useRecorderErrors.ts
+++ b/frontend/src/ui/message/composer/Recorder/useRecorderErrors.ts
@@ -1,4 +1,5 @@
 import { useMap } from "react-use";
+
 import { MediaSource } from "./MediaSource";
 
 export function useRecorderErrors() {

--- a/frontend/src/ui/message/composer/attachments.tsx
+++ b/frontend/src/ui/message/composer/attachments.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+
 import { uploadUrlQueryManager } from "~frontend/gql/attachments";
 
 interface UploadFileConfig {

--- a/frontend/src/ui/message/display/MessageLinksPreviews/figmaPreviewProvider/index.tsx
+++ b/frontend/src/ui/message/display/MessageLinksPreviews/figmaPreviewProvider/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+
 import { MessageEmbedPreviewConfig } from "~frontend/ui/message/display/MessageLinksPreviews/MessageEmbedPreviewConfig";
 import { MessageLinkPreviewIFrame } from "~frontend/ui/message/display/MessageLinksPreviews/MessageLinkPreviewIFrame";
+
 import { getFigmaEmbedUrl } from "./getFigmaEmbedUrl";
 
 const PREVIEW_DIMENTIONS_RATIO = 800 / 450;

--- a/frontend/src/ui/message/display/MessageLinksPreviews/index.tsx
+++ b/frontend/src/ui/message/display/MessageLinksPreviews/index.tsx
@@ -1,9 +1,11 @@
 import styled from "styled-components";
+
 import { MessageBasicInfoFragment } from "~gql";
-import { loomPreviewProvider } from "./loomPreviewProvider";
-import { figmaPreviewProvider } from "./figmaPreviewProvider";
-import { notionPreviewProvider } from "./notionPreviewProvider";
 import { extractLinksFromRichContent } from "~richEditor/links/extract";
+
+import { figmaPreviewProvider } from "./figmaPreviewProvider";
+import { loomPreviewProvider } from "./loomPreviewProvider";
+import { notionPreviewProvider } from "./notionPreviewProvider";
 
 const supportedPreviewProviders = [loomPreviewProvider, figmaPreviewProvider, notionPreviewProvider];
 

--- a/frontend/src/ui/message/display/MessageLinksPreviews/loomPreviewProvider/index.tsx
+++ b/frontend/src/ui/message/display/MessageLinksPreviews/loomPreviewProvider/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+
 import { MessageEmbedPreviewConfig } from "~frontend/ui/message/display/MessageLinksPreviews/MessageEmbedPreviewConfig";
 import { MessageLinkPreviewIFrame } from "~frontend/ui/message/display/MessageLinksPreviews/MessageLinkPreviewIFrame";
+
 import { getLoomEmbedUrl } from "./getLoomEmbedUrl";
 
 const PREVIEW_DIMENTIONS_RATIO = 640 / 392;

--- a/frontend/src/ui/message/display/MessageLinksPreviews/notionPreviewProvider/index.tsx
+++ b/frontend/src/ui/message/display/MessageLinksPreviews/notionPreviewProvider/index.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import styled from "styled-components";
+
 import { MessageEmbedPreviewConfig } from "~frontend/ui/message/display/MessageLinksPreviews/MessageEmbedPreviewConfig";
 import { IconNotionLogo } from "~ui/icons";
 import { theme } from "~ui/theme";
 import { TextBody } from "~ui/typo";
+
 import { getNotionPreviewText } from "./getNotionPreviewText";
 
 export const notionPreviewProvider: MessageEmbedPreviewConfig = {

--- a/frontend/src/ui/message/display/MessageMedia.tsx
+++ b/frontend/src/ui/message/display/MessageMedia.tsx
@@ -1,7 +1,8 @@
 import styled, { css } from "styled-components";
-import { MessageDetailedInfoFragment } from "~gql";
-import { MessageAttachment } from "~frontend/ui/message/attachment/MessageAttachment";
+
 import { removeAttachment } from "~frontend/gql/attachments";
+import { MessageAttachment } from "~frontend/ui/message/attachment/MessageAttachment";
+import { MessageDetailedInfoFragment } from "~gql";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/message/display/types/TextMessageContent.tsx
+++ b/frontend/src/ui/message/display/types/TextMessageContent.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
-import { MessageBasicInfoFragment } from "~gql";
-import { richEditorContentCss } from "~richEditor/Theme";
-import { RichContentRenderer } from "~richEditor/content/RichContentRenderer";
 import { messageComposerExtensions } from "~frontend/message/extensions";
-import { ErrorBoundary } from "~ui/ErrorBoundary";
+import { MessageBasicInfoFragment } from "~gql";
 import { isRichEditorContentEmpty } from "~richEditor/content/isEmpty";
+import { RichContentRenderer } from "~richEditor/content/RichContentRenderer";
+import { richEditorContentCss } from "~richEditor/Theme";
+import { ErrorBoundary } from "~ui/ErrorBoundary";
 
 interface Props {
   message: MessageBasicInfoFragment;

--- a/frontend/src/ui/message/display/types/Transcription.tsx
+++ b/frontend/src/ui/message/display/types/Transcription.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled, { css } from "styled-components";
+
 import { Transcription } from "~gql";
 import { theme } from "~ui/theme";
 

--- a/frontend/src/ui/message/messagesFeed/Message.tsx
+++ b/frontend/src/ui/message/messagesFeed/Message.tsx
@@ -1,28 +1,30 @@
 import { MotionProps } from "framer-motion";
+import { observer } from "mobx-react";
 import React, { useRef, useState } from "react";
 import { useClickAway } from "react-use";
-import { observer } from "mobx-react";
 import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useDeleteTextMessageMutation } from "~frontend/gql/messages";
-import { MessageFeedInfoFragment } from "~gql";
-import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
+import { useTopicStoreContext } from "~frontend/topics/TopicStore";
+import { EditMessageEditor } from "~frontend/ui/message/composer/EditMessageEditor";
+import { MessageLinksPreviews } from "~frontend/ui/message/display/MessageLinksPreviews";
 import { MessageMedia } from "~frontend/ui/message/display/MessageMedia";
 import { MessageText } from "~frontend/ui/message/display/types/TextMessageContent";
-import { MessageLikeContent } from "./MessageLikeContent";
-import { EditMessageEditor } from "~frontend/ui/message/composer/EditMessageEditor";
-import { useTopicStoreContext } from "~frontend/topics/TopicStore";
-import { ReplyingToMessage } from "~frontend/ui/message/reply/ReplyingToMessage";
-import { IconEdit, IconTrash } from "~ui/icons";
-import { openConfirmPrompt } from "~frontend/utils/confirm";
-import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
-import { OptionsButton } from "~frontend/ui/options/OptionsButton";
-import { MessageLinksPreviews } from "~frontend/ui/message/display/MessageLinksPreviews";
 import { MakeReactionButton } from "~frontend/ui/message/reactions/MakeReactionButton";
 import { MessageReactions } from "~frontend/ui/message/reactions/MessageReactions";
 import { ReplyButton } from "~frontend/ui/message/reply/ReplyButton";
+import { ReplyingToMessage } from "~frontend/ui/message/reply/ReplyingToMessage";
+import { OptionsButton } from "~frontend/ui/options/OptionsButton";
+import { openConfirmPrompt } from "~frontend/utils/confirm";
+import { MessageFeedInfoFragment } from "~gql";
+import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
 import { select } from "~shared/sharedState";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { IconEdit, IconTrash } from "~ui/icons";
+import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
+import { MessageLikeContent } from "./MessageLikeContent";
 
 interface Props extends MotionProps {
   message: MessageFeedInfoFragment;

--- a/frontend/src/ui/message/messagesFeed/MessageLikeContent.tsx
+++ b/frontend/src/ui/message/messagesFeed/MessageLikeContent.tsx
@@ -1,11 +1,13 @@
 import { motion } from "framer-motion";
 import { ReactNode, useRef } from "react";
 import styled from "styled-components";
+
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { UserBasicInfoFragment } from "~gql";
-import { ITEM_BACKGROUND_WEAK_TRANSPARENT } from "~ui/theme/colors/base";
 import { borderRadius } from "~ui/baseStyles";
+import { ITEM_BACKGROUND_WEAK_TRANSPARENT } from "~ui/theme/colors/base";
 import { hoverTransition } from "~ui/transitions";
+
 import { MessageMetaData } from "./MessageMetaData";
 
 interface Props {

--- a/frontend/src/ui/message/messagesFeed/MessageMetaData.tsx
+++ b/frontend/src/ui/message/messagesFeed/MessageMetaData.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { UserBasicInfoFragment } from "~gql";
-import { TimeLabelWithDateTooltip } from "~ui/time/DateLabel";
 import { fontSize } from "~ui/baseStyles";
+import { TimeLabelWithDateTooltip } from "~ui/time/DateLabel";
 
 interface Props {
   user: UserBasicInfoFragment;

--- a/frontend/src/ui/message/messagesFeed/MessagesFeed.tsx
+++ b/frontend/src/ui/message/messagesFeed/MessagesFeed.tsx
@@ -1,9 +1,11 @@
 import { isSameDay } from "date-fns";
 import { Fragment, useRef } from "react";
 import styled from "styled-components";
+
 import { MessageFeedInfoFragment } from "~gql";
 import { niceFormatDate } from "~shared/dates/format";
 import { fontSize } from "~ui/baseStyles";
+
 import { Message } from "./Message";
 import { MessageLikeContent } from "./MessageLikeContent";
 

--- a/frontend/src/ui/message/reactions/MakeReactionButton.tsx
+++ b/frontend/src/ui/message/reactions/MakeReactionButton.tsx
@@ -1,16 +1,17 @@
-import { useRef } from "react";
-import { AnimatePresence } from "framer-motion";
 import { EmojiData } from "emoji-mart";
-import { IconEmotionSmile } from "~ui/icons";
-import { WideIconButton } from "~ui/buttons/WideIconButton";
-import { Popover } from "~ui/popovers/Popover";
-import { useBoolean } from "~shared/hooks/useBoolean";
-import { EmojiPickerWindow } from "~ui/EmojiPicker/EmojiPickerWindow";
-import { isBaseEmoji } from "~richEditor/EmojiButton";
-import { MessageDetailedInfoFragment } from "~gql";
+import { AnimatePresence } from "framer-motion";
+import { useRef } from "react";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { addMessageReaction } from "~frontend/gql/reactions";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { MessageDetailedInfoFragment } from "~gql";
+import { isBaseEmoji } from "~richEditor/EmojiButton";
+import { useBoolean } from "~shared/hooks/useBoolean";
+import { WideIconButton } from "~ui/buttons/WideIconButton";
+import { EmojiPickerWindow } from "~ui/EmojiPicker/EmojiPickerWindow";
+import { IconEmotionSmile } from "~ui/icons";
+import { Popover } from "~ui/popovers/Popover";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/message/reactions/MessageReactions/MessageReaction.tsx
+++ b/frontend/src/ui/message/reactions/MessageReactions/MessageReaction.tsx
@@ -1,12 +1,14 @@
 import React, { useRef } from "react";
 import styled, { css } from "styled-components";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { MessageDetailedInfoFragment, ReactionBasicInfoFragment } from "~gql";
-import { BACKGROUND_ACCENT, BACKGROUND_ACCENT_WEAK, WHITE, SECONDARY_TEXT_COLOR } from "~ui/theme/colors/base";
 import { addMessageReaction, removeMessageReaction } from "~frontend/gql/reactions";
-import { MessageReactionTooltip } from "./MessageReactionTooltip";
+import { MessageDetailedInfoFragment, ReactionBasicInfoFragment } from "~gql";
 import { fontSize } from "~ui/baseStyles";
 import { Tooltip } from "~ui/popovers/Tooltip";
+import { BACKGROUND_ACCENT, BACKGROUND_ACCENT_WEAK, SECONDARY_TEXT_COLOR, WHITE } from "~ui/theme/colors/base";
+
+import { MessageReactionTooltip } from "./MessageReactionTooltip";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/message/reactions/MessageReactions/MessageReactionTooltip.tsx
+++ b/frontend/src/ui/message/reactions/MessageReactions/MessageReactionTooltip.tsx
@@ -1,9 +1,10 @@
+import { Data as EmojiDataset, getEmojiDataFromNative } from "emoji-mart";
+import data from "emoji-mart/data/all.json";
 import React from "react";
 import styled from "styled-components";
-import { getEmojiDataFromNative, Data as EmojiDataset } from "emoji-mart";
-import data from "emoji-mart/data/all.json";
-import { ReactionBasicInfoFragment } from "~gql";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { ReactionBasicInfoFragment } from "~gql";
 import { WHITE } from "~ui/theme/colors/base";
 
 interface Props {

--- a/frontend/src/ui/message/reactions/MessageReactions/index.tsx
+++ b/frontend/src/ui/message/reactions/MessageReactions/index.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from "react";
 import styled from "styled-components";
+
 import { MessageDetailedInfoFragment } from "~gql";
+
 import { groupReactionsByEmoji } from "./groupReactionsByEmoji";
 import { MessageReaction } from "./MessageReaction";
 

--- a/frontend/src/ui/message/reply/ReplyButton.tsx
+++ b/frontend/src/ui/message/reply/ReplyButton.tsx
@@ -1,9 +1,10 @@
+import { observer } from "mobx-react";
 import React from "react";
-import { WideIconButton } from "~ui/buttons/WideIconButton";
-import { IconReply } from "~ui/icons";
+
 import { useTopicStoreContext } from "~frontend/topics/TopicStore";
 import { MessageDetailedInfoFragment } from "~gql";
-import { observer } from "mobx-react";
+import { WideIconButton } from "~ui/buttons/WideIconButton";
+import { IconReply } from "~ui/icons";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/message/reply/ReplyingToMessage.tsx
+++ b/frontend/src/ui/message/reply/ReplyingToMessage.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import styled from "styled-components";
-import { MessageText } from "~frontend/ui/message/display/types/TextMessageContent";
-import { MessageDetailedInfoFragment } from "~gql";
-import { CornerButtonWrapper } from "~ui/buttons/CornerButtonWrapper";
-import { ITEM_BACKGROUND_WEAK, SECONDARY_ORANGE_1, PRIMARY_PINK_1, PRIMARY_TEAL_1 } from "~ui/theme/colors/base";
-import { borderRadius } from "~ui/baseStyles";
-import { MessageMetaData } from "~frontend/ui/message/messagesFeed/MessageMetaData";
+
 import { MessageMedia } from "~frontend/ui/message/display/MessageMedia";
+import { MessageText } from "~frontend/ui/message/display/types/TextMessageContent";
+import { MessageMetaData } from "~frontend/ui/message/messagesFeed/MessageMetaData";
+import { MessageDetailedInfoFragment } from "~gql";
+import { borderRadius } from "~ui/baseStyles";
 import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
+import { CornerButtonWrapper } from "~ui/buttons/CornerButtonWrapper";
+import { ITEM_BACKGROUND_WEAK, PRIMARY_PINK_1, PRIMARY_TEAL_1, SECONDARY_ORANGE_1 } from "~ui/theme/colors/base";
 
 interface Props {
   message: MessageDetailedInfoFragment;

--- a/frontend/src/ui/notifications/NotificationLabel/NotificationLabel.tsx
+++ b/frontend/src/ui/notifications/NotificationLabel/NotificationLabel.tsx
@@ -1,15 +1,16 @@
-import { NotificationInfoFragment } from "~gql";
-import { routes, RouteLink } from "~frontend/router";
+import { useSingleRoomQuery } from "~frontend/gql/rooms";
 import { useCurrentTeamMember } from "~frontend/gql/teams";
 import { useSingleTopicQuery } from "~frontend/gql/topics";
+import { RouteLink, routes } from "~frontend/router";
+import { NotificationInfoFragment } from "~gql";
 import {
   AnyNotificationData,
-  isNotificationDataOfType,
   NotificationType,
   NotificationTypesMap,
+  isNotificationDataOfType,
 } from "~shared/notifications/types";
+
 import { NotificationPlainLabel } from "./NotificationPlainLabel";
-import { useSingleRoomQuery } from "~frontend/gql/rooms";
 import { useRemoveIncorrectNotification } from "./useRemoveIncorrectNotification";
 
 interface Props {

--- a/frontend/src/ui/notifications/NotificationLabel/NotificationPlainLabel.tsx
+++ b/frontend/src/ui/notifications/NotificationLabel/NotificationPlainLabel.tsx
@@ -1,23 +1,24 @@
 import { AnimatePresence } from "framer-motion";
 import { MouseEvent, ReactNode } from "react";
 import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+import { markNotificationAsRead, markNotificationAsUnread } from "~frontend/gql/notifications";
+import { useCurrentTeamMember } from "~frontend/gql/teams";
+import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { NotificationInfoFragment } from "~gql";
 import { relativeFormatDateTime } from "~shared/dates/format";
 import { handleWithStopPropagation } from "~shared/events";
 import { useIsElementOrChildHovered } from "~shared/hooks/useIsElementOrChildHovered";
+import { useSharedRef } from "~shared/hooks/useSharedRef";
+import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { PopPresenceAnimator } from "~ui/animations";
 import { borderRadius } from "~ui/baseStyles";
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
-import { BACKGROUND_ACCENT, BACKGROUND_ACCENT_WEAK, NOTIFICATION_COLOR } from "~ui/theme/colors/base";
 import { IconCheck, IconNotificationIndicator } from "~ui/icons";
+import { BACKGROUND_ACCENT, BACKGROUND_ACCENT_WEAK, NOTIFICATION_COLOR } from "~ui/theme/colors/base";
 import { hoverTransition } from "~ui/transitions";
-import { TextBody14, TextBody } from "~ui/typo";
-import { markNotificationAsRead, markNotificationAsUnread } from "~frontend/gql/notifications";
-import { useCurrentTeamMember } from "~frontend/gql/teams";
-import { UserAvatar } from "~frontend/ui/users/UserAvatar";
-import { namedForwardRef } from "~shared/react/namedForwardRef";
-import { useSharedRef } from "~shared/hooks/useSharedRef";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { TextBody, TextBody14 } from "~ui/typo";
 
 interface Props {
   userId: string;

--- a/frontend/src/ui/notifications/NotificationLabel/NotificationsTimeline.tsx
+++ b/frontend/src/ui/notifications/NotificationLabel/NotificationsTimeline.tsx
@@ -1,14 +1,16 @@
 import { startOfDay } from "date-fns";
 import styled from "styled-components";
+
 import { NotificationInfoFragment } from "~gql";
 import { relativeFormatDate } from "~shared/dates/format";
-import { CategoryNameLabel } from "~ui/theme/functional";
 import { groupByDate } from "~shared/dates/groupByDate";
-import { NotificationLabel } from "./NotificationLabel";
-import { ErrorBoundary } from "~ui/ErrorBoundary";
-import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
-import { IconNotificationIndicator } from "~ui/icons";
 import { sortByDate } from "~shared/dates/utils";
+import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
+import { ErrorBoundary } from "~ui/ErrorBoundary";
+import { IconNotificationIndicator } from "~ui/icons";
+import { CategoryNameLabel } from "~ui/theme/functional";
+
+import { NotificationLabel } from "./NotificationLabel";
 
 interface Props {
   notifications: NotificationInfoFragment[];

--- a/frontend/src/ui/notifications/NotificationLabel/useRemoveIncorrectNotification.tsx
+++ b/frontend/src/ui/notifications/NotificationLabel/useRemoveIncorrectNotification.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { NotificationInfoFragment } from "~gql";
+
 import { removeNotification } from "~frontend/gql/notifications";
+import { NotificationInfoFragment } from "~gql";
 
 interface UseRemoveIncorrectNotificationInput {
   isLoading: boolean;

--- a/frontend/src/ui/options/CornerOptionsMenu.tsx
+++ b/frontend/src/ui/options/CornerOptionsMenu.tsx
@@ -1,6 +1,8 @@
 import styled, { css } from "styled-components";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { PopoverMenuOption } from "~ui/popovers/PopoverMenu";
+
 import { OptionsButtonWithMenu } from "./OptionsButtonWithMenu";
 
 interface Props {

--- a/frontend/src/ui/options/OptionsButton.tsx
+++ b/frontend/src/ui/options/OptionsButton.tsx
@@ -1,6 +1,6 @@
-import { IconMoreHoriz } from "~ui/icons";
-import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
+import { WideIconButton } from "~ui/buttons/WideIconButton";
+import { IconMoreHoriz } from "~ui/icons";
 
 interface Props {
   onClick?: () => void;

--- a/frontend/src/ui/options/OptionsButtonWithMenu.tsx
+++ b/frontend/src/ui/options/OptionsButtonWithMenu.tsx
@@ -1,5 +1,6 @@
 import { PopoverMenuOption } from "~ui/popovers/PopoverMenu";
 import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
 import { OptionsButton } from "./OptionsButton";
 
 interface Props {

--- a/frontend/src/ui/rooms/CreateRoomButton.tsx
+++ b/frontend/src/ui/rooms/CreateRoomButton.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { routes } from "~frontend/router";
-import { createRoom } from "~frontend/gql/rooms";
-import { openRoomInputPrompt } from "~frontend/rooms/create/openRoomInputPrompt";
-import { Button } from "~ui/buttons/Button";
-import { IconPlusSquare } from "~ui/icons/default";
 import styled from "styled-components";
-import { getUUID } from "~shared/uuid";
+
 import { trackEvent } from "~frontend/analytics/tracking";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { createRoom } from "~frontend/gql/rooms";
+import { openRoomInputPrompt } from "~frontend/rooms/create/openRoomInputPrompt";
+import { routes } from "~frontend/router";
+import { getUUID } from "~shared/uuid";
+import { Button } from "~ui/buttons/Button";
+import { IconPlusSquare } from "~ui/icons/default";
 
 type Props = {
   className?: string;

--- a/frontend/src/ui/rooms/ManageRoomMembers/RoomOwner.tsx
+++ b/frontend/src/ui/rooms/ManageRoomMembers/RoomOwner.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
-import { theme } from "~ui/theme";
+
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { RoomDetailedInfoFragment } from "~gql";
+import { theme } from "~ui/theme";
 
 interface Props {
   room: RoomDetailedInfoFragment;

--- a/frontend/src/ui/rooms/ManageRoomMembers/index.tsx
+++ b/frontend/src/ui/rooms/ManageRoomMembers/index.tsx
@@ -1,25 +1,27 @@
-import { useState, useRef } from "react";
-import styled from "styled-components";
 import { AnimatePresence } from "framer-motion";
-import { useAddRoomMemberMutation, useIsCurrentUserRoomMember, useRemoveRoomMemberMutation } from "~frontend/gql/rooms";
+import { useRef, useState } from "react";
+import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { assertDefined } from "~shared/assert";
-import { RoomDetailedInfoFragment } from "~gql";
-import { openLastPrivateRoomMemberDeletionPrompt } from "./openLastPrivateRoomMemberDeletionPrompt";
-import { useBoolean } from "~shared/hooks/useBoolean";
+import { createRoomInvitation, removeRoomInvitation } from "~frontend/gql/roomInvitations";
+import { useAddRoomMemberMutation, useIsCurrentUserRoomMember, useRemoveRoomMemberMutation } from "~frontend/gql/rooms";
+import { useCurrentTeamDetails } from "~frontend/gql/teams";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { JoinToggleButton } from "~frontend/ui/buttons/JoinToggleButton";
 import { MembersManagerModal } from "~frontend/ui/MembersManager/MembersManagerModal";
-import { handleWithStopPropagation } from "~shared/events";
 import { AvatarList } from "~frontend/ui/users/AvatarList";
+import { WarningModal } from "~frontend/utils/warningModal";
+import { RoomDetailedInfoFragment } from "~gql";
+import { assertDefined } from "~shared/assert";
+import { handleWithStopPropagation } from "~shared/events";
+import { useBoolean } from "~shared/hooks/useBoolean";
+import { Button } from "~ui/buttons/Button";
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
 import { IconPlus } from "~ui/icons";
-import { JoinToggleButton } from "~frontend/ui/buttons/JoinToggleButton";
-import { createRoomInvitation, removeRoomInvitation } from "~frontend/gql/roomInvitations";
 import { addToast } from "~ui/toasts/data";
-import { WarningModal } from "~frontend/utils/warningModal";
-import { Button } from "~ui/buttons/Button";
-import { useCurrentTeamDetails } from "~frontend/gql/teams";
-import { trackEvent } from "~frontend/analytics/tracking";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+
+import { openLastPrivateRoomMemberDeletionPrompt } from "./openLastPrivateRoomMemberDeletionPrompt";
 import { RoomOwner } from "./RoomOwner";
 
 interface Props {

--- a/frontend/src/ui/rooms/ManageRoomMembers/openLastPrivateRoomMemberDeletionPrompt.tsx
+++ b/frontend/src/ui/rooms/ManageRoomMembers/openLastPrivateRoomMemberDeletionPrompt.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import styled from "styled-components";
-import { routes } from "~frontend/router";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { deleteRoom } from "~frontend/gql/rooms";
+import { routes } from "~frontend/router";
 import { ModalAnchor } from "~frontend/ui/Modal";
 import { WarningModal } from "~frontend/utils/warningModal";
 import { RoomBasicInfoFragment } from "~gql";
 import { useBoolean } from "~shared/hooks/useBoolean";
-import { createPromiseUI } from "~ui/createPromiseUI";
 import { Button } from "~ui/buttons/Button";
-import { trackEvent } from "~frontend/analytics/tracking";
+import { createPromiseUI } from "~ui/createPromiseUI";
 
 interface PromptInput {
   room: RoomBasicInfoFragment;

--- a/frontend/src/ui/rooms/RoomsList/CollapsibleRoomInfo.tsx
+++ b/frontend/src/ui/rooms/RoomsList/CollapsibleRoomInfo.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+
 import { useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
-import { routes, RouteLink } from "~frontend/router";
+import { RouteLink, routes } from "~frontend/router";
 import { NotificationCount } from "~frontend/ui/NotificationCount";
 import { AvatarList } from "~frontend/ui/users/AvatarList";
 import { useRoomUnreadMessagesCount } from "~frontend/utils/unreadMessages";
@@ -15,6 +16,7 @@ import { ValueDescriptor } from "~ui/meta/ValueDescriptor";
 import { GoogleCalendarIcon } from "~ui/social/GoogleCalendarIcon";
 import { PrivateTag } from "~ui/tags";
 import { theme } from "~ui/theme";
+
 import { ExpandableTopicsList } from "./ExpandableTopicsList";
 
 interface Props {

--- a/frontend/src/ui/rooms/RoomsList/ExpandableTopicsList.tsx
+++ b/frontend/src/ui/rooms/RoomsList/ExpandableTopicsList.tsx
@@ -1,16 +1,18 @@
 import React, { useMemo } from "react";
 import styled from "styled-components";
-import { groupByFilter } from "~shared/groupByFilter";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { getIndexBetweenCurrentAndLast } from "~frontend/rooms/order";
 import { startCreateNewTopicFlow } from "~frontend/topics/startCreateNewTopicFlow";
 import { useDetailedRoomMessagesCount } from "~frontend/utils/unreadMessages";
 import { TopicDetailedInfoFragment } from "~gql";
+import { groupByFilter } from "~shared/groupByFilter";
 import { Button } from "~ui/buttons/Button";
 import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
 import { IconChevronDown, IconChevronUp, IconPlusSquare } from "~ui/icons";
+
 import { TopicCard } from "./TopicCard";
 import { useExpandableListToggle } from "./useExpandableListToggle";
-import { getIndexBetweenCurrentAndLast } from "~frontend/rooms/order";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 
 interface Props {
   roomId: string;

--- a/frontend/src/ui/rooms/RoomsList/RoomsGroupedByActivities.tsx
+++ b/frontend/src/ui/rooms/RoomsList/RoomsGroupedByActivities.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+
 import { RoomDetailedInfoFragment } from "~gql";
 import { groupByFilter } from "~shared/groupByFilter";
+
 import { RoomsListCategory } from "./RoomsListCategory";
 import { RoomWithActivity, useRoomsWithActivities } from "./useRoomsWithActivity";
 

--- a/frontend/src/ui/rooms/RoomsList/RoomsGroupedByMembership.tsx
+++ b/frontend/src/ui/rooms/RoomsList/RoomsGroupedByMembership.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { RoomDetailedInfoFragment } from "~gql";
 import { groupByFilter } from "~shared/groupByFilter";
+
 import { RoomsListCategory } from "./RoomsListCategory";
 import { RoomWithActivity, useRoomsWithActivities } from "./useRoomsWithActivity";
 

--- a/frontend/src/ui/rooms/RoomsList/RoomsList.tsx
+++ b/frontend/src/ui/rooms/RoomsList/RoomsList.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { CollapsibleRoomInfo } from "./CollapsibleRoomInfo";
 import { RoomWithActivity } from "./useRoomsWithActivity";
 

--- a/frontend/src/ui/rooms/RoomsList/RoomsListCategory.tsx
+++ b/frontend/src/ui/rooms/RoomsList/RoomsListCategory.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 import styled from "styled-components";
+
 import { trackEvent } from "~frontend/analytics/tracking";
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { CategoryNameLabel } from "~ui/theme/functional";
 import { Toggle } from "~ui/toggle";
+
 import { RoomsList } from "./RoomsList";
 import { RoomWithActivity } from "./useRoomsWithActivity";
 

--- a/frontend/src/ui/rooms/RoomsList/TopicCard.tsx
+++ b/frontend/src/ui/rooms/RoomsList/TopicCard.tsx
@@ -1,15 +1,17 @@
-import styled, { css } from "styled-components";
-import { routes, RouteLink } from "~frontend/router";
-import { TopicDetailedInfoFragment, MessageBasicInfoFragment } from "~gql";
-import { TextH6 } from "~ui/typo";
-import { useTopicUnreadMessagesCount } from "~frontend/utils/unreadMessages";
-import { NOTIFICATION_COLOR } from "~ui/theme/colors/base";
-import { useTopicMessagesQuery } from "~frontend/gql/topics";
 import React from "react";
+import styled, { css } from "styled-components";
+
+import { useTopicMessagesQuery } from "~frontend/gql/topics";
+import { RouteLink, routes } from "~frontend/router";
 import { useTopic } from "~frontend/topics/useTopic";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
-import { UICardListItem } from "./shared";
+import { useTopicUnreadMessagesCount } from "~frontend/utils/unreadMessages";
+import { MessageBasicInfoFragment, TopicDetailedInfoFragment } from "~gql";
 import { convertRichEditorContentToHtml } from "~richEditor/content/html";
+import { NOTIFICATION_COLOR } from "~ui/theme/colors/base";
+import { TextH6 } from "~ui/typo";
+
+import { UICardListItem } from "./shared";
 
 interface Props {
   topic: TopicDetailedInfoFragment;

--- a/frontend/src/ui/rooms/RoomsList/shared.tsx
+++ b/frontend/src/ui/rooms/RoomsList/shared.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { borderRadius, shadow } from "~ui/baseStyles";
 import { BACKGROUND_ACCENT_WEAK } from "~ui/theme/colors/base";
 import { hoverActionCss } from "~ui/transitions";

--- a/frontend/src/ui/rooms/RoomsList/useRoomsWithActivity.ts
+++ b/frontend/src/ui/rooms/RoomsList/useRoomsWithActivity.ts
@@ -1,4 +1,5 @@
 import { compareAsc, compareDesc } from "date-fns";
+
 import { useSSRRoomsMessagesCount } from "~frontend/utils/unreadMessages";
 import { RoomDetailedInfoFragment } from "~gql";
 

--- a/frontend/src/ui/rooms/filters/FiltersList.tsx
+++ b/frontend/src/ui/rooms/filters/FiltersList.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
-import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
+
 import { getObjectKey } from "~shared/object";
 import { Button } from "~ui/buttons/Button";
+import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
+
 import { RoomCriteria } from "./filter";
 
 interface Props {

--- a/frontend/src/ui/rooms/filters/ParticipantsPickerMenu.tsx
+++ b/frontend/src/ui/rooms/filters/ParticipantsPickerMenu.tsx
@@ -1,8 +1,9 @@
 import { RefObject } from "react";
-import { PopoverMenu } from "~ui/popovers/PopoverMenu";
-import { UserBasicInfoFragment } from "~gql";
+
 import { useCurrentTeamMembers } from "~frontend/gql/user";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
+import { UserBasicInfoFragment } from "~gql";
+import { PopoverMenu } from "~ui/popovers/PopoverMenu";
 
 interface Props {
   anchorRef: RefObject<HTMLElement>;

--- a/frontend/src/ui/rooms/filters/RoomFilters.tsx
+++ b/frontend/src/ui/rooms/filters/RoomFilters.tsx
@@ -1,11 +1,13 @@
 import { AnimatePresence, AnimateSharedLayout } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+
 import { Button } from "~ui/buttons/Button";
 import { IconChevronDown } from "~ui/icons";
 import { PopoverMenu } from "~ui/popovers/PopoverMenu";
+
 import { createSortByDueDateFilter, createSortByLatestActivityFilter, createUserFilter } from "./factories";
-import { getUsersFromRoomCriteriaList, RoomCriteria } from "./filter";
+import { RoomCriteria, getUsersFromRoomCriteriaList } from "./filter";
 import { FiltersList } from "./FiltersList";
 import { ParticipantsPickerMenu } from "./ParticipantsPickerMenu";
 

--- a/frontend/src/ui/rooms/filters/factories.tsx
+++ b/frontend/src/ui/rooms/filters/factories.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { getUserDisplayName } from "~frontend/utils/getUserDisplayName";
 import { UserBasicInfoFragment } from "~gql";
 import { IconFilter } from "~ui/icons";
+
 import { RoomCriteria, UserRoomCriteria } from "./filter";
 
 export function createUserFilter(user: UserBasicInfoFragment): UserRoomCriteria {

--- a/frontend/src/ui/rooms/filters/filter.tsx
+++ b/frontend/src/ui/rooms/filters/filter.tsx
@@ -1,8 +1,9 @@
 import { sortBy } from "lodash";
 import { ReactNode } from "react";
-import { isNotNullish } from "~shared/nullish";
-import { RoomDetailedInfoFragment, UserBasicInfoFragment } from "~gql";
 import { useList } from "react-use";
+
+import { RoomDetailedInfoFragment, UserBasicInfoFragment } from "~gql";
+import { isNotNullish } from "~shared/nullish";
 
 export type RoomCriteria = {
   key: string;

--- a/frontend/src/ui/search/SearchBar.tsx
+++ b/frontend/src/ui/search/SearchBar.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import { useDebounce } from "react-use";
 import styled from "styled-components";
-import { borderRadius } from "~ui/baseStyles";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { useFullTextSearchQuery } from "~frontend/gql/search";
+import { namedForwardRef } from "~shared/react/namedForwardRef";
+import { borderRadius } from "~ui/baseStyles";
 import { SearchInput } from "~ui/forms/SearchInput";
 import { WHITE } from "~ui/theme/colors/base";
-import { namedForwardRef } from "~shared/react/namedForwardRef";
-import { trackEvent } from "~frontend/analytics/tracking";
+
 import { SearchResults } from "./SearchResults";
 
 interface Props {

--- a/frontend/src/ui/search/SearchResults.tsx
+++ b/frontend/src/ui/search/SearchResults.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
 import styled, { css } from "styled-components";
-import { BASE_GREY_5, PRIMARY_PINK_1, PRIMARY_PINK_1_TRANSPARENT } from "~ui/theme/colors/base";
-import { borderRadius } from "~ui/baseStyles";
-import { zIndex } from "~ui/zIndex";
+
+import { routes } from "~frontend/router";
+import { SearchResultsQuery } from "~gql";
+import { assert } from "~shared/assert";
 import { useListWithNavigation } from "~shared/hooks/useListWithNavigation";
 import { PopPresenceAnimator } from "~ui/animations";
-import { SearchResultsQuery } from "~gql";
-import { routes } from "~frontend/router";
-import { assert } from "~shared/assert";
+import { borderRadius } from "~ui/baseStyles";
+import { BASE_GREY_5, PRIMARY_PINK_1, PRIMARY_PINK_1_TRANSPARENT } from "~ui/theme/colors/base";
+import { zIndex } from "~ui/zIndex";
 
 interface Props {
   className?: string;

--- a/frontend/src/ui/spaces/SpaceCard.tsx
+++ b/frontend/src/ui/spaces/SpaceCard.tsx
@@ -1,14 +1,15 @@
 import styled from "styled-components";
-import { useSpaceManager } from "~frontend/spaces/useSpaceManager";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { RouteLink, routes } from "~frontend/router";
+import { useSpaceManager } from "~frontend/spaces/useSpaceManager";
+import { JoinToggleButton } from "~frontend/ui/buttons/JoinToggleButton";
+import { CornerOptionsMenu } from "~frontend/ui/options/CornerOptionsMenu";
+import { AvatarList } from "~frontend/ui/users/AvatarList";
 import { SpaceBasicInfoFragment } from "~gql";
 import { CardBase } from "~ui/card/Base";
 import { IconEdit, IconTrash } from "~ui/icons";
 import { EntityKindLabel, PrimaryItemTitle } from "~ui/theme/functional";
-import { JoinToggleButton } from "~frontend/ui/buttons/JoinToggleButton";
-import { CornerOptionsMenu } from "~frontend/ui/options/CornerOptionsMenu";
-import { AvatarList } from "~frontend/ui/users/AvatarList";
-import { RouteLink, routes } from "~frontend/router";
 
 interface Props {
   space: SpaceBasicInfoFragment;

--- a/frontend/src/ui/spaces/SpacePicker.tsx
+++ b/frontend/src/ui/spaces/SpacePicker.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import styled from "styled-components";
-import { createLengthValidator } from "~shared/validation/inputValidation";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+
 import { createSpace, useCurrentTeamSpaces } from "~frontend/gql/spaces";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import { SpaceGradientIcon } from "~frontend/ui/spaces/spaceGradient";
 import { openUIPrompt } from "~frontend/utils/prompt";
 import { SpaceBasicInfoFragment } from "~gql";
+import { createLengthValidator } from "~shared/validation/inputValidation";
 import { SingleOptionDropdown } from "~ui/forms/OptionsDropdown/single";
 import { IconSelection } from "~ui/icons";
 

--- a/frontend/src/ui/spaces/spaceGradient.ts
+++ b/frontend/src/ui/spaces/spaceGradient.ts
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
-import { borderRadius } from "~ui/baseStyles";
+
 import { pickNArrayItemsWithSeed } from "~shared/array";
+import { borderRadius } from "~ui/baseStyles";
 import { COLORS_PALETTE } from "~ui/theme/colors/base";
 
 const PALETTE_LIST = [...Object.values(COLORS_PALETTE)];

--- a/frontend/src/ui/users/Avatar.test.tsx
+++ b/frontend/src/ui/users/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import { Avatar } from "./Avatar";
 
 describe("Avatar", () => {

--- a/frontend/src/ui/users/Avatar.tsx
+++ b/frontend/src/ui/users/Avatar.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { Maybe } from "~gql";
+
 import { getInitials } from "~frontend/utils";
+import { Maybe } from "~gql";
 import { borderRadius } from "~ui/baseStyles";
 import { NamedSize, getNamedSizeValue } from "~ui/namedSize";
 import { PRIMARY_PINK_1, WHITE } from "~ui/theme/colors/base";

--- a/frontend/src/ui/users/AvatarList.tsx
+++ b/frontend/src/ui/users/AvatarList.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import styled from "styled-components";
-import { UserBasicInfoFragment } from "~gql";
-import { Avatar, AvatarSize } from "~frontend/ui/users/Avatar";
-import { groupByFilter } from "~shared/groupByFilter";
 import { useRef } from "react";
-import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
-import { UserAvatar } from "./UserAvatar";
-import { CircleLabel } from "~ui/icons/CircleLabel";
+import styled from "styled-components";
+
+import { Avatar, AvatarSize } from "~frontend/ui/users/Avatar";
+import { UserBasicInfoFragment } from "~gql";
+import { groupByFilter } from "~shared/groupByFilter";
 import { formatNumberWithMaxValue } from "~shared/numbers";
+import { CircleLabel } from "~ui/icons/CircleLabel";
+import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
+import { UserAvatar } from "./UserAvatar";
 
 interface Props {
   users: UserBasicInfoFragment[];

--- a/frontend/src/ui/users/UserAvatar.tsx
+++ b/frontend/src/ui/users/UserAvatar.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+
 import { UserBasicInfoFragment } from "~gql";
+
 import { Avatar, AvatarSize } from "./Avatar";
 
 interface Props {

--- a/frontend/src/ui/users/UserBasicInfo.tsx
+++ b/frontend/src/ui/users/UserBasicInfo.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { TextBody14, TextMeta10 } from "~ui/typo";
+
 import { UserBasicInfoFragment } from "~gql";
+import { TextBody14, TextMeta10 } from "~ui/typo";
+
 import { Avatar } from "./Avatar";
 import { UserBasicInfoContainer } from "./UserBasicInfoContainer";
 

--- a/frontend/src/utils/PageMeta.tsx
+++ b/frontend/src/utils/PageMeta.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+
 import { Maybe } from "~shared/types";
 
 interface Props {

--- a/frontend/src/utils/accessForbidden.tsx
+++ b/frontend/src/utils/accessForbidden.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+
 import { ModalAnchor } from "~frontend/ui/Modal";
 import { Button } from "~ui/buttons/Button";
 import { createPromiseUI } from "~ui/createPromiseUI";
+
 import { WarningModal } from "./warningModal";
 
 type Place = "room" | "space";

--- a/frontend/src/utils/confirm.tsx
+++ b/frontend/src/utils/confirm.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { Modal } from "~frontend/ui/Modal";
 import { Button } from "~ui/buttons/Button";
 import { createPromiseUI } from "~ui/createPromiseUI";

--- a/frontend/src/utils/notFound.tsx
+++ b/frontend/src/utils/notFound.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+
 import { ModalAnchor } from "~frontend/ui/Modal";
 import { Button } from "~ui/buttons/Button";
 import { createPromiseUI } from "~ui/createPromiseUI";
+
 import { WarningModal } from "./warningModal";
 
 type Place = "room" | "space";

--- a/frontend/src/utils/prompt.tsx
+++ b/frontend/src/utils/prompt.tsx
@@ -1,13 +1,14 @@
 import { useRef, useState } from "react";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { Button } from "~ui/buttons/Button";
-import { TextInput } from "~ui/forms/TextInput";
-import { Modal, ModalAnchor } from "~frontend/ui/Modal";
-import { createPromiseUI } from "~ui/createPromiseUI";
+import { ReactNode } from "react";
 import styled from "styled-components";
+
+import { Modal, ModalAnchor } from "~frontend/ui/Modal";
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { InputValidatorFunction } from "~shared/validation/inputValidation";
-import { ReactNode } from "react";
+import { Button } from "~ui/buttons/Button";
+import { createPromiseUI } from "~ui/createPromiseUI";
+import { TextInput } from "~ui/forms/TextInput";
+import { useShortcut } from "~ui/keyboard/useShortcut";
 
 interface PromptInput {
   title: string;

--- a/frontend/src/utils/unreadMessages.ts
+++ b/frontend/src/utils/unreadMessages.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import { memoize } from "lodash";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { createQuery } from "~frontend/gql/utils";
 import {

--- a/frontend/src/utils/user.ts
+++ b/frontend/src/utils/user.ts
@@ -1,5 +1,5 @@
-import { UserTokenData } from "~shared/types/jwtAuth";
 import { UserBasicInfoFragment } from "~gql";
+import { UserTokenData } from "~shared/types/jwtAuth";
 
 export function convertUserAuthToBasicFragment({ id, name, email, picture }: UserTokenData): UserBasicInfoFragment {
   return {

--- a/frontend/src/utils/warningModal.tsx
+++ b/frontend/src/utils/warningModal.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { ReactNode } from "react";
 import styled from "styled-components";
-import { theme } from "~ui/theme";
+
 import { Modal, ModalAnchor } from "~frontend/ui/Modal";
 import { useShortcut } from "~ui/keyboard/useShortcut";
+import { theme } from "~ui/theme";
 
 interface Props {
   warning?: string;

--- a/frontend/src/views/CalendarView/GoogleCalendarEventsCard.tsx
+++ b/frontend/src/views/CalendarView/GoogleCalendarEventsCard.tsx
@@ -1,20 +1,21 @@
 import styled from "styled-components";
-import { tryParseStringDate } from "~shared/dates/parseJSONWithDates";
-import { JsonValue } from "~shared/types";
-import { CardBase } from "~ui/card/Base";
-import { ValueDescriptor } from "~ui/meta/ValueDescriptor";
-import { hoverTransition } from "~ui/transitions";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { createRoom } from "~frontend/gql/rooms";
 import { useCurrentTeamMembers } from "~frontend/gql/user";
 import { openRoomInputPrompt } from "~frontend/rooms/create/openRoomInputPrompt";
+import { routes } from "~frontend/router";
 import { niceFormatDateTime } from "~shared/dates/format";
+import { tryParseStringDate } from "~shared/dates/parseJSONWithDates";
+import { JsonValue } from "~shared/types";
 import { GoogleCalendarEvent } from "~shared/types/googleCalendar";
 import { Button } from "~ui/buttons/Button";
+import { CardBase } from "~ui/card/Base";
+import { ValueDescriptor } from "~ui/meta/ValueDescriptor";
 import { GoogleCalendarIcon } from "~ui/social/GoogleCalendarIcon";
+import { hoverTransition } from "~ui/transitions";
 import { TextH4 } from "~ui/typo";
-import { trackEvent } from "~frontend/analytics/tracking";
-import { routes } from "~frontend/router";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 
 interface Props {
   event: JsonValue<GoogleCalendarEvent>;

--- a/frontend/src/views/CalendarView/RoomsTimeline.tsx
+++ b/frontend/src/views/CalendarView/RoomsTimeline.tsx
@@ -1,6 +1,7 @@
 import { addDays, eachDayOfInterval, isSameDay } from "date-fns";
 import { AnimateSharedLayout } from "framer-motion";
 import styled from "styled-components";
+
 import { RoomsTimelineSingleDay } from "./RoomsTimelineSingleDay";
 
 interface Props {

--- a/frontend/src/views/CalendarView/RoomsTimelineSingleDay.tsx
+++ b/frontend/src/views/CalendarView/RoomsTimelineSingleDay.tsx
@@ -1,21 +1,23 @@
-import styled from "styled-components";
-import { TextH3 } from "~ui/typo";
 import { endOfDay, startOfDay } from "date-fns";
-import { getDayBoundaries } from "~shared/dates/utils";
-import { niceFormatDate } from "~shared/dates/format";
-import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
-import { IconCalendar } from "~ui/icons";
 import { motion } from "framer-motion";
-import { getSpringTransitionWithDuration } from "~ui/animations";
+import { sortBy } from "lodash";
+import styled from "styled-components";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useRoomsQuery } from "~frontend/gql/rooms";
 import { googleCalendarEventsApi } from "~frontend/requests/googleCalendar";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { GoogleCalendarEvent } from "~shared/types/googleCalendar";
-import { RoomDetailedInfoFragment } from "~gql";
-import { JsonValue } from "~shared/types";
-import { sortBy } from "lodash";
-import { GoogleCalendarEventsCard } from "./GoogleCalendarEventsCard";
 import { CollapsibleRoomInfo } from "~frontend/ui/rooms/RoomsList/CollapsibleRoomInfo";
+import { RoomDetailedInfoFragment } from "~gql";
+import { niceFormatDate } from "~shared/dates/format";
+import { getDayBoundaries } from "~shared/dates/utils";
+import { JsonValue } from "~shared/types";
+import { GoogleCalendarEvent } from "~shared/types/googleCalendar";
+import { getSpringTransitionWithDuration } from "~ui/animations";
+import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
+import { IconCalendar } from "~ui/icons";
+import { TextH3 } from "~ui/typo";
+
+import { GoogleCalendarEventsCard } from "./GoogleCalendarEventsCard";
 
 interface Props {
   startDate: Date;

--- a/frontend/src/views/CalendarView/index.tsx
+++ b/frontend/src/views/CalendarView/index.tsx
@@ -1,8 +1,10 @@
 import { startOfToday } from "date-fns";
 import { useState } from "react";
 import styled from "styled-components";
+
 import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
 import { Calendar } from "~ui/time/Calendar";
+
 import { RoomsTimeline } from "./RoomsTimeline";
 
 export function CalendarView() {

--- a/frontend/src/views/HomeView/index.tsx
+++ b/frontend/src/views/HomeView/index.tsx
@@ -1,12 +1,14 @@
 import styled from "styled-components";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useRoomsQuery } from "~frontend/gql/rooms";
 import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
+import { CreateRoomButton } from "~frontend/ui/rooms/CreateRoomButton";
 import { createSortByLatestActivityFilter } from "~frontend/ui/rooms/filters/factories";
 import { useRoomsCriteria } from "~frontend/ui/rooms/filters/filter";
 import { RoomsGroupedByActivities } from "~frontend/ui/rooms/RoomsList";
+
 import { getHomeViewRoomsQueryWhere } from "./query";
-import { CreateRoomButton } from "~frontend/ui/rooms/CreateRoomButton";
 
 const sortByLatestActivity = createSortByLatestActivityFilter();
 

--- a/frontend/src/views/HomeView/query.ts
+++ b/frontend/src/views/HomeView/query.ts
@@ -1,7 +1,7 @@
-import { ValueUpdater } from "~shared/updateValue";
 import { readUserDataFromCookie } from "~frontend/authentication/cookie";
 import { roomsQueryManager } from "~frontend/gql/rooms";
-import { RoomsQuery, Room_Bool_Exp } from "~gql";
+import { Room_Bool_Exp, RoomsQuery } from "~gql";
+import { ValueUpdater } from "~shared/updateValue";
 
 export function getHomeViewRoomsQueryWhere(userId: string): Room_Bool_Exp {
   return {

--- a/frontend/src/views/LoginOptionsView/index.tsx
+++ b/frontend/src/views/LoginOptionsView/index.tsx
@@ -1,5 +1,5 @@
-import { GoogleLoginButton } from "~frontend/authentication/GoogleLoginButton";
 import { EmailLoginButton } from "~frontend/authentication/EmailLoginButton";
+import { GoogleLoginButton } from "~frontend/authentication/GoogleLoginButton";
 
 type LoginOptionsViewProps = {
   isEmailLoginEnabled?: boolean;

--- a/frontend/src/views/RoomView/DeadlineManager/index.tsx
+++ b/frontend/src/views/RoomView/DeadlineManager/index.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { RoomDetailedInfoFragment } from "~gql";
-import { updateRoom } from "~frontend/gql/rooms";
-import { DateTimeInput } from "~ui/time/DateTimeInput";
+
 import { trackEvent } from "~frontend/analytics/tracking";
+import { updateRoom } from "~frontend/gql/rooms";
+import { RoomDetailedInfoFragment } from "~gql";
+import { DateTimeInput } from "~ui/time/DateTimeInput";
 
 interface Props {
   room: RoomDetailedInfoFragment;

--- a/frontend/src/views/RoomView/RoomCloseModal/index.tsx
+++ b/frontend/src/views/RoomView/RoomCloseModal/index.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-
-import { createPromiseUI } from "~ui/createPromiseUI";
-
-import { TopicDetailedInfoFragment } from "~gql";
-import { Modal } from "~frontend/ui/Modal";
-import { useCloseOpenTopicsMutation } from "~frontend/gql/rooms";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import styled from "styled-components";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useCloseOpenTopicsMutation } from "~frontend/gql/rooms";
+import { Modal } from "~frontend/ui/Modal";
+import { TopicDetailedInfoFragment } from "~gql";
 import { Button } from "~ui/buttons/Button";
-import { TextH3, TextBody } from "~ui/typo";
+import { createPromiseUI } from "~ui/createPromiseUI";
+import { TextBody, TextH3 } from "~ui/typo";
 
 interface RoomCloseModalInput {
   roomId: string;

--- a/frontend/src/views/RoomView/RoomSidebarInfo.tsx
+++ b/frontend/src/views/RoomView/RoomSidebarInfo.tsx
@@ -1,9 +1,11 @@
 import { useRouter } from "next/router";
 import styled from "styled-components";
+
 import { useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { ManageRoomMembers } from "~frontend/ui/rooms/ManageRoomMembers";
 import { RoomDetailedInfoFragment } from "~gql";
 import { TextBody12 } from "~ui/typo";
+
 import { DeadlineManager } from "./DeadlineManager";
 
 interface Props {

--- a/frontend/src/views/RoomView/RoomSummary/roomConverter.ts
+++ b/frontend/src/views/RoomView/RoomSummary/roomConverter.ts
@@ -1,7 +1,9 @@
+import { convert as convertToPlainText } from "html-to-text";
+
 import { routes } from "~frontend/router";
 import { RoomDetailedInfoFragment, TopicDetailedInfoFragment } from "~gql";
+
 import { formatDate } from "../shared";
-import { convert as convertToPlainText } from "html-to-text";
 
 // Contains a special character within div that allows line-breaks to occur in notion
 const htmlLineBreak = "<div>‎</div>";

--- a/frontend/src/views/RoomView/RoomSummaryView.tsx
+++ b/frontend/src/views/RoomView/RoomSummaryView.tsx
@@ -2,14 +2,16 @@ import * as clipboard from "clipboard-polyfill";
 import React, { useState } from "react";
 import { useDebounce } from "react-use";
 import styled from "styled-components";
-import { theme } from "~ui/theme";
+
 import { useUpdateRoomMutation } from "~frontend/gql/rooms";
 import { RoomDetailedInfoFragment } from "~gql";
 import { handleWithStopPropagation } from "~shared/events";
 import { Button } from "~ui/buttons/Button";
 import { TextArea } from "~ui/forms/TextArea";
 import { IconClipboardCheck, IconCopy } from "~ui/icons";
+import { theme } from "~ui/theme";
 import { addToast } from "~ui/toasts/data";
+
 import { convertRoomToHtml, convertRoomToPlainText } from "./RoomSummary/roomConverter";
 import { RoomView } from "./RoomView";
 import { formatDate } from "./shared";

--- a/frontend/src/views/RoomView/RoomTopicView.tsx
+++ b/frontend/src/views/RoomView/RoomTopicView.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
+
 import { routes } from "~frontend/router";
+import { RoomDetailedInfoFragment } from "~gql";
+
 import { TopicView } from "../topic/TopicView";
 import { RoomView } from "./RoomView";
-import { RoomDetailedInfoFragment } from "~gql";
 
 interface Props {
   room: RoomDetailedInfoFragment;

--- a/frontend/src/views/RoomView/RoomView.tsx
+++ b/frontend/src/views/RoomView/RoomView.tsx
@@ -1,6 +1,8 @@
 import React, { useRef } from "react";
 import styled, { css } from "styled-components";
-import { useIsCurrentUserRoomMember, updateRoom } from "~frontend/gql/rooms";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+import { updateRoom, useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { getRoomManagePopoverOptions } from "~frontend/rooms/editOptions";
 import { RoomStoreContext } from "~frontend/rooms/RoomStore";
 import { CircleOptionsButton } from "~frontend/ui/options/OptionsButton";
@@ -14,7 +16,7 @@ import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
 import { GoogleCalendarIcon } from "~ui/social/GoogleCalendarIcon";
 import { PrivateTag } from "~ui/tags";
 import { TextH4 } from "~ui/typo";
-import { trackEvent } from "~frontend/analytics/tracking";
+
 import { RoomSidebarInfo } from "./RoomSidebarInfo";
 import { TopicsList } from "./TopicsList";
 

--- a/frontend/src/views/RoomView/TopicSummary/index.tsx
+++ b/frontend/src/views/RoomView/TopicSummary/index.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+
 import { useTopic } from "~frontend/topics/useTopic";
 import { TopicDetailedInfoFragment } from "~gql";
 import { fontSize } from "~ui/baseStyles";
 import { TextArea } from "~ui/forms/TextArea";
 import { theme } from "~ui/theme";
 import { Modifiers } from "~ui/theme/colors/createColor";
+
 import { formatDate } from "../shared";
 
 interface Props {

--- a/frontend/src/views/RoomView/TopicsList/LazyTopicsList.tsx
+++ b/frontend/src/views/RoomView/TopicsList/LazyTopicsList.tsx
@@ -1,7 +1,9 @@
 import React, { Suspense } from "react";
+
 import { TopicDetailedInfoFragment } from "~gql";
 import { namedLazy } from "~shared/namedLazy";
 import { ClientSideOnly } from "~ui/ClientSideOnly";
+
 import { StaticTopicsList } from "./StaticTopicsList";
 
 const SortableTopicsList = namedLazy(() => import("./SortableTopicsList"), "SortableTopicsList");

--- a/frontend/src/views/RoomView/TopicsList/ManageTopic/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/ManageTopic/index.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback } from "react";
-import { TopicDetailedInfoFragment } from "~gql";
+
+import { useIsCurrentUserTopicManager } from "~frontend/topics/useIsCurrentUserTopicManager";
 import { useTopic } from "~frontend/topics/useTopic";
 import { CircleOptionsButton } from "~frontend/ui/options/OptionsButton";
 import { openConfirmPrompt } from "~frontend/utils/confirm";
+import { openUIPrompt } from "~frontend/utils/prompt";
+import { TopicDetailedInfoFragment } from "~gql";
+import { createLengthValidator } from "~shared/validation/inputValidation";
 import { IconEdit, IconTrash } from "~ui/icons";
 import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
-import { openUIPrompt } from "~frontend/utils/prompt";
-import { createLengthValidator } from "~shared/validation/inputValidation";
-import { useIsCurrentUserTopicManager } from "~frontend/topics/useIsCurrentUserTopicManager";
 
 interface Props {
   topic: TopicDetailedInfoFragment;

--- a/frontend/src/views/RoomView/TopicsList/SortableTopicsList.tsx
+++ b/frontend/src/views/RoomView/TopicsList/SortableTopicsList.tsx
@@ -1,15 +1,16 @@
-import React, { useMemo, useState } from "react";
 import {
-  closestCenter,
   DndContext,
   DragEndEvent,
   DragStartEvent,
   PointerSensor,
+  closestCenter,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { restrictToFirstScrollableAncestor } from "@dnd-kit/modifiers";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import React, { useMemo, useState } from "react";
+
 import { TopicDetailedInfoFragment } from "~gql";
 
 import { UIScrollContainer, UITopic, UITopicsList } from "./shared";

--- a/frontend/src/views/RoomView/TopicsList/StaticTopicsList.tsx
+++ b/frontend/src/views/RoomView/TopicsList/StaticTopicsList.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+
 import { TopicDetailedInfoFragment } from "~gql";
-import { UIScrollContainer, UITopicsList, UITopic } from "./shared";
+
+import { UIScrollContainer, UITopic, UITopicsList } from "./shared";
 import { TopicMenuItem } from "./TopicMenuItem";
 
 interface Props {

--- a/frontend/src/views/RoomView/TopicsList/TopicMenuItem.tsx
+++ b/frontend/src/views/RoomView/TopicsList/TopicMenuItem.tsx
@@ -3,21 +3,23 @@ import { CSS } from "@dnd-kit/utilities";
 import { observer } from "mobx-react";
 import React, { useCallback, useRef } from "react";
 import styled, { css } from "styled-components";
-import { select } from "~shared/sharedState";
+
 import { updateTopic } from "~frontend/gql/topics";
 import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
-import { routes, RouteLink } from "~frontend/router";
+import { RouteLink, routes } from "~frontend/router";
+import { useTopic } from "~frontend/topics/useTopic";
 import { useTopicUnreadMessagesCount } from "~frontend/utils/unreadMessages";
 import { TopicDetailedInfoFragment } from "~gql";
 import { useBoolean } from "~shared/hooks/useBoolean";
-import { theme } from "~ui/theme";
+import { select } from "~shared/sharedState";
+import { CircleIconButton } from "~ui/buttons/CircleIconButton";
 import { EditableText } from "~ui/forms/EditableText";
 import { IconCross, IconDragAndDrop } from "~ui/icons";
 import { Popover } from "~ui/popovers/Popover";
+import { theme } from "~ui/theme";
 import { hoverActionCss } from "~ui/transitions";
+
 import { ManageTopic } from "./ManageTopic";
-import { CircleIconButton } from "~ui/buttons/CircleIconButton";
-import { useTopic } from "~frontend/topics/useTopic";
 import { TopicOwner } from "./TopicOwner";
 
 type Props = {

--- a/frontend/src/views/RoomView/TopicsList/TopicOwner.tsx
+++ b/frontend/src/views/RoomView/TopicsList/TopicOwner.tsx
@@ -1,16 +1,17 @@
-import styled, { css } from "styled-components";
-import { IconChevronDown } from "~ui/icons";
-import { theme } from "~ui/theme";
-import { UserAvatar } from "~frontend/ui/users/UserAvatar";
-import { TopicDetailedInfoFragment, UserBasicInfoFragment } from "~gql";
-import { useIsCurrentUserTopicManager } from "~frontend/topics/useIsCurrentUserTopicManager";
-import { useBoolean } from "~shared/hooks/useBoolean";
-import { useRef } from "react";
 import { AnimatePresence } from "framer-motion";
-import { Popover } from "~ui/popovers/Popover";
-import { ItemsDropdown } from "~ui/forms/OptionsDropdown/ItemsDropdown";
+import { useRef } from "react";
+import styled, { css } from "styled-components";
+
 import { updateTopic } from "~frontend/gql/topics";
+import { useIsCurrentUserTopicManager } from "~frontend/topics/useIsCurrentUserTopicManager";
+import { UserAvatar } from "~frontend/ui/users/UserAvatar";
 import { getUserDisplayName } from "~frontend/utils/getUserDisplayName";
+import { TopicDetailedInfoFragment, UserBasicInfoFragment } from "~gql";
+import { useBoolean } from "~shared/hooks/useBoolean";
+import { ItemsDropdown } from "~ui/forms/OptionsDropdown/ItemsDropdown";
+import { IconChevronDown } from "~ui/icons";
+import { Popover } from "~ui/popovers/Popover";
+import { theme } from "~ui/theme";
 
 interface Props {
   topic: TopicDetailedInfoFragment;

--- a/frontend/src/views/RoomView/TopicsList/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/index.tsx
@@ -2,22 +2,24 @@ import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import React, { useRef } from "react";
 import styled from "styled-components";
-import { getUUID } from "~shared/uuid";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { createLastItemIndex, getIndexBetweenCurrentAndLast, getIndexBetweenItems } from "~frontend/rooms/order";
 import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
 import { useRoomTopicList } from "~frontend/rooms/useRoomTopicList";
-import { routes, RouteLink } from "~frontend/router";
+import { RouteLink, routes } from "~frontend/router";
 import { startCreateNewTopicFlow } from "~frontend/topics/startCreateNewTopicFlow";
 import { RoomDetailedInfoFragment } from "~gql";
 import { generateId } from "~shared/id";
 import { select } from "~shared/sharedState";
+import { getUUID } from "~shared/uuid";
 import { Button } from "~ui/buttons/Button";
 import { CollapsePanel } from "~ui/collapse/CollapsePanel";
 import { IconPlusSquare } from "~ui/icons";
 import { VStack } from "~ui/Stack";
 import { TextH6 } from "~ui/typo";
+
 import { LazyTopicsList } from "./LazyTopicsList";
 import { StaticTopicsList } from "./StaticTopicsList";
 

--- a/frontend/src/views/RoomView/TopicsList/shared.ts
+++ b/frontend/src/views/RoomView/TopicsList/shared.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { TopicMenuItem } from "./TopicMenuItem";
 
 export const UIScrollContainer = styled.div<{}>`

--- a/frontend/src/views/SpaceView/SpaceHeader.tsx
+++ b/frontend/src/views/SpaceView/SpaceHeader.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { SpaceDetailedInfoFragment } from "~gql";
 import { EntityKindLabel, HeroItemTitle } from "~ui/theme/functional";
 

--- a/frontend/src/views/SpaceView/SpaceTools.tsx
+++ b/frontend/src/views/SpaceView/SpaceTools.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
-import { SpaceDetailedInfoFragment } from "~gql";
-import { useBoolean } from "~shared/hooks/useBoolean";
-import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
+
 import { useSpaceManager } from "~frontend/spaces/useSpaceManager";
 import { JoinToggleButton } from "~frontend/ui/buttons/JoinToggleButton";
 import { MembersManagerModal } from "~frontend/ui/MembersManager/MembersManagerModal";
 import { CircleOptionsButton } from "~frontend/ui/options/OptionsButton";
+import { SpaceDetailedInfoFragment } from "~gql";
+import { useBoolean } from "~shared/hooks/useBoolean";
+import { PopoverMenuTrigger } from "~ui/popovers/PopoverMenuTrigger";
 
 interface Props {
   space: SpaceDetailedInfoFragment;

--- a/frontend/src/views/SpaceView/index.tsx
+++ b/frontend/src/views/SpaceView/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import styled from "styled-components";
+
 import { useIsCurrentUserSpaceMember, useSingleSpaceQuery } from "~frontend/gql/spaces";
 import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
 import { CreateRoomButton } from "~frontend/ui/rooms/CreateRoomButton";
@@ -10,6 +11,7 @@ import { RoomsGroupedByMembership } from "~frontend/ui/rooms/RoomsList";
 import { AvatarList } from "~frontend/ui/users/AvatarList";
 import { PageMeta } from "~frontend/utils/PageMeta";
 import { CenteredContentWithSides } from "~ui/layout/CenteredContentWithSides";
+
 import { SpaceHeader } from "./SpaceHeader";
 import { SpaceTools } from "./SpaceTools";
 

--- a/frontend/src/views/SpacesView/SpacesList.tsx
+++ b/frontend/src/views/SpacesView/SpacesList.tsx
@@ -1,12 +1,13 @@
 import styled from "styled-components";
-import { TextH3, TextBody14 } from "~ui/typo";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useTeamSpacesQuery } from "~frontend/gql/spaces";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import { NoticeLabel } from "~frontend/ui/NoticeLabel";
 import { SpaceCard } from "~frontend/ui/spaces/SpaceCard";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { groupByFilter } from "~shared/groupByFilter";
 import { CategoryNameLabel } from "~ui/theme/functional";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { TextBody14, TextH3 } from "~ui/typo";
 
 export function SpacesList() {
   const teamId = useAssertCurrentTeamId();

--- a/frontend/src/views/SpacesView/index.tsx
+++ b/frontend/src/views/SpacesView/index.tsx
@@ -1,17 +1,19 @@
-import styled from "styled-components";
-import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
-import { useCreateSpaceMutation } from "~frontend/gql/spaces";
-import { routes } from "~frontend/router";
-import { openUIPrompt } from "~frontend/utils/prompt";
-import { Button } from "~ui/buttons/Button";
-import { SpacesList } from "./SpacesList";
 import { useRef } from "react";
-import { createLengthValidator } from "~shared/validation/inputValidation";
-import { IconPlusSquare, IconSelection } from "~ui/icons";
-import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
-import { PageHeader } from "~frontend/layouts/AppLayout/PageHeader";
+import styled from "styled-components";
+
 import { trackEvent } from "~frontend/analytics/tracking";
+import { useCreateSpaceMutation } from "~frontend/gql/spaces";
+import { PageHeader } from "~frontend/layouts/AppLayout/PageHeader";
+import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
+import { routes } from "~frontend/router";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { openUIPrompt } from "~frontend/utils/prompt";
 import { getUUID } from "~shared/uuid";
+import { createLengthValidator } from "~shared/validation/inputValidation";
+import { Button } from "~ui/buttons/Button";
+import { IconPlusSquare, IconSelection } from "~ui/icons";
+
+import { SpacesList } from "./SpacesList";
 
 export function SpacesView() {
   const teamId = useAssertCurrentTeamId();

--- a/frontend/src/views/TeamMembersView/CurrentTeamMembersManager.tsx
+++ b/frontend/src/views/TeamMembersView/CurrentTeamMembersManager.tsx
@@ -1,14 +1,16 @@
 import styled from "styled-components";
-import { removeTeamMember, useCurrentTeamDetails, removeTeamInvitation } from "~frontend/gql/teams";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { removeTeamInvitation, removeTeamMember, useCurrentTeamDetails } from "~frontend/gql/teams";
+import { InvitationPendingIndicator } from "~frontend/ui/MembersManager/InvitationPendingIndicator";
 import { UISelectGridContainer } from "~frontend/ui/MembersManager/UISelectGridContainer";
 import { UserBasicInfo } from "~frontend/ui/users/UserBasicInfo";
-import { InviteMemberForm } from "./InviteMemberForm";
-import { InvitationPendingIndicator } from "~frontend/ui/MembersManager/InvitationPendingIndicator";
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
-import { trackEvent } from "~frontend/analytics/tracking";
 import { theme } from "~ui/theme";
+
 import { ExitTeamButton } from "./ExitTeamButton";
+import { InviteMemberForm } from "./InviteMemberForm";
 import { ResendInviteButton } from "./ResendInviteButton";
 
 export const CurrentTeamMembersManager = () => {

--- a/frontend/src/views/TeamMembersView/ExitTeamButton.tsx
+++ b/frontend/src/views/TeamMembersView/ExitTeamButton.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
-import { theme } from "~ui/theme";
-import { useChangeCurrentTeamIdMutation } from "~frontend/gql/user";
+
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useChangeCurrentTeamIdMutation } from "~frontend/gql/user";
+import { theme } from "~ui/theme";
 
 export const ExitTeamButton = () => {
   const user = useAssertCurrentUser();

--- a/frontend/src/views/TeamMembersView/InviteMemberForm.tsx
+++ b/frontend/src/views/TeamMembersView/InviteMemberForm.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
+import { useMemo } from "react";
 import styled from "styled-components";
 import isEmail from "validator/lib/isEmail";
-import { RoundedTextInput } from "~ui/forms/RoundedTextInput";
+
+import { trackEvent } from "~frontend/analytics/tracking";
 import { createTeamIvitation, useCurrentTeamDetails } from "~frontend/gql/teams";
 import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
-import { useMemo } from "react";
-import { trackEvent } from "~frontend/analytics/tracking";
 import { Button } from "~ui/buttons/Button";
+import { RoundedTextInput } from "~ui/forms/RoundedTextInput";
 import { IconPlusSquare } from "~ui/icons";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 

--- a/frontend/src/views/TeamMembersView/ResendInviteButton.tsx
+++ b/frontend/src/views/TeamMembersView/ResendInviteButton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useResendInvitation } from "~frontend/gql/teams";
 import { Button } from "~ui/buttons/Button";
 

--- a/frontend/src/views/TeamMembersView/index.tsx
+++ b/frontend/src/views/TeamMembersView/index.tsx
@@ -1,8 +1,10 @@
 import styled from "styled-components";
-import { CurrentTeamMembersManager } from "./CurrentTeamMembersManager";
+
 import { SpacedAppLayoutContainer } from "~frontend/layouts/AppLayout/SpacedAppLayoutContainer";
-import { TextMeta10 } from "~ui/typo";
 import { useCurrentTeamId } from "~frontend/team/useCurrentTeamId";
+import { TextMeta10 } from "~ui/typo";
+
+import { CurrentTeamMembersManager } from "./CurrentTeamMembersManager";
 
 const appVersion = process.env.NEXT_PUBLIC_SENTRY_RELEASE;
 

--- a/frontend/src/views/WindowView/index.tsx
+++ b/frontend/src/views/WindowView/index.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
-import { borderRadius, shadow } from "~ui/baseStyles";
+
 import { Logo } from "~frontend/ui/Logo";
+import { borderRadius, shadow } from "~ui/baseStyles";
 
 interface Props {
   children: ReactNode;

--- a/frontend/src/views/topic/CloseTopicModal.tsx
+++ b/frontend/src/views/topic/CloseTopicModal.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { TextH3 } from "~ui/typo";
+
 import { Modal } from "~frontend/ui/Modal";
-import { TextArea } from "~ui/forms/TextArea";
 import { Button } from "~ui/buttons/Button";
+import { TextArea } from "~ui/forms/TextArea";
 import { HStack } from "~ui/Stack";
+import { TextH3 } from "~ui/typo";
 
 interface Props {
   topicId: string;

--- a/frontend/src/views/topic/ScrollToBottomMonitor.tsx
+++ b/frontend/src/views/topic/ScrollToBottomMonitor.tsx
@@ -1,7 +1,8 @@
 import { RefObject, useCallback, useEffect, useRef } from "react";
-import styled from "styled-components";
-import { useResizeCallback } from "~shared/hooks/useResizeCallback";
 import { useIsomorphicLayoutEffect } from "react-use";
+import styled from "styled-components";
+
+import { useResizeCallback } from "~shared/hooks/useResizeCallback";
 
 interface Props {
   parentRef: RefObject<HTMLElement>;

--- a/frontend/src/views/topic/ScrollableMessages.tsx
+++ b/frontend/src/views/topic/ScrollableMessages.tsx
@@ -1,10 +1,12 @@
 import React, { ReactNode, useCallback, useRef } from "react";
 import styled from "styled-components";
-import { ScrollToBottomMonitor } from "./ScrollToBottomMonitor";
-import { assertDefined } from "~shared/assert";
+
 import { useTopicStoreContext } from "~frontend/topics/TopicStore";
-import { select } from "~shared/sharedState";
+import { assertDefined } from "~shared/assert";
 import { useElementEvent } from "~shared/domEvents";
+import { select } from "~shared/sharedState";
+
+import { ScrollToBottomMonitor } from "./ScrollToBottomMonitor";
 
 interface Props {
   children: ReactNode;

--- a/frontend/src/views/topic/TopicClosureNote.tsx
+++ b/frontend/src/views/topic/TopicClosureNote.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { borderRadius } from "~ui/baseStyles";
 
 interface Props {

--- a/frontend/src/views/topic/TopicHeader.tsx
+++ b/frontend/src/views/topic/TopicHeader.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 import styled, { css } from "styled-components";
+
 import { useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { useIsCurrentUserTopicManager } from "~frontend/topics/useIsCurrentUserTopicManager";
 import { useTopic } from "~frontend/topics/useTopic";
@@ -9,6 +10,7 @@ import { useBoolean } from "~shared/hooks/useBoolean";
 import { Button } from "~ui/buttons/Button";
 import { theme } from "~ui/theme";
 import { TextH3 } from "~ui/typo";
+
 import { CloseTopicModal } from "./CloseTopicModal";
 
 interface Props {

--- a/frontend/src/views/topic/TopicSummary.tsx
+++ b/frontend/src/views/topic/TopicSummary.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+
 import { getTopicCloseInfo } from "~frontend/topics/useTopic";
 import { MessageLikeContent } from "~frontend/ui/message/messagesFeed/MessageLikeContent";
 import { TopicDetailedInfoFragment } from "~gql";

--- a/frontend/src/views/topic/TopicView.tsx
+++ b/frontend/src/views/topic/TopicView.tsx
@@ -1,6 +1,7 @@
 import { AnimateSharedLayout } from "framer-motion";
 import React from "react";
 import styled from "styled-components";
+
 import { Message as MessageType } from "~db";
 import { useIsCurrentUserRoomMember } from "~frontend/gql/rooms";
 import { updateLastSeenMessage, useSingleTopicQuery, useTopicMessagesQuery } from "~frontend/gql/topics";
@@ -16,6 +17,7 @@ import { ClientSideOnly } from "~ui/ClientSideOnly";
 import { disabledCss } from "~ui/disabled";
 import { theme } from "~ui/theme";
 import { Modifiers } from "~ui/theme/colors/createColor";
+
 import { ScrollableMessages } from "./ScrollableMessages";
 import { TopicClosureBanner as TopicClosureNote } from "./TopicClosureNote";
 import { TopicHeader } from "./TopicHeader";

--- a/frontend/styles/global.ts
+++ b/frontend/styles/global.ts
@@ -1,4 +1,5 @@
 import { css } from "styled-components";
+
 import { base } from "./base";
 import { fontFacesStyles } from "./fontFaces";
 

--- a/package.json
+++ b/package.json
@@ -117,15 +117,28 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "import-sort-style-module-and-prefix": "^0.1.3",
     "jest": "^27.0.6",
     "lint-staged": "^11.0.0",
     "ntl": "^5.1.0",
     "prettier": "^2.3.2",
+    "prettier-plugin-import-sort": "^0.0.7",
     "tslib": "^2.3.0"
   },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "importSort": {
+    ".js, .jsx, .ts, .tsx": {
+      "style": "module-and-prefix",
+      "parser": "typescript"
+    }
+  },
+  "importSortPrefix": {
+    "groupings": [
+      "~"
+    ]
   }
 }

--- a/richEditor/DropFileContext.tsx
+++ b/richEditor/DropFileContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, ReactNode, RefObject, useContext, useEffect, useMemo, useRef } from "react";
+import { ReactNode, RefObject, createContext, useContext, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
+
 import { createCleanupObject } from "~shared/cleanup";
 import { createElementEvent, createElementEvents } from "~shared/domEvents";
 

--- a/richEditor/EmojiButton.tsx
+++ b/richEditor/EmojiButton.tsx
@@ -1,11 +1,13 @@
+import type { BaseEmoji, EmojiData } from "emoji-mart";
+import { AnimatePresence } from "framer-motion";
 import { useRef } from "react";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { EmojiPickerWindow } from "~ui/EmojiPicker/EmojiPickerWindow";
 import { IconEmotionSmile } from "~ui/icons";
 import { Popover } from "~ui/popovers/Popover";
+
 import { ToolbarButton } from "./ToolbarButton";
-import { AnimatePresence } from "framer-motion";
-import type { EmojiData, BaseEmoji } from "emoji-mart";
 
 interface Props {
   onEmojiSelected: (emoji: string) => void;

--- a/richEditor/RichEditor.tsx
+++ b/richEditor/RichEditor.tsx
@@ -1,14 +1,18 @@
 import { ChainedCommands, Editor, EditorContent, Extensions, JSONContent } from "@tiptap/react";
 import { isEqual } from "lodash";
 import React, { ReactNode, useEffect, useImperativeHandle, useMemo } from "react";
+import { useUpdate } from "react-use";
 import styled from "styled-components";
+
 import { getFocusedElement } from "~shared/focus";
 import { useConst } from "~shared/hooks/useConst";
 import { useEqualDependencyChangeEffect } from "~shared/hooks/useEqualEffect";
+import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { createTimeout, wait } from "~shared/time";
 import { borderRadius } from "~ui/baseStyles";
 import { useAlphanumericShortcut } from "~ui/keyboard/useAlphanumericShortcut";
 import { useShortcut } from "~ui/keyboard/useShortcut";
+
 import { RichEditorNode } from "./content/types";
 import { RichEditorContext } from "./context";
 import { useFileDroppedInContext } from "./DropFileContext";
@@ -16,8 +20,6 @@ import { richEditorExtensions } from "./preset";
 import { richEditorContentCss } from "./Theme";
 import { RichEditorSubmitMode, Toolbar } from "./Toolbar";
 import { useDocumentFilesPaste } from "./useDocumentFilePaste";
-import { useUpdate } from "react-use";
-import { namedForwardRef } from "~shared/react/namedForwardRef";
 
 export type { Editor } from "@tiptap/react";
 export type { RichEditorSubmitMode } from "./Toolbar";

--- a/richEditor/Theme.tsx
+++ b/richEditor/Theme.tsx
@@ -1,4 +1,5 @@
 import { css } from "styled-components";
+
 import { theme } from "~ui/theme";
 
 export const richEditorContentCss = css`

--- a/richEditor/Toolbar.tsx
+++ b/richEditor/Toolbar.tsx
@@ -1,7 +1,8 @@
 import { ChainedCommands } from "@tiptap/react";
 import { Children } from "react";
 import styled from "styled-components";
-import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
+
+import { namedForwardRef } from "~shared/react/namedForwardRef";
 import {
   IconAt,
   IconBrackets,
@@ -14,11 +15,12 @@ import {
   IconTextItalic,
   IconTextStrikethrough,
 } from "~ui/icons";
+import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
+
 import { useRichEditorContext } from "./context";
 import { EmojiButton } from "./EmojiButton";
 import { FileInput } from "./FileInput";
 import { ToolbarButton } from "./ToolbarButton";
-import { namedForwardRef } from "~shared/react/namedForwardRef";
 
 interface Props {
   onFilesSelected?: (files: File[]) => void;

--- a/richEditor/ToolbarButton.tsx
+++ b/richEditor/ToolbarButton.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
-import { borderRadius } from "~ui/baseStyles";
-import { PRIMARY_COLOR, WHITE } from "~ui/theme/colors/base";
-import { disabledCss } from "~ui/disabled";
-import { getButtonColorStyles } from "~ui/transitions";
+
 import { namedForwardRef } from "~shared/react/namedForwardRef";
+import { borderRadius } from "~ui/baseStyles";
+import { disabledCss } from "~ui/disabled";
+import { PRIMARY_COLOR, WHITE } from "~ui/theme/colors/base";
+import { getButtonColorStyles } from "~ui/transitions";
 
 interface Props {
   icon: ReactNode;

--- a/richEditor/autocomplete/AutocompleteNodeWrapper.tsx
+++ b/richEditor/autocomplete/AutocompleteNodeWrapper.tsx
@@ -1,5 +1,6 @@
 import { JSONContent, NodeViewWrapper } from "@tiptap/react";
 import { ComponentType } from "react";
+
 import { AutocompleteNodeProps } from "./component";
 
 interface Props<D> {

--- a/richEditor/autocomplete/AutocompletePickerPopover.tsx
+++ b/richEditor/autocomplete/AutocompletePickerPopover.tsx
@@ -1,12 +1,14 @@
-import { Popover } from "~ui/popovers/Popover";
 import { NodeViewWrapper } from "@tiptap/react";
 import { SuggestionProps } from "@tiptap/suggestion";
 import { ComponentType, useState } from "react";
-import { AutocompletePickerProps } from "./component";
+
+import { useComparingEffect } from "~shared/hooks/useComparingEffect";
 import { useValueRef } from "~shared/hooks/useValueRef";
 import { PopPresenceAnimator } from "~ui/animations";
 import { useShortcut } from "~ui/keyboard/useShortcut";
-import { useComparingEffect } from "~shared/hooks/useComparingEffect";
+import { Popover } from "~ui/popovers/Popover";
+
+import { AutocompletePickerProps } from "./component";
 
 interface Props<D> {
   baseProps: SuggestionProps;

--- a/richEditor/autocomplete/index.tsx
+++ b/richEditor/autocomplete/index.tsx
@@ -1,10 +1,11 @@
-import { Node, mergeAttributes, Editor } from "@tiptap/core";
-import Suggestion, { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
+import { Editor, Node, mergeAttributes } from "@tiptap/core";
 import { KeyboardShortcutCommand, ReactNodeViewRenderer, ReactRenderer } from "@tiptap/react";
+import Suggestion, { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { ComponentType, FunctionComponent } from "react";
-import { AutocompleteNodeProps, AutocompletePickerProps } from "./component";
-import { AutocompletePickerPopoverBase } from "./AutocompletePickerPopover";
+
 import { AutocompleteNodeWrapper } from "./AutocompleteNodeWrapper";
+import { AutocompletePickerPopoverBase } from "./AutocompletePickerPopover";
+import { AutocompleteNodeProps, AutocompletePickerProps } from "./component";
 
 interface AutocompletePluginOptions<D> {
   type: string;

--- a/richEditor/content/RichContentRenderer.tsx
+++ b/richEditor/content/RichContentRenderer.tsx
@@ -1,5 +1,6 @@
 import { EditorContent, Extensions, JSONContent, useEditor } from "@tiptap/react";
 import React, { useMemo } from "react";
+
 import { richEditorExtensions } from "../preset";
 
 export function getEmptyRichContent(): JSONContent {

--- a/richEditor/content/html.ts
+++ b/richEditor/content/html.ts
@@ -1,5 +1,7 @@
 import { generateHTML } from "@tiptap/html";
+
 import { richEditorExtensions } from "~richEditor/preset";
+
 import { RichEditorNode } from "./types";
 
 export function convertRichEditorContentToHtml(content: RichEditorNode) {

--- a/richEditor/content/isEmpty.ts
+++ b/richEditor/content/isEmpty.ts
@@ -1,5 +1,6 @@
-import { RichEditorNode } from "./types";
 import { JSONContent } from "@tiptap/react";
+
+import { RichEditorNode } from "./types";
 
 function hasContentNodeAnyTextContent(node: JSONContent): boolean {
   if (node.text && node.text.length > 0) return true;

--- a/richEditor/emoji/SearchModal.tsx
+++ b/richEditor/emoji/SearchModal.tsx
@@ -1,6 +1,7 @@
 import type { BaseEmoji } from "emoji-mart";
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+
 import { Channel } from "~shared/channel";
 import { SelectionPopover } from "~ui/popovers/SelectionPopover";
 import { SelectList } from "~ui/SelectList";

--- a/richEditor/links/autolinks.ts
+++ b/richEditor/links/autolinks.ts
@@ -1,6 +1,7 @@
 import { markInputRule } from "@tiptap/core";
 import { InputRule, inputRules } from "prosemirror-inputrules";
 import { MarkType } from "prosemirror-model";
+
 import { Link } from "./link";
 
 // These are almost the same as pasteRegex and pasteRegexWithBrackets but with

--- a/richEditor/preset.ts
+++ b/richEditor/preset.ts
@@ -1,7 +1,7 @@
-import StarterKit from "@tiptap/starter-kit";
-import { Links } from "./links/autolinks";
-
 import { Extensions } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+import { Links } from "./links/autolinks";
 
 /**
  * Let's have definition of extensions shared as it's used both by editor and message html renderer.

--- a/richEditor/useDocumentFilePaste.ts
+++ b/richEditor/useDocumentFilePaste.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+
 import { createDocumentEvent } from "~shared/domEvents";
 
 let isAnyWatchingForPaste = false;

--- a/shared/backendAnalytics.ts
+++ b/shared/backendAnalytics.ts
@@ -1,5 +1,7 @@
-import { User } from "~db";
 import Analytics from "analytics-node";
+
+import { User } from "~db";
+
 import { AnalyticsEventsMap, AnalyticsUserProfile } from "./types/analytics";
 
 function getAnalyticsProfileFromDbUser(user: User): AnalyticsUserProfile {

--- a/shared/channel.ts
+++ b/shared/channel.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+
 import { useConst } from "~shared/hooks/useConst";
 
 type Cancel = () => void;

--- a/shared/dates/format.ts
+++ b/shared/dates/format.ts
@@ -1,4 +1,4 @@
-import { format, formatRelative, startOfWeek, compareAsc } from "date-fns";
+import { compareAsc, format, formatRelative, startOfWeek } from "date-fns";
 import { upperFirst } from "lodash";
 
 export function relativeFormatDate(date: Date): string {

--- a/shared/dates/utils.ts
+++ b/shared/dates/utils.ts
@@ -1,4 +1,4 @@
-import { startOfDay, endOfDay } from "date-fns";
+import { endOfDay, startOfDay } from "date-fns";
 import { sortBy } from "lodash";
 
 export function getDayBoundaries(date: Date) {

--- a/shared/debug/events.ts
+++ b/shared/debug/events.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+
 import { createCleanupObject } from "~shared/cleanup";
 import { createDocumentEvent, createWindowEvent } from "~shared/domEvents";
 

--- a/shared/domEvents.ts
+++ b/shared/domEvents.ts
@@ -1,6 +1,7 @@
-import { RefObject, useEffect } from "react";
-import { useBoolean } from "./hooks/useBoolean";
 import { noop } from "lodash";
+import { RefObject, useEffect } from "react";
+
+import { useBoolean } from "./hooks/useBoolean";
 
 export function createWindowEvent<K extends keyof WindowEventMap>(
   type: K,

--- a/shared/email.ts
+++ b/shared/email.ts
@@ -1,4 +1,5 @@
 import sendgrid, { MailDataRequired } from "@sendgrid/mail";
+
 import { assertDefined } from "./assert";
 
 const sendgridApiKey = assertDefined(

--- a/shared/hooks/useAsyncEffect.ts
+++ b/shared/hooks/useAsyncEffect.ts
@@ -1,4 +1,4 @@
-import { useEffect, EffectCallback, DependencyList } from "react";
+import { DependencyList, EffectCallback, useEffect } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 
 type GetIsCancelled = () => boolean;

--- a/shared/hooks/useBoundingBox.ts
+++ b/shared/hooks/useBoundingBox.ts
@@ -1,5 +1,6 @@
 import { RefObject } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
+
 import { useEqualState } from "./useEqualState";
 import { useResizeCallback } from "./useResizeCallback";
 

--- a/shared/hooks/useDebouncedValue.ts
+++ b/shared/hooks/useDebouncedValue.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+
 import { createTimeout } from "~shared/time";
 
 interface Options<T> {

--- a/shared/hooks/useDoubleClick.ts
+++ b/shared/hooks/useDoubleClick.ts
@@ -1,4 +1,5 @@
 import { RefObject, useEffect } from "react";
+
 import { createElementEvent } from "~shared/domEvents";
 import { createTimeout } from "~shared/time";
 

--- a/shared/hooks/useEqualEffect.ts
+++ b/shared/hooks/useEqualEffect.ts
@@ -1,4 +1,5 @@
 import { DependencyList, EffectCallback, useEffect } from "react";
+
 import { useDependencyChangeEffect } from "./useChangeEffect";
 import { useEqualRef } from "./useEqualRef";
 

--- a/shared/hooks/useIsElementOrChildHovered.ts
+++ b/shared/hooks/useIsElementOrChildHovered.ts
@@ -1,5 +1,7 @@
 import { RefObject, useEffect } from "react";
+
 import { createElementEvent } from "~shared/domEvents";
+
 import { useBoolean } from "./useBoolean";
 
 export function useIsElementOrChildHovered(ref: RefObject<HTMLElement>) {

--- a/shared/hooks/useListWithNavigation.ts
+++ b/shared/hooks/useListWithNavigation.ts
@@ -1,4 +1,5 @@
 import { useStateList } from "react-use";
+
 import { useShortcut } from "~ui/keyboard/useShortcut";
 
 interface UseListWithNavigationConfig {

--- a/shared/hooks/useNewItemInArrayEffect.ts
+++ b/shared/hooks/useNewItemInArrayEffect.ts
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+
 import { useDependencyChangeEffect } from "./useChangeEffect";
 import { useMethod } from "./useMethod";
 

--- a/shared/localStorage.ts
+++ b/shared/localStorage.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
+
 import { createChannel } from "./channel";
 import { getJSONValue, typeSafeParseJSON } from "./dates/parseJSONWithDates";
 import { JsonValue } from "./types";
-import { updateValue, ValueUpdater } from "./updateValue";
+import { ValueUpdater, updateValue } from "./updateValue";
 
 type ValueWrapper<T> = { value: T };
 

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -1,7 +1,8 @@
 import "~config/dotenv";
 
-import { Request } from "express";
 import { ServerResponse } from "http";
+
+import { Request } from "express";
 import pino from "pino";
 
 import { assertDefined } from "./assert";

--- a/shared/namedLazy.ts
+++ b/shared/namedLazy.ts
@@ -1,6 +1,7 @@
 import { memoize } from "lodash";
-import { ComponentType, lazy, LazyExoticComponent } from "react";
+import { ComponentType, LazyExoticComponent, lazy } from "react";
 import { PickByValue } from "utility-types";
+
 import { onDocumentReady } from "~shared/document";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/shared/react/namedForwardRef.tsx
+++ b/shared/react/namedForwardRef.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ForwardRefExoticComponent, ForwardRefRenderFunction, PropsWithoutRef, RefAttributes } from "react";
+import { ForwardRefExoticComponent, ForwardRefRenderFunction, PropsWithoutRef, RefAttributes, forwardRef } from "react";
 
 /**
  * Built in forwardRef creates anonymous component which results in bunch of fast-refresh warnings quote:

--- a/shared/search.ts
+++ b/shared/search.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+
 import { isNotNullish } from "./nullish";
 import { Maybe } from "./types";
 

--- a/shared/sharedState.tsx
+++ b/shared/sharedState.tsx
@@ -1,6 +1,8 @@
 import { autorun, computed, configure, makeAutoObservable, runInAction } from "mobx";
-import { createContext, PropsWithChildren, useContext, useEffect } from "react";
+import { PropsWithChildren, createContext, useContext, useEffect } from "react";
+
 import { useConst } from "~shared/hooks/useConst";
+
 import { assert } from "./assert";
 import { useMethod } from "./hooks/useMethod";
 

--- a/tooling/cli-tooling.ts
+++ b/tooling/cli-tooling.ts
@@ -2,11 +2,13 @@
 // TODO: It's a bit awkward.
 process.env.APP = "tooling";
 
+import "~config/dotenv";
+
 import yargs from "yargs";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { hideBin } from "yargs/helpers";
-import "~config/dotenv";
+
 import logger from "~shared/logger";
 
 const tooling = yargs(hideBin(process.argv));

--- a/tooling/fetchSchema.ts
+++ b/tooling/fetchSchema.ts
@@ -1,9 +1,13 @@
-import axios from "axios";
-import fs from "fs";
-import { buildClientSchema, getIntrospectionQuery, printSchema } from "graphql/utilities";
-import path from "path";
 import "~config/dotenv";
+
+import fs from "fs";
+import path from "path";
+
+import axios from "axios";
+import { buildClientSchema, getIntrospectionQuery, printSchema } from "graphql/utilities";
+
 import { log } from "~shared/logger";
+
 import { GQL_PACKAGE_PATH } from "./files";
 
 export interface ProcessEnv {

--- a/tooling/graphqlCodegen.ts
+++ b/tooling/graphqlCodegen.ts
@@ -1,7 +1,10 @@
-import { generate } from "@graphql-codegen/cli";
 import fs from "fs";
 import path from "path";
+
+import { generate } from "@graphql-codegen/cli";
+
 import { log } from "~shared/logger";
+
 import { SCHEMA_FILE_PATH, updateSchemaFile } from "./fetchSchema";
 import { GQL_PACKAGE_PATH, ROOT_PATH } from "./files";
 

--- a/ui/Badge.tsx
+++ b/ui/Badge.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { borderRadius } from "./baseStyles";
 
 export const Badge = styled.div<{}>`

--- a/ui/EmojiPicker/EmojiPickerWindow.tsx
+++ b/ui/EmojiPicker/EmojiPickerWindow.tsx
@@ -1,11 +1,13 @@
 import type { PickerProps } from "emoji-mart";
 import { Suspense, useRef } from "react";
-import styled from "styled-components";
-import { namedLazy } from "~shared/namedLazy";
-import { EmojiMartStyles } from "./styles";
 import { useClickAway } from "react-use";
-import { PresenceAnimator } from "~ui/PresenceAnimator";
+import styled from "styled-components";
+
+import { namedLazy } from "~shared/namedLazy";
 import { POP_ANIMATION_CONFIG, POP_PRESENCE_STYLES } from "~ui/animations";
+import { PresenceAnimator } from "~ui/PresenceAnimator";
+
+import { EmojiMartStyles } from "./styles";
 
 // Emoji picker is quite heavy component due to amount of data. Let's make it lazy component.
 export const EmojiPickerWindowLazy = namedLazy(() => import("emoji-mart"), "Picker");

--- a/ui/EmojiPicker/index.tsx
+++ b/ui/EmojiPicker/index.tsx
@@ -3,9 +3,11 @@ import { AnimatePresence } from "framer-motion";
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useClickAway } from "react-use";
 import styled from "styled-components";
+
 import { namedLazy } from "~shared/namedLazy";
 import { IconEmotionHappy } from "~ui/icons";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
+
 import { EmojiMartStyles } from "./styles";
 
 // Emoji picker is quite heavy component due to amount of data. Let's make it lazy component.

--- a/ui/PresenceAnimator.tsx
+++ b/ui/PresenceAnimator.tsx
@@ -1,7 +1,9 @@
-import { HTMLMotionProps, motion, Target as MotionAnimations } from "framer-motion";
+import { HTMLMotionProps, Target as MotionAnimations, motion } from "framer-motion";
 import styled from "styled-components";
+
 import { objectMap } from "~shared/object";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
+
 import { POP_ANIMATION_CONFIG } from "./animations";
 
 interface Props extends HTMLMotionProps<"div"> {

--- a/ui/SelectList/index.tsx
+++ b/ui/SelectList/index.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
-import { hoverActionCss, hoverActionActiveCss } from "~ui/transitions";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { borderRadius, shadow } from "~ui/baseStyles";
+
 import { useListWithNavigation } from "~shared/hooks/useListWithNavigation";
+import { borderRadius, shadow } from "~ui/baseStyles";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { hoverActionActiveCss, hoverActionCss } from "~ui/transitions";
 
 interface Props<T> {
   items: T[];

--- a/ui/animations.tsx
+++ b/ui/animations.tsx
@@ -1,6 +1,8 @@
-import { Transition, HTMLMotionProps } from "framer-motion";
+import { HTMLMotionProps, Transition } from "framer-motion";
+
 import { namedForwardRef } from "~shared/react/namedForwardRef";
-import { PresenceStyles, PresenceAnimator } from "./PresenceAnimator";
+
+import { PresenceAnimator, PresenceStyles } from "./PresenceAnimator";
 
 export const POP_ANIMATION_CONFIG: Transition = { type: "spring", bounce: 0, duration: 0.2 };
 

--- a/ui/baseStyles.ts
+++ b/ui/baseStyles.ts
@@ -1,5 +1,7 @@
-import { css, StylesPart } from "styled-components";
+import { StylesPart, css } from "styled-components";
+
 import { setColorOpacity } from "~shared/colors";
+
 import { BLACK } from "./theme/colors/base";
 
 function createShadowCss(size: number, opacity = 0.2): StylesPart {

--- a/ui/buttons/Button.tsx
+++ b/ui/buttons/Button.tsx
@@ -1,9 +1,11 @@
 import { HTMLMotionProps, motion } from "framer-motion";
 import { ForwardedRef, ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { disabledOpacityCss } from "~ui/disabled";
 import { theme } from "~ui/theme";
+
 import { buttonKindSpecificStyle, buttonSizeSpecificStyle } from "./sharedStyles";
 import { ButtonIconPosition, ButtonKind, ButtonSize } from "./types";
 

--- a/ui/buttons/CircleCloseIconButton.tsx
+++ b/ui/buttons/CircleCloseIconButton.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+
 import { IconCross } from "~ui/icons";
-import { Props as CircleIconButtonProps, CircleIconButton } from "./CircleIconButton";
+
+import { CircleIconButton, Props as CircleIconButtonProps } from "./CircleIconButton";
 
 export const CircleCloseIconButton = styled(function (props: Omit<CircleIconButtonProps, "icon">) {
   return <CircleIconButton size="medium" icon={<IconCross />} {...props} />;

--- a/ui/buttons/CircleIconButton.tsx
+++ b/ui/buttons/CircleIconButton.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
-import styled, { css, StylesPart } from "styled-components";
+import styled, { StylesPart, css } from "styled-components";
+
 import { theme } from "~ui/theme";
+
 import { ButtonKind, ButtonSize } from "./types";
 
 export interface Props {

--- a/ui/buttons/CollapseToggleButton.tsx
+++ b/ui/buttons/CollapseToggleButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+
 import { CircleIconButton } from "~ui/buttons/CircleIconButton";
 import { IconChevronDown } from "~ui/icons";
 

--- a/ui/buttons/ToggleButton.tsx
+++ b/ui/buttons/ToggleButton.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { theme } from "~ui/theme";
+
 import { buttonKindSpecificStyle, buttonSizeSpecificStyle } from "./sharedStyles";
 
 interface Props {

--- a/ui/buttons/WideIconButton.tsx
+++ b/ui/buttons/WideIconButton.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { theme } from "~ui/theme";
+
 import { buttonKindSpecificStyle } from "./sharedStyles";
 import { ButtonKind } from "./types";
 

--- a/ui/buttons/sharedStyles.ts
+++ b/ui/buttons/sharedStyles.ts
@@ -1,6 +1,8 @@
 import { StylesPart, css } from "styled-components";
+
 import { theme } from "~ui/theme";
-import { ButtonSize, ButtonKind } from "./types";
+
+import { ButtonKind, ButtonSize } from "./types";
 
 export const buttonSizeSpecificStyle: Partial<Record<ButtonSize, StylesPart>> = {
   small: css`

--- a/ui/card/Base.tsx
+++ b/ui/card/Base.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { theme } from "~ui/theme";
 
 export const CardBase = styled.div<{ isClickable?: boolean }>`

--- a/ui/collapse/CollapsePanel.tsx
+++ b/ui/collapse/CollapsePanel.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { ReactNode, useRef, useState } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 import styled from "styled-components";
+
 import { getFocusedElement } from "~shared/focus";
 import { useDependencyChangeEffect } from "~shared/hooks/useChangeEffect";
 import { useIsElementOrChildHovered } from "~shared/hooks/useIsElementOrChildHovered";

--- a/ui/createPromiseUI.tsx
+++ b/ui/createPromiseUI.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 import { ReactNode } from "react";
+
 import { createChannel } from "~shared/channel";
 
 /**

--- a/ui/empty/EmptyStatePlaceholder.tsx
+++ b/ui/empty/EmptyStatePlaceholder.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { IconSelection } from "~ui/icons";
 import { theme } from "~ui/theme";
 

--- a/ui/field.tsx
+++ b/ui/field.tsx
@@ -1,5 +1,6 @@
 import { ChangeEventHandler, InputHTMLAttributes, RefObject, useCallback, useRef, useState } from "react";
 import styled from "styled-components";
+
 import { borderRadius } from "./baseStyles";
 
 export const Field = styled.input<{}>`

--- a/ui/forms/EditableText.tsx
+++ b/ui/forms/EditableText.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useClickAway, useIsomorphicLayoutEffect } from "react-use";
 import styled, { css } from "styled-components";
+
 import { createDocumentEvent, useElementEvent } from "~shared/domEvents";
 import { useShortcut } from "~ui/keyboard/useShortcut";
 

--- a/ui/forms/FieldWithLabel.tsx
+++ b/ui/forms/FieldWithLabel.tsx
@@ -1,12 +1,13 @@
 import { AnimateSharedLayout, motion } from "framer-motion";
 import { ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { useId } from "~shared/id";
+import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { POP_ANIMATION_CONFIG } from "~ui/animations";
 import { borderRadius } from "~ui/baseStyles";
-import { BACKGROUND_ACCENT, SECONDARY_TEXT_COLOR, WHITE } from "~ui/theme/colors/base";
 import { IconChevronDown } from "~ui/icons";
-import { namedForwardRef } from "~shared/react/namedForwardRef";
+import { BACKGROUND_ACCENT, SECONDARY_TEXT_COLOR, WHITE } from "~ui/theme/colors/base";
 
 type CursorType = "action" | "input";
 export interface Props {

--- a/ui/forms/InputError.tsx
+++ b/ui/forms/InputError.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
+
 import { fontSize } from "~ui/baseStyles";
-import { DANGER_COLOR } from "~ui/theme/colors/base";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
+import { DANGER_COLOR } from "~ui/theme/colors/base";
 
 interface Props {
   message: string;

--- a/ui/forms/OptionsDropdown/DropdownItem.tsx
+++ b/ui/forms/OptionsDropdown/DropdownItem.tsx
@@ -1,11 +1,13 @@
 import React, { ReactNode } from "react";
 import styled, { css } from "styled-components";
+
 import { setColorOpacity } from "~shared/colors";
 import { handleWithStopPropagation } from "~shared/events";
-import { PRIMARY_PINK_1 } from "~ui/theme/colors/base";
 import { IconCheck } from "~ui/icons";
-import { OptionLabel } from "./OptionLabel";
 import { theme } from "~ui/theme";
+import { PRIMARY_PINK_1 } from "~ui/theme/colors/base";
+
+import { OptionLabel } from "./OptionLabel";
 
 interface Props {
   label: string;

--- a/ui/forms/OptionsDropdown/ItemsDropdown.tsx
+++ b/ui/forms/OptionsDropdown/ItemsDropdown.tsx
@@ -1,13 +1,15 @@
 import React, { ReactNode, useRef } from "react";
 import { useClickAway, useWindowSize } from "react-use";
 import styled, { css } from "styled-components";
-import { useListWithNavigation } from "~shared/hooks/useListWithNavigation";
-import { borderRadius, shadow } from "~ui/baseStyles";
-import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
-import { PopPresenceAnimator } from "~ui/animations";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { DropdownItem } from "./DropdownItem";
+
 import { useBoundingBox } from "~shared/hooks/useBoundingBox";
+import { useListWithNavigation } from "~shared/hooks/useListWithNavigation";
+import { PopPresenceAnimator } from "~ui/animations";
+import { borderRadius, shadow } from "~ui/baseStyles";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
+
+import { DropdownItem } from "./DropdownItem";
 
 interface Props<I> {
   items: I[];

--- a/ui/forms/OptionsDropdown/OptionLabel.tsx
+++ b/ui/forms/OptionsDropdown/OptionLabel.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
+
 import { TextBody } from "~ui/typo";
 
 interface Props {

--- a/ui/forms/OptionsDropdown/SelectedOptionPreview.tsx
+++ b/ui/forms/OptionsDropdown/SelectedOptionPreview.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+
 import { borderRadius } from "~ui/baseStyles";
 import { SELECTED_ITEM_COLOR } from "~ui/theme/colors/base";
+
 import { OptionLabel } from "./OptionLabel";
 
 export const SelectedOptionPreview = styled(OptionLabel)<{}>`

--- a/ui/forms/OptionsDropdown/multiple.tsx
+++ b/ui/forms/OptionsDropdown/multiple.tsx
@@ -1,10 +1,12 @@
 import { AnimatePresence } from "framer-motion";
 import React, { ReactNode, useRef } from "react";
 import styled from "styled-components";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { useBoundingBox } from "~shared/hooks/useBoundingBox";
 import { IconPlus } from "~ui/icons";
 import { Popover } from "~ui/popovers/Popover";
+
 import { FieldWithLabel } from "../FieldWithLabel";
 import { DropdownItem } from "./DropdownItem";
 import { ItemsDropdown } from "./ItemsDropdown";

--- a/ui/forms/OptionsDropdown/single.tsx
+++ b/ui/forms/OptionsDropdown/single.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode } from "react";
+
 import { TextBody } from "~ui/typo";
+
 import { MultipleOptionsDropdown } from "./multiple";
 import { OptionLabel } from "./OptionLabel";
 

--- a/ui/forms/RoundedTextInput.tsx
+++ b/ui/forms/RoundedTextInput.tsx
@@ -1,9 +1,10 @@
-import { ComponentPropsWithoutRef, ReactNode, ChangeEvent, useRef } from "react";
+import { ChangeEvent, ComponentPropsWithoutRef, ReactNode, useRef } from "react";
 import styled from "styled-components";
+
+import { combineCallbacks } from "~shared/callbacks/combineCallbacks";
 import { borderRadius } from "~ui/baseStyles";
 import { BASE_GREY_1, BASE_GREY_3, BASE_GREY_5, BASE_GREY_6, PRIMARY_PINK_1, WHITE } from "~ui/theme/colors/base";
 import { hoverTransition } from "~ui/transitions";
-import { combineCallbacks } from "~shared/callbacks/combineCallbacks";
 
 interface Props extends ComponentPropsWithoutRef<"input"> {
   onChangeText?: (text: string) => void;

--- a/ui/forms/SearchInput.tsx
+++ b/ui/forms/SearchInput.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+
 import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { IconSearch } from "~ui/icons";
+
 import { TextInput, TextInputProps } from "./TextInput";
 
 interface Props extends TextInputProps {

--- a/ui/forms/TextArea.tsx
+++ b/ui/forms/TextArea.tsx
@@ -1,7 +1,9 @@
-import React, { InputHTMLAttributes, useState, useEffect } from "react";
+import React, { InputHTMLAttributes, useEffect, useState } from "react";
 import styled from "styled-components";
+
 import { useSharedRef } from "~shared/hooks/useSharedRef";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
+
 import { baseInputStyles } from "./utils";
 
 export interface TextAreaProps extends InputHTMLAttributes<HTMLTextAreaElement> {

--- a/ui/forms/TextInput.tsx
+++ b/ui/forms/TextInput.tsx
@@ -1,9 +1,11 @@
 import { HTMLMotionProps, motion } from "framer-motion";
 import { ChangeEvent, ReactNode } from "react";
 import styled from "styled-components";
+
 import { combineCallbacks } from "~shared/callbacks/combineCallbacks";
 import { useSharedRef } from "~shared/hooks/useSharedRef";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
+
 import { FieldWithLabel } from "./FieldWithLabel";
 
 export interface TextInputProps extends HTMLMotionProps<"input"> {

--- a/ui/forms/utils.ts
+++ b/ui/forms/utils.ts
@@ -1,4 +1,5 @@
 import { css } from "styled-components";
+
 import { borderRadius } from "~ui/baseStyles";
 
 export const baseInputStyles = css`

--- a/ui/icons/CircleLabel.tsx
+++ b/ui/icons/CircleLabel.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { borderRadius, fontSize } from "~ui/baseStyles";
-import { PRIMARY_COLOR } from "~ui/theme/colors/base";
 import { NamedSize, getNamedSizeSquareStyles } from "~ui/namedSize";
+import { PRIMARY_COLOR } from "~ui/theme/colors/base";
 import { getTextColorForBackgroundColor } from "~ui/transitions";
 
 interface Props {

--- a/ui/keyboard/useShortcut.tsx
+++ b/ui/keyboard/useShortcut.tsx
@@ -1,11 +1,13 @@
-import { convertMaybeArrayToArray, removeElementFromArray } from "~shared/array";
-import { Key } from "./codes";
 import isHotkey from "is-hotkey";
+import { sortBy } from "lodash";
 import { useEffect } from "react";
+
+import { convertMaybeArrayToArray, removeElementFromArray } from "~shared/array";
 import { createCleanupObject } from "~shared/cleanup";
 import { onDocumentReady } from "~shared/document";
 import { mapGetOrCreate } from "~shared/map";
-import { sortBy } from "lodash";
+
+import { Key } from "./codes";
 
 type ShortcutDefinition = Key | Key[];
 

--- a/ui/media/AudioPlayer.tsx
+++ b/ui/media/AudioPlayer.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
+
 import { useSharedRef } from "~shared/hooks/useSharedRef";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
 import { TranscriptData } from "~shared/types/transcript";
+
 import { PlaybackControls } from "./PlaybackControls";
 import { defaultAllowedPlaybackRates } from "./playbackRates";
 import { usePlaybackState } from "./usePlaybackState";

--- a/ui/media/PlaybackControls.tsx
+++ b/ui/media/PlaybackControls.tsx
@@ -1,11 +1,13 @@
 import { AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { MouseEvent } from "react";
 import styled from "styled-components";
+
 import { handleWithStopPropagation } from "~shared/events";
 import { PopPresenceAnimator } from "~ui/animations";
 import { IconPause, IconPlay } from "~ui/icons";
 import { theme } from "~ui/theme";
-import { motion } from "framer-motion";
+
 import { PlaybackRateButton } from "./PlaybackRateButton";
 
 interface Props {

--- a/ui/media/PlaybackRateButton.tsx
+++ b/ui/media/PlaybackRateButton.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { getNextItemInArray } from "~shared/array";
 import { handleWithStopPropagation } from "~shared/events";
 import { theme } from "~ui/theme";

--- a/ui/media/VideoPlayer.tsx
+++ b/ui/media/VideoPlayer.tsx
@@ -1,17 +1,19 @@
+import { AnimatePresence } from "framer-motion";
+import { useRef } from "react";
 import styled from "styled-components";
+
+import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
+import { useIsElementOrChildHovered } from "~shared/hooks/useIsElementOrChildHovered";
 import { useSharedRef } from "~shared/hooks/useSharedRef";
 import { namedForwardRef } from "~shared/react/namedForwardRef";
-import { theme } from "~ui/theme";
 import { TranscriptData } from "~shared/types/transcript";
+import { PopPresenceAnimator } from "~ui/animations";
+import { useShortcut } from "~ui/keyboard/useShortcut";
+import { theme } from "~ui/theme";
+
 import { PlaybackControls } from "./PlaybackControls";
 import { defaultAllowedPlaybackRates } from "./playbackRates";
 import { usePlaybackState } from "./usePlaybackState";
-import { useRef } from "react";
-import { useIsElementOrChildHovered } from "~shared/hooks/useIsElementOrChildHovered";
-import { useShortcut } from "~ui/keyboard/useShortcut";
-import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
-import { AnimatePresence } from "framer-motion";
-import { PopPresenceAnimator } from "~ui/animations";
 
 interface Props {
   fileUrl: string;

--- a/ui/media/usePlaybackState.ts
+++ b/ui/media/usePlaybackState.ts
@@ -1,8 +1,10 @@
 import { RefObject, useEffect, useState } from "react";
+
 import { createCleanupObject } from "~shared/cleanup";
 import { createElementEvent } from "~shared/domEvents";
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { createLocalStorageValueManager } from "~shared/localStorage";
+
 import { MediaElement } from "./types";
 
 /**

--- a/ui/popovers/DropdownPanelBody.tsx
+++ b/ui/popovers/DropdownPanelBody.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { PopPresenceAnimator } from "~ui/animations";
 import { borderRadius, shadow } from "~ui/baseStyles";
 import { BASE_GREY_5, WHITE } from "~ui/theme/colors/base";

--- a/ui/popovers/Popover.tsx
+++ b/ui/popovers/Popover.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, RefObject, useState } from "react";
 import { usePopper } from "react-popper";
 import { useClickAway } from "react-use";
 import styled from "styled-components";
+
 import { ScreenCover } from "~frontend/src/ui/Modal/ScreenCover";
 import { useRefValue } from "~shared/hooks/useRefValue";
 import { useResizeCallback } from "~shared/hooks/useResizeCallback";

--- a/ui/popovers/PopoverMenu.tsx
+++ b/ui/popovers/PopoverMenu.tsx
@@ -1,10 +1,12 @@
 import React, { ReactNode, RefObject } from "react";
 import { useClickAway } from "react-use";
 import styled, { css } from "styled-components";
+
 import { ScreenCover } from "~frontend/src/ui/Modal/ScreenCover";
 import { borderRadius, fontSize } from "~ui/baseStyles";
 import { BASE_GREY_1, DANGER_COLOR, PRIMARY_PINK_1_TRANSPARENT, PRIMARY_PINK_2 } from "~ui/theme/colors/base";
 import { hoverTransition } from "~ui/transitions";
+
 import { UIDropdownPanelBody } from "./DropdownPanelBody";
 import { Popover, PopoverPlacement } from "./Popover";
 

--- a/ui/popovers/PopoverMenuTrigger.tsx
+++ b/ui/popovers/PopoverMenuTrigger.tsx
@@ -2,9 +2,11 @@ import { AnimatePresence } from "framer-motion";
 import React, { ReactNode, useRef } from "react";
 import { useClickAway } from "react-use";
 import styled from "styled-components";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { useDependencyChangeEffect } from "~shared/hooks/useChangeEffect";
 import { zIndex } from "~ui/zIndex";
+
 import { PopoverPlacement } from "./Popover";
 import { PopoverMenu, PopoverMenuOption } from "./PopoverMenu";
 

--- a/ui/popovers/SelectionPopover.tsx
+++ b/ui/popovers/SelectionPopover.tsx
@@ -3,6 +3,7 @@ import { throttle } from "lodash";
 import React, { ReactNode, useEffect, useState } from "react";
 import { usePopper } from "react-popper";
 import styled, { css } from "styled-components";
+
 import { createCleanupObject } from "~shared/cleanup";
 import { createDocumentEvent } from "~shared/domEvents";
 import { useResizeCallback } from "~shared/hooks/useResizeCallback";

--- a/ui/popovers/Tooltip.tsx
+++ b/ui/popovers/Tooltip.tsx
@@ -1,11 +1,13 @@
+import { AnimatePresence } from "framer-motion";
 import React from "react";
 import styled from "styled-components";
+
 import { createChannel } from "~shared/channel";
 import { createDocumentEvent, createWindowEvent, useElementEvent } from "~shared/domEvents";
-import { useId } from "~shared/id";
-import { AnimatePresence } from "framer-motion";
-import { TooltipLabel, TooltipLabelProps } from "./TooltipLabel";
 import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
+import { useId } from "~shared/id";
+
+import { TooltipLabel, TooltipLabelProps } from "./TooltipLabel";
 
 /**
  * Having shared channel instead of 'isOpened' local state ensures there is never more than 1 tooltips opened at once

--- a/ui/popovers/TooltipLabel.tsx
+++ b/ui/popovers/TooltipLabel.tsx
@@ -1,8 +1,10 @@
 import React, { ReactNode, RefObject } from "react";
 import styled from "styled-components";
+
 import { POP_PRESENCE_STYLES } from "~ui/animations";
 import { borderRadius, colors, fontSize } from "~ui/baseStyles";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
+
 import { Popover, PopoverPlacement } from "./Popover";
 
 export interface TooltipLabelProps {

--- a/ui/popovers/TooltipsRenderer.tsx
+++ b/ui/popovers/TooltipsRenderer.tsx
@@ -1,9 +1,11 @@
-import { RefObject, useEffect, useRef, useState } from "react";
-import { useDebouncedDocumentEvent, useDocumentEvent } from "~shared/domEvents";
-import { TooltipLabel } from "./TooltipLabel";
 import { AnimatePresence } from "framer-motion";
+import { RefObject, useEffect, useRef, useState } from "react";
+
+import { useDebouncedDocumentEvent, useDocumentEvent } from "~shared/domEvents";
 import { useDebouncedValue } from "~shared/hooks/useDebouncedValue";
 import { getObjectKey } from "~shared/object";
+
+import { TooltipLabel } from "./TooltipLabel";
 
 /**
  * This component will handle showing tooltips for every element that has html `data-tooltip` attribute.

--- a/ui/styleHelpers.ts
+++ b/ui/styleHelpers.ts
@@ -1,4 +1,4 @@
-import { css, StaticInterpolation } from "styled-components";
+import { StaticInterpolation, css } from "styled-components";
 
 export function propValueStyles<P, K extends keyof P>(name: K, value: P[K], styles: StaticInterpolation | string) {
   return function applied(props: P): StaticInterpolation | undefined {

--- a/ui/tags/index.tsx
+++ b/ui/tags/index.tsx
@@ -1,8 +1,10 @@
-import styled from "styled-components";
-import { PRIMARY_PINK_3 } from "../theme/colors/base";
 import { ReactNode } from "react";
+import styled from "styled-components";
+
 import { setColorOpacity } from "~shared/colors";
 import { borderRadius } from "~ui/baseStyles";
+
+import { PRIMARY_PINK_3 } from "../theme/colors/base";
 
 interface TagProps {
   color: string;

--- a/ui/theme/actions/styleBuilder.ts
+++ b/ui/theme/actions/styleBuilder.ts
@@ -1,4 +1,5 @@
-import { css, StylesPart, StaticInterpolation } from "styled-components";
+import { StaticInterpolation, StylesPart, css } from "styled-components";
+
 import { ColorTargetOptions, VariantStates } from "../colors";
 
 export interface ActionStateInterpolations {

--- a/ui/theme/colors/default.ts
+++ b/ui/theme/colors/default.ts
@@ -1,7 +1,8 @@
-import { ThemeColorScheme } from ".";
 import { setColorOpacity } from "~shared/colors";
+
 import * as colors from "./base";
 import { createColor } from "./createColor";
+import { ThemeColorScheme } from ".";
 
 export const defaultTheme: ThemeColorScheme = {
   layout: {

--- a/ui/theme/colors/index.ts
+++ b/ui/theme/colors/index.ts
@@ -1,6 +1,6 @@
-import { Variant } from "..";
 import { ColorGetter } from "./createColor";
 import { defaultTheme } from "./default";
+import { Variant } from "..";
 
 export interface VariantStates {
   regular: ColorTargetOptions;

--- a/ui/theme/font.ts
+++ b/ui/theme/font.ts
@@ -1,6 +1,7 @@
-import { css, StylesPart } from "styled-components";
-import { markAsNotTerminal } from "~ui/theme/proxy/nonTerminal";
 import { noop } from "lodash";
+import { StylesPart, css } from "styled-components";
+
+import { markAsNotTerminal } from "~ui/theme/proxy/nonTerminal";
 
 export interface Font {
   spezia: Font;

--- a/ui/theme/functional.ts
+++ b/ui/theme/functional.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { theme } from "~ui/theme";
 import { PRIMARY_PINK_1, PRIMARY_TEAL_1 } from "~ui/theme/colors/base";
 

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -1,10 +1,12 @@
 import { StylesPart } from "styled-components";
+
 import { borderRadius, shadow } from "~ui/baseStyles";
 import { spacer } from "~ui/spacer";
 import { hoverTransition } from "~ui/transitions";
 import { zIndex } from "~ui/zIndex";
+
 import { ActionStateInterpolations, variantToStyles } from "./actions/styleBuilder";
-import { getColorTheme, ThemeColorScheme, ThemeColorSchemeName } from "./colors";
+import { ThemeColorScheme, ThemeColorSchemeName, getColorTheme } from "./colors";
 import { Font, font } from "./font";
 import { buildThemeProxy } from "./proxy";
 

--- a/ui/theme/proxy/index.ts
+++ b/ui/theme/proxy/index.ts
@@ -1,7 +1,8 @@
 import { get, isFunction, isPlainObject } from "lodash";
 import DeepProxy from "proxy-deep";
-import { Theme } from "..";
+
 import { getIsTerminal } from "./nonTerminal";
+import { Theme } from "..";
 
 /*
  * Creates an access layer that allows us to easily use the theme provided to the styled-components context.

--- a/ui/theme/typography.tsx
+++ b/ui/theme/typography.tsx
@@ -1,5 +1,6 @@
-import styled, { css, StylesPart } from "styled-components";
 import { motion } from "framer-motion";
+import styled, { StylesPart, css } from "styled-components";
+
 import { typedKeys } from "~shared/object";
 import { BASE_GREY_1, BASE_GREY_3, PRIMARY_PINK_1, WARNING_COLOR } from "~ui/theme/colors/base";
 

--- a/ui/time/Calendar/Header.tsx
+++ b/ui/time/Calendar/Header.tsx
@@ -2,6 +2,7 @@ import { addMonths, format, isSameMonth, startOfMonth, subMonths } from "date-fn
 import { AnimatePresence } from "framer-motion";
 import React from "react";
 import styled from "styled-components";
+
 import { PopPresenceAnimator } from "~ui/animations";
 import { WideIconButton } from "~ui/buttons/WideIconButton";
 import { IconCalendar, IconChevronLeft, IconChevronRight } from "~ui/icons";

--- a/ui/time/Calendar/MonthDays/Week/Day.tsx
+++ b/ui/time/Calendar/MonthDays/Week/Day.tsx
@@ -1,9 +1,10 @@
 import { format, isSameDay, isSameMonth } from "date-fns";
 import React from "react";
 import styled, { css } from "styled-components";
+
+import { Button } from "~ui/buttons/Button";
 import { ACTIVE_COLOR } from "~ui/theme/colors/base";
 import { getButtonColorStyles } from "~ui/transitions";
-import { Button } from "~ui/buttons/Button";
 
 interface Props {
   dayDate: Date;

--- a/ui/time/Calendar/MonthDays/Week/index.tsx
+++ b/ui/time/Calendar/MonthDays/Week/index.tsx
@@ -2,6 +2,7 @@ import { eachDayOfInterval, endOfWeek, isSameDay } from "date-fns";
 import { startOfWeek } from "date-fns";
 import React from "react";
 import styled from "styled-components";
+
 import { Day } from "./Day";
 
 interface Props {

--- a/ui/time/Calendar/MonthDays/WeekDayNames.tsx
+++ b/ui/time/Calendar/MonthDays/WeekDayNames.tsx
@@ -1,6 +1,7 @@
+import { eachDayOfInterval, endOfWeek, format, startOfWeek } from "date-fns";
 import React from "react";
-import { startOfWeek, endOfWeek, eachDayOfInterval, format } from "date-fns";
 import styled from "styled-components";
+
 import { TextBody12 } from "~ui/typo";
 
 const now = new Date();

--- a/ui/time/Calendar/MonthDays/index.tsx
+++ b/ui/time/Calendar/MonthDays/index.tsx
@@ -1,6 +1,7 @@
 import { eachWeekOfInterval, endOfMonth, startOfMonth } from "date-fns";
 import React from "react";
 import styled, { css } from "styled-components";
+
 import { Week } from "./Week";
 import { WeekDaysNames } from "./WeekDayNames";
 

--- a/ui/time/Calendar/index.tsx
+++ b/ui/time/Calendar/index.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
+import styled from "styled-components";
+
+import { trackEvent } from "~frontend/analytics/tracking";
+
 import { Header } from "./Header";
 import { MonthDays } from "./MonthDays";
-import styled from "styled-components";
-import { trackEvent } from "~frontend/analytics/tracking";
 
 interface Props {
   date: Date;

--- a/ui/time/DateLabel.tsx
+++ b/ui/time/DateLabel.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { niceFormatTime, relativeFormatDate } from "~shared/dates/format";
 
 interface Props {

--- a/ui/time/DateTimeInput.tsx
+++ b/ui/time/DateTimeInput.tsx
@@ -1,11 +1,13 @@
 import { AnimatePresence } from "framer-motion";
 import React, { useRef } from "react";
 import styled from "styled-components";
+
 import { useBoolean } from "~shared/hooks/useBoolean";
 import { FieldWithLabel } from "~ui/forms/FieldWithLabel";
 import { IconCalendar } from "~ui/icons";
 import { Popover } from "~ui/popovers/Popover";
 import { TextBody } from "~ui/typo";
+
 import { DateTimePicker } from "./DateTimePicker";
 
 interface Props {

--- a/ui/time/DateTimePicker/TimePicker/index.tsx
+++ b/ui/time/DateTimePicker/TimePicker/index.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useMemo, useRef } from "react";
 import { addMinutes, format, minutesInHour, startOfDay } from "date-fns";
-import { RadioOption } from "~ui/forms/RadioOption";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useRendersCount } from "react-use";
-import { TextBody } from "~ui/typo";
 import styled from "styled-components";
+
+import { RadioOption } from "~ui/forms/RadioOption";
+import { TextBody } from "~ui/typo";
 
 interface Props {
   value: number;

--- a/ui/time/DateTimePicker/index.tsx
+++ b/ui/time/DateTimePicker/index.tsx
@@ -1,12 +1,14 @@
+import { addMinutes, getHours, getMinutes, minutesInHour, startOfDay } from "date-fns";
 import React, { useMemo, useState } from "react";
-import { getMinutes, getHours, minutesInHour, addMinutes, startOfDay } from "date-fns";
 import styled from "styled-components";
-import { Calendar } from "~ui/time/Calendar";
-import { TimePicker } from "./TimePicker";
-import { Button } from "~ui/buttons/Button";
-import { borderRadius, shadow } from "~ui/baseStyles";
-import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
+
 import { PopPresenceAnimator } from "~ui/animations";
+import { borderRadius, shadow } from "~ui/baseStyles";
+import { Button } from "~ui/buttons/Button";
+import { BACKGROUND_ACCENT } from "~ui/theme/colors/base";
+import { Calendar } from "~ui/time/Calendar";
+
+import { TimePicker } from "./TimePicker";
 
 interface Props {
   initialValue: Date;

--- a/ui/toasts/ToastLabel.tsx
+++ b/ui/toasts/ToastLabel.tsx
@@ -1,13 +1,15 @@
+import { ReactNode } from "react";
 import styled from "styled-components";
+
 import { getObjectKey } from "~shared/object";
 import { POP_PRESENCE_STYLES } from "~ui/animations";
 import { borderRadius } from "~ui/baseStyles";
-import { PresenceAnimator } from "~ui/PresenceAnimator";
-import { ToastData, ToastType } from "./data";
 import { CircleCloseIconButton } from "~ui/buttons/CircleCloseIconButton";
-import { theme } from "~ui/theme";
-import { ReactNode } from "react";
 import { IconAlertCircle, IconAlertTriangle, IconCheckCircle } from "~ui/icons";
+import { PresenceAnimator } from "~ui/PresenceAnimator";
+import { theme } from "~ui/theme";
+
+import { ToastData, ToastType } from "./data";
 
 interface Props {
   toast: ToastData;

--- a/ui/toasts/ToastsRenderer.tsx
+++ b/ui/toasts/ToastsRenderer.tsx
@@ -1,10 +1,12 @@
-import styled from "styled-components";
-import { BodyPortal } from "~ui/BodyPortal";
-import { useToasts, removeToast } from "./data";
-import { ToastLabel } from "./ToastLabel";
 import { AnimatePresence } from "framer-motion";
+import styled from "styled-components";
+
 import { getObjectKey } from "~shared/object";
+import { BodyPortal } from "~ui/BodyPortal";
 import { zIndex } from "~ui/zIndex";
+
+import { removeToast, useToasts } from "./data";
+import { ToastLabel } from "./ToastLabel";
 
 export function ToastsRenderer() {
   const toasts = useToasts();

--- a/ui/toasts/data.tsx
+++ b/ui/toasts/data.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+
 import { createChannel } from "~shared/channel";
 import { createTimeout } from "~shared/time";
 

--- a/ui/toggle/index.tsx
+++ b/ui/toggle/index.tsx
@@ -1,7 +1,9 @@
 import React, { ChangeEvent } from "react";
 import styled from "styled-components";
+
 import { useId } from "~shared/id";
 import { getColorHoverVariant } from "~ui/transitions";
+
 import { BACKGROUND_ACCENT, BUTTON_BACKGROUND_COLOR, WHITE } from "../theme/colors/base";
 
 /**

--- a/ui/transitions.ts
+++ b/ui/transitions.ts
@@ -1,5 +1,7 @@
 import { css } from "styled-components";
+
 import { changeColorLightness, isColorDark } from "~shared/colors";
+
 import { BUTTON_ACCENT_COLOR, WHITE } from "./theme/colors/base";
 
 export function hoverTransition(propName = "all") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.5.tgz#8ef4c18e58e801c5c95d3c1c0f2874a2680fadea"
   integrity sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
 
+"@babel/compat-data@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
+  integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
+
 "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
@@ -89,6 +94,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.2.2":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.0.tgz#749e57c68778b73ad8082775561f67f5196aafa8"
+  integrity sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-compilation-targets" "^7.15.0"
+    "@babel/helper-module-transforms" "^7.15.0"
+    "@babel/helpers" "^7.14.8"
+    "@babel/parser" "^7.15.0"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.12.13", "@babel/generator@^7.14.5", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
@@ -107,6 +133,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.0.tgz#a7d0c172e0d814974bad5aa77ace543b97917f15"
+  integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
+  dependencies:
+    "@babel/types" "^7.15.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz#7bf478ec3b71726d56a8ca5775b046fc29879e61"
@@ -120,6 +155,16 @@
   integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
   dependencies:
     "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz#973df8cbd025515f3ff25db0c05efc704fa79818"
+  integrity sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==
+  dependencies:
+    "@babel/compat-data" "^7.15.0"
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.16.6"
     semver "^6.3.0"
@@ -185,6 +230,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-member-expression-to-functions@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz#0ddaf5299c8179f27f37327936553e9bba60990b"
+  integrity sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==
+  dependencies:
+    "@babel/types" "^7.15.0"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
@@ -220,6 +272,20 @@
     "@babel/traverse" "^7.14.8"
     "@babel/types" "^7.14.8"
 
+"@babel/helper-module-transforms@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz#679275581ea056373eddbe360e1419ef23783b08"
+  integrity sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.15.0"
+    "@babel/helper-simple-access" "^7.14.8"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.9"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
+
 "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
@@ -241,6 +307,16 @@
     "@babel/helper-optimise-call-expression" "^7.14.5"
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
+
+"@babel/helper-replace-supers@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz#ace07708f5bf746bf2e6ba99572cce79b5d4e7f4"
+  integrity sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.15.0"
+    "@babel/helper-optimise-call-expression" "^7.14.5"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
 
 "@babel/helper-simple-access@^7.14.5":
   version "7.14.5"
@@ -321,6 +397,11 @@
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
   integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
+
+"@babel/parser@^7.0.0-beta.54", "@babel/parser@^7.15.0":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
+  integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
 "@babel/parser@^7.14.8", "@babel/parser@^7.14.9":
   version "7.14.9"
@@ -775,6 +856,21 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.0.0-beta.54", "@babel/traverse@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.0.tgz#4cca838fd1b2a03283c1f38e141f639d60b3fc98"
+  integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.14.8":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.9.tgz#016126b331210bf06fff29d52971eef8383e556f"
@@ -814,6 +910,14 @@
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0-beta.54", "@babel/types@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.14.8", "@babel/types@^7.14.9":
@@ -4140,6 +4244,11 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+builtin-modules@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -4175,6 +4284,25 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -4778,6 +4906,27 @@ cosmiconfig@7.0.0, cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^5.0.5:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -5257,6 +5406,11 @@ detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -6152,6 +6306,11 @@ find-cache-dir@3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-line-column@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/find-line-column/-/find-line-column-0.5.2.tgz#db00238ff868551a182e74a103416d295a98c8ca"
+  integrity sha1-2wAjj/hoVRoYLnShA0FtKVqYyMo=
+
 find-node-modules@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/find-node-modules/-/find-node-modules-2.1.2.tgz#57565a3455baf671b835bc6b2134a9b938b9c53c"
@@ -6160,7 +6319,7 @@ find-node-modules@^2.1.2:
     findup-sync "^4.0.0"
     merge "^2.1.0"
 
-find-root@1.1.0:
+find-root@1.1.0, find-root@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
@@ -7002,7 +7161,15 @@ immutable@~3.7.6:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -7024,6 +7191,62 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
+
+import-sort-config@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort-config/-/import-sort-config-6.0.0.tgz#7313775b761eb479ab2d383945ecb15c008763b8"
+  integrity sha512-FJpF2F3+30JXqH1rJKeajxoSCHCueai3/0ntDN4y3GJL5pjnLDt/VjCy5FzjH7u0NHnllL/zVEf1wfmsVxJlPQ==
+  dependencies:
+    cosmiconfig "^5.0.5"
+    find-root "^1.0.0"
+    minimatch "^3.0.4"
+    resolve-from "^4.0.0"
+
+import-sort-parser-babylon@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort-parser-babylon/-/import-sort-parser-babylon-6.0.0.tgz#e1a4c28e0794ad7d9ff36cd045559d8ca8c38be7"
+  integrity sha512-NyShTiNhTh4Vy7kJUVe6CuvOaQAzzfSIT72wtp3CzGjz8bHjNj59DCAjncuviicmDOgVAgmLuSh1WMcLYAMWGg==
+  dependencies:
+    "@babel/core" "^7.2.2"
+    "@babel/parser" "^7.0.0-beta.54"
+    "@babel/traverse" "^7.0.0-beta.54"
+    "@babel/types" "^7.0.0-beta.54"
+    find-line-column "^0.5.2"
+
+import-sort-parser-typescript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort-parser-typescript/-/import-sort-parser-typescript-6.0.0.tgz#98e73cef9e077d073e798722ed59e215b51c17e2"
+  integrity sha512-pgxnr3I156DonupQriNsgDb2zJN9TxrqCCIN1rwT/6SDO1rkJb+a0fjqshCjlgacTSA92oPAp1eAwmQUeZi3dw==
+  dependencies:
+    typescript "^3.2.4"
+
+import-sort-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort-parser/-/import-sort-parser-6.0.0.tgz#0d901f264d98ed7caaae71f66128a686f828f2f4"
+  integrity sha512-H5L+d6HnqHvThB0GmAA3/43Sv74oCwL0iMk3/ixOv0LRJ69rCyHXeG/+UadMHrD2FefEmgPIWboEPAG7gsQrkA==
+
+import-sort-style-module-and-prefix@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/import-sort-style-module-and-prefix/-/import-sort-style-module-and-prefix-0.1.3.tgz#3d2792ea1c9b95195726e3ad1d9d2aca94ef917f"
+  integrity sha512-R6NuUkLZwc3o+D68iyL5LJkhBow86r0WDVgFmW6nxQY1X3TAXSUlQWtPdeBsOsbsKxBELK9VQlPTjIZZV+hWBg==
+  dependencies:
+    cosmiconfig "^6.0.0"
+
+import-sort-style@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort-style/-/import-sort-style-6.0.0.tgz#088523f056e5064c34a6426f4733674d81b42e6a"
+  integrity sha512-z0H5PKs7YoDeKxNYXv2AA1mjjZFY07fjeNCXUdTM3ymJtWeeEoTm8CQkFm2l+KPZoMczIvdwzJpWkkOamBnsPw==
+
+import-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/import-sort/-/import-sort-6.0.0.tgz#48ba2a7b53f2566ca1dd004327ea271321ad64ff"
+  integrity sha512-XUwSQMGAGmcW/wfshFE0gXgb1NPF6ibbQD6wDr3KRDykZf/lZj0jf58Bwa02xNb8EE59oz7etFe9OHnJocUW5Q==
+  dependencies:
+    detect-newline "^2.1.0"
+    import-sort-parser "^6.0.0"
+    import-sort-style "^6.0.0"
+    is-builtin-module "^3.0.0"
+    resolve "^1.8.1"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -7235,6 +7458,13 @@ is-buffer@~1.1.6:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-builtin-module@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.1.0.tgz#6fdb24313b1c03b75f8b9711c0feb8c30b903b00"
+  integrity sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==
+  dependencies:
+    builtin-modules "^3.0.0"
+
 is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
@@ -7258,6 +7488,11 @@ is-date-object@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
   integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
   version "2.2.1"
@@ -8144,6 +8379,11 @@ json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
@@ -9540,6 +9780,14 @@ parse-filepath@^1.0.2:
     map-cache "^0.2.0"
     path-root "^0.1.1"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -10217,6 +10465,16 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-plugin-import-sort@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-import-sort/-/prettier-plugin-import-sort-0.0.7.tgz#b13dcc4de98940b99066a9e34606a955d109b546"
+  integrity sha512-O0KlUSq+lwvh+UiN3wZDT6wWkf7TNxTVv2/XXE5KqpRNbFJq3nRg2ftzBYFFO8QGpdWIrOB0uCTCtFjIxmVKQw==
+  dependencies:
+    import-sort "^6.0.0"
+    import-sort-config "^6.0.0"
+    import-sort-parser-babylon "^6.0.0"
+    import-sort-parser-typescript "^6.0.0"
+
 prettier@^2.1.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
@@ -10729,7 +10987,7 @@ react-use@^17.2.4:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react@^17.0.2:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -10946,6 +11204,11 @@ resolve-from@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
   integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+  integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -10958,7 +11221,7 @@ resolve-global@^1.0.0:
   dependencies:
     global-dirs "^0.1.1"
 
-resolve@^1.0.0, resolve@^1.10.0, resolve@^1.20.0:
+resolve@^1.0.0, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -12263,30 +12526,10 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
+tslib@2.3.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3, tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.0.1, tslib@~2.1.0, tslib@~2.2.0, tslib@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
-
-tslib@~2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
-
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
-tslib@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -12392,12 +12635,7 @@ typeorm@^0.2.30:
     yargs "^16.2.0"
     zen-observable-ts "^1.0.0"
 
-typescript@*:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
-
-typescript@4.4.0-beta:
+typescript@*, typescript@4.4.0-beta, typescript@^3.2.4:
   version "4.4.0-beta"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.0-beta.tgz#a5b8a3a0d260fa5ce84daa3ab58f7102ad19a655"
   integrity sha512-qMxA8NzN3igwX8Mii7MXGNW+YeFAkUKyKg+x4F1CCFsO36LqISf1EXXSOLDuRIdGjdVvV53grRxfHjOW65YfMA==
@@ -12921,7 +13159,7 @@ yaml-ast-parser@^0.0.43:
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
As I am once again hand-merging conflicts largely caused by import reordering conflicts, I'd like to introduce a prettier plugin for automatically sorting imports, which should minimize these kinds of conflicts.

Here's an example:
```ts
import { useSortable } from "@dnd-kit/sortable";
import { observer } from "mobx-react";
import React, { useCallback, useRef } from "react";
import styled, { css } from "styled-components";

import { updateTopic } from "~frontend/gql/topics";
import { TopicDetailedInfoFragment } from "~gql";
import { useBoolean } from "~shared/hooks/useBoolean";
import { select } from "~shared/sharedState";
import { CircleIconButton } from "~ui/buttons/CircleIconButton";
import { Popover } from "~ui/popovers/Popover";
import { theme } from "~ui/theme";

import { ManageTopic } from "./ManageTopic";
import { TopicOwner } from "./TopicOwner";
```

Imo it's not perfect yet as `~frontend` is closer to `./ManageTopic` so my fave order would probably be something like:
```ts
import React from "react";

import { TopicDetailedInfoFragment } from "~gql";
import { theme } from "~ui/theme";

import { updateTopic } from "~frontend/gql/topics";
import { ManageTopic } from "./ManageTopic";
```
That would be for a ~frontend module, i.e. always have the current module's imports grouped with its relative imports.

Anyway, I think this is still better than hand-managing import order so lmkwyt!

If you have pending changes with import changes, simply apply this patch and run `yarn format`. That should make it conflict free again.
```diff
--- a/.prettierrc.yaml	(revision 2d5f1a9ec670c7a73deb5ba929d5aa0b24ca9480)
+++ b/.prettierrc.yaml	(revision a5a36669eee7a95e0f7ebed8000d81e24bed1dcf)
@@ -1,2 +1,4 @@
 singleQuote: false
 printWidth: 120
+plugins:
+  - "./node_modules/prettier-plugin-import-sort"

--- a/package.json	(revision 2d5f1a9ec670c7a73deb5ba929d5aa0b24ca9480)
+++ b/package.json	(revision a5a36669eee7a95e0f7ebed8000d81e24bed1dcf)
@@ -117,15 +117,28 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "import-sort-style-module-and-prefix": "^0.1.3",
     "jest": "^27.0.6",
     "lint-staged": "^11.0.0",
     "ntl": "^5.1.0",
     "prettier": "^2.3.2",
+    "prettier-plugin-import-sort": "^0.0.7",
     "tslib": "^2.3.0"
   },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "importSort": {
+    ".js, .jsx, .ts, .tsx": {
+      "style": "module-and-prefix",
+      "parser": "typescript"
+    }
+  },
+  "importSortPrefix": {
+    "groupings": [
+      "~"
+    ]
   }
 }
```