### PR TITLE
fix: allow message author access for topic's team members

### DIFF
--- a/infrastructure/hasura/metadata/tables.yaml
+++ b/infrastructure/hasura/metadata/tables.yaml
@@ -1513,11 +1513,20 @@
       - id
       - name
       filter:
-        team_memberships:
-          team:
-            memberships:
-              user_id:
-                _eq: X-Hasura-User-Id
+        _or:
+        - team_memberships:
+            team:
+              memberships:
+                user_id:
+                  _eq: X-Hasura-User-Id
+        - messages:
+            topic:
+              room:
+                space:
+                  team:
+                    memberships:
+                      user_id:
+                        _eq: X-Hasura-User-Id
   update_permissions:
   - role: user
     permission:


### PR DESCRIPTION
See Linear issue for context

I am not 100% convinced of this yet but given that the bug is application breaking it might be a good route to consider temporarily.

The issue is that one can't access a message's author if they are not in one's team (like we saw in prod when we removed someone from the team).
The way this PR fixes it is by allowing access to users if they have messages in one's team. That query could get somewhat expensive, but my hope would be that for most queries the first condition should kick in first anyway. But I have not really validated that assumption yet.