### PR TITLE
feat: Make name param optional for signup endpoint

### DIFF
--- a/backend/src/waitlist/mailchimp.ts
+++ b/backend/src/waitlist/mailchimp.ts
@@ -1,0 +1,35 @@
+import * as crypto from "crypto";
+
+import axios from "axios";
+
+import { assertDefined } from "~shared/assert";
+
+const mailchimpApiKey = assertDefined(process.env.MAILCHIMP_API_KEY, "MAILCHIMP_API_KEY is required");
+
+type MembersApiPutRequestBody = {
+  email_address: string;
+  status_if_new: "subscribed";
+  merge_fields?: Record<string, string>;
+};
+export async function addUserToMailchimp(email: string, firstName?: string) {
+  const membersApiQueryBody: MembersApiPutRequestBody = {
+    email_address: email.toLowerCase().trim(),
+    status_if_new: "subscribed",
+  };
+  if (firstName) {
+    membersApiQueryBody.merge_fields = { FNAME: firstName };
+  }
+  const emailMd5Hash = crypto.createHash("md5").update(email).digest("hex").toString();
+  await axios.put(
+    `https://us17.api.mailchimp.com/3.0/lists/b989557221/members/${emailMd5Hash}`,
+    JSON.stringify(membersApiQueryBody),
+    {
+      headers: {
+        Authorization: `Basic ${Buffer.from(`user:${mailchimpApiKey}`).toString("base64")}`,
+      },
+      params: {
+        skip_merge_validation: true,
+      },
+    }
+  );
+}

--- a/backend/src/waitlist/waitlist.ts
+++ b/backend/src/waitlist/waitlist.ts
@@ -1,15 +1,10 @@
-import * as crypto from "crypto";
-
-import axios from "axios";
 import { Request, Response, Router } from "express";
 
 import { db } from "~db";
-import { assertDefined } from "~shared/assert";
 import logger from "~shared/logger";
 
 import { HttpStatus } from "../http";
-
-const mailchimpApiKey = assertDefined(process.env.MAILCHIMP_API_KEY, "MAILCHIMP_API_KEY is required");
+import { addUserToMailchimp } from "./mailchimp";
 
 export const router = Router();
 
@@ -17,12 +12,6 @@ interface SignupPayload {
   email?: string;
   firstName?: string;
 }
-
-type MembersApiPutRequestBody = {
-  email_address: string;
-  status_if_new: "subscribed";
-  merge_fields?: Record<string, string>;
-};
 
 /**
  * This endpoint handles user signup calls from the landing page
@@ -40,27 +29,8 @@ router.post("/v1/waitlist", async (req: Request, res: Response) => {
     await db.whitelist.create({ data: { email } });
     // we want to respond with success even when the mailchimp API call fails
     res.status(HttpStatus.CREATED).end();
-    const membersApiQueryBody: MembersApiPutRequestBody = {
-      email_address: email.toLowerCase().trim(),
-      status_if_new: "subscribed",
-    };
-    if (firstName) {
-      membersApiQueryBody.merge_fields = { FNAME: firstName };
-    }
-    const emailMd5Hash = crypto.createHash("md5").update(email).digest("hex").toString();
-    await axios.put(
-      `https://us17.api.mailchimp.com/3.0/lists/b989557221/members/${emailMd5Hash}`,
-      JSON.stringify(membersApiQueryBody),
-      {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`user:${mailchimpApiKey}`).toString("base64")}`,
-        },
-        params: {
-          skip_merge_validation: true,
-        },
-      }
-    );
-    logger.info(`Mailchimp create subscriber API call successful`);
+    await addUserToMailchimp(email, firstName);
+    logger.info(`User waitlist signup successful`);
   } catch (e) {
     console.error(e);
     logger.error("Adding a new subscriber failed");


### PR DESCRIPTION
Now `firstName` parameter is optional. Made the change due to us not requiring user's first name when signing up.