### PR TITLE
fix: use previous data for RoomPage query

### DIFF
--- a/frontend/src/rooms/RoomPage.tsx
+++ b/frontend/src/rooms/RoomPage.tsx
@@ -13,7 +13,11 @@ interface Props {
 }
 
 export const RoomPage = ({ topicId, spaceId, roomId }: Props) => {
-  const { data, loading } = useQuery<RoomPageQuery, RoomPageQueryVariables>(
+  const {
+    data: newData,
+    previousData,
+    loading,
+  } = useQuery<RoomPageQuery, RoomPageQueryVariables>(
     gql`
       ${RoomTopicView.fragments.room}
       ${RoomTopicView.fragments.topic}
@@ -31,6 +35,8 @@ export const RoomPage = ({ topicId, spaceId, roomId }: Props) => {
     `,
     { variables: { roomId, topicId: topicId, hasTopicId: !!topicId } }
   );
+
+  const data = newData ?? previousData;
 
   const hasRoom = Boolean(data && data.room);
 


### PR DESCRIPTION
Our new appraoch leads to cases where switching topics leads to long enough fetches where Apollo sets query data to `undefined`. Thus leading to a page-reload-like flicker. Fortunately there is a [recommended](https://github.com/apollographql/apollo-client/issues/6866#issuecomment-700295108) escape hatch.