### PR TITLE
Fix: attached images spacing on Safari

### DIFF
--- a/frontend/src/ui/message/attachment/AttachmentPreview.tsx
+++ b/frontend/src/ui/message/attachment/AttachmentPreview.tsx
@@ -38,6 +38,7 @@ const UIHolder = styled.div<{}>`
   display: flex;
   position: relative;
   height: 120px;
+  width: 120px;
 `;
 
 const UIRemoveButtonHolder = styled.div<{}>`

--- a/frontend/src/ui/message/attachment/MessageImageAttachment.tsx
+++ b/frontend/src/ui/message/attachment/MessageImageAttachment.tsx
@@ -69,7 +69,5 @@ const ImageWrapper = styled.img<{}>`
   will-change: transform, opacity;
 
   /* Safari fix - make sure image always keeps its aspect ratio. */
-  object-fit: scale-down;
-  width: auto;
-  height: 100%;
+  object-fit: cover;
 `;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/17750556/131655634-e782526c-58a7-4480-a9a3-3710fbec23c2.png)


After:
![image](https://user-images.githubusercontent.com/17750556/131655405-ec2228e5-944a-43e7-b84a-8c8bcc9c3732.png)
