### PR TITLE
Enable playwright traces

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,6 +4,7 @@ const config: PlaywrightTestConfig = {
   globalSetup: require.resolve("./helper/global-setup"),
   use: {
     video: "retain-on-failure",
+    trace: "retain-on-failure",
   },
 };
 export default config;


### PR DESCRIPTION
This will upload the [playwright traces](https://playwright.dev/docs/trace-viewer/) for every failed e2e test.