### PR TITLE
ci: cleanup node_modules cache if job is cancelled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
           curl -v localhost:1337/healthz
       - run: yarn e2e test
       - uses: actions/upload-artifact@v2
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() }}
         with:
           name: test-artifacts
           path: e2e/test-results/


### PR DESCRIPTION
At the moment cache artifacts are not cleaned properly if the job is canceled. This PR fixes this issue.