### PR TITLE
fix: mark open tasks as done when topic closes

### DIFF
--- a/backend/src/tasks/taskHandlers.ts
+++ b/backend/src/tasks/taskHandlers.ts
@@ -1,0 +1,19 @@
+import { Topic, db } from "~db";
+
+export async function markAllOpenTasksAsDone(topic: Topic) {
+  const nowInTimestamp = new Date().toISOString();
+
+  return await db.task.updateMany({
+    data: {
+      done_at: nowInTimestamp,
+    },
+    where: {
+      AND: {
+        message: {
+          topic_id: { equals: topic.id },
+        },
+        done_at: { equals: null },
+      },
+    },
+  });
+}

--- a/backend/src/topics/events.ts
+++ b/backend/src/topics/events.ts
@@ -3,6 +3,7 @@ import { Topic, db } from "~db";
 import { HasuraEvent } from "../hasura";
 import { createNotification } from "../notifications/entity";
 import { updateRoomLastActivityDate } from "../rooms/rooms";
+import { markAllOpenTasksAsDone } from "../tasks/taskHandlers";
 
 export async function handleTopicUpdates(event: HasuraEvent<Topic>) {
   await updateRoomLastActivityDate(event.item.room_id);
@@ -12,10 +13,11 @@ export async function handleTopicUpdates(event: HasuraEvent<Topic>) {
   }
 
   if (event.type === "update") {
-    const wasJustClosed = !event.item.closed_at && event.itemBefore.closed_at;
+    const wasJustClosed = event.item.closed_at && !event.itemBefore.closed_at;
 
     if (wasJustClosed && event.userId) {
       await createTopicClosedNotifications(event.item, event.userId);
+      await markAllOpenTasksAsDone(event.item);
     }
 
     const ownerId = event.item.owner_id;


### PR DESCRIPTION
# Bug fix

<img width="875" alt="Screenshot 2021-08-27 at 16 18 01" src="https://user-images.githubusercontent.com/4765697/131133483-b4e42a70-02ab-4fa1-a166-aca30b036365.png">

I currently have a perpetually open task that I can not complete. This is open because the topic in itself was closed before I could respond. This logic marks all open tasks in topic as done when the topic closes.