### PR TITLE
fix: make __typename required

### DIFF
--- a/backend/src/slack/install.ts
+++ b/backend/src/slack/install.ts
@@ -45,6 +45,6 @@ export const getTeamSlackInstallationURL: ActionHandler<
     assert(team, new UnprocessableEntityError(`Team ${teamId} for member ${userId} not found`));
     const url = await getSlackInstallURL({ withBot: true }, { teamId, redirectURL, userId });
     assert(url, new UnprocessableEntityError("could not get Slack installation URL"));
-    return { url };
+    return { __typename: "GetTeamSlackInstallationURLOutput", url };
   },
 };

--- a/frontend/src/gql/spaces.ts
+++ b/frontend/src/gql/spaces.ts
@@ -263,6 +263,7 @@ export const [useAddSpaceMemberMutation] = createMutation<AddSpaceMemberMutation
       return {
         __typename: "mutation_root",
         insert_space_member_one: {
+          __typename: "space_member",
           space_id: vars.spaceId,
           user_id: vars.userId,
         },

--- a/frontend/src/views/RoomView/DeadlineManager/index.tsx
+++ b/frontend/src/views/RoomView/DeadlineManager/index.tsx
@@ -34,7 +34,7 @@ export const DeadlineManager = withFragments(fragments, ({ room, isReadonly }: P
       }
     `,
     {
-      optimisticResponse: (vars) => ({ room: { __typename: "room", ...vars } }),
+      optimisticResponse: (vars) => ({ __typename: "mutation_root", room: { __typename: "room", ...vars } }),
     }
   );
   useSubscription<DeadlineManagerSubscription, DeadlineManagerSubscriptionVariables>(

--- a/frontend/src/views/RoomView/RecurranceManager.tsx
+++ b/frontend/src/views/RoomView/RecurranceManager.tsx
@@ -40,7 +40,7 @@ export const RecurranceManager = withFragments(fragments, ({ room, isReadonly }:
       }
     `,
     {
-      optimisticResponse: (vars) => ({ room: { __typename: "room", ...vars } }),
+      optimisticResponse: (vars) => ({ __typename: "mutation_root", room: { __typename: "room", ...vars } }),
     }
   );
 

--- a/frontend/src/views/RoomView/RoomSummaryView.tsx
+++ b/frontend/src/views/RoomView/RoomSummaryView.tsx
@@ -54,7 +54,7 @@ export const RoomSummaryView = withFragments(fragments, function RoomSummaryView
       }
     `,
     {
-      optimisticResponse: (vars) => ({ room: { __typename: "room", ...vars } }),
+      optimisticResponse: (vars) => ({ __typename: "mutation_root", room: { __typename: "room", ...vars } }),
     }
   );
 

--- a/frontend/src/views/RoomView/RoomView.tsx
+++ b/frontend/src/views/RoomView/RoomView.tsx
@@ -84,6 +84,7 @@ function RoomViewDisplayer({ room, selectedTopicId, children }: Props) {
     `,
     {
       optimisticResponse: (vars) => ({
+        __typename: "mutation_root",
         room: { __typename: "room", id: vars.id, finished_at: vars.finishedAt },
       }),
     }
@@ -98,7 +99,7 @@ function RoomViewDisplayer({ room, selectedTopicId, children }: Props) {
       }
     `,
     {
-      optimisticResponse: (vars) => ({ room: { __typename: "room", ...vars } }),
+      optimisticResponse: (vars) => ({ __typename: "mutation_root", room: { __typename: "room", ...vars } }),
     }
   );
 

--- a/frontend/src/views/RoomView/TopicWithMessages/CreateNewMessageEditor.tsx
+++ b/frontend/src/views/RoomView/TopicWithMessages/CreateNewMessageEditor.tsx
@@ -108,11 +108,13 @@ const useCreateMessageMutation = () =>
           query: TOPIC_WITH_MESSAGES_QUERY,
           variables: { topicId: message.topic_id },
         };
-        const messages = cache.readQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>(options)?.messages;
-        if (messages) {
+        const data = cache.readQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>(options);
+        if (data) {
+          const { messages } = data;
           cache.writeQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>({
             ...options,
             data: {
+              ...data,
               messages: messages.some((m) => m.id == message.id) ? messages : messages.concat(message),
             },
           });

--- a/frontend/src/views/RoomView/TopicWithMessages/useMessagesSubscription.ts
+++ b/frontend/src/views/RoomView/TopicWithMessages/useMessagesSubscription.ts
@@ -40,12 +40,13 @@ function useExistingMessagesSubscription(topicId?: string) {
       query: TOPIC_WITH_MESSAGES_QUERY,
       variables: { topicId },
     };
-    const messages = client.readQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>(options)?.messages;
-    if (messages) {
+    const data = client.readQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>(options);
+    if (data) {
       client.writeQuery<TopicWithMessagesQuery, TopicWithMessagesQueryVariables>({
         ...options,
         data: {
-          messages: messages.filter((m) => existingMessageIds.has(m.id)),
+          ...data,
+          messages: data.messages.filter((m) => existingMessageIds.has(m.id)),
         },
       });
     }

--- a/frontend/src/views/RoomView/TopicsList/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/index.tsx
@@ -18,13 +18,7 @@ import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
 import { RouteLink, routes } from "~frontend/router";
 import { byIndexAscending } from "~frontend/topics/utils";
 import { TopicWithMessages } from "~frontend/views/RoomView/TopicWithMessages";
-import {
-  CreateRoomViewTopicMutation,
-  CreateRoomViewTopicMutationVariables,
-  RoomViewTopicQuery,
-  RoomViewTopicQueryVariables,
-  TopicList_RoomFragment,
-} from "~gql";
+import { CreateRoomViewTopicMutation, CreateRoomViewTopicMutationVariables, TopicList_RoomFragment } from "~gql";
 import { select } from "~shared/sharedState";
 import { getUUID } from "~shared/uuid";
 import { Button } from "~ui/buttons/Button";
@@ -134,7 +128,7 @@ const useCreateTopic = () =>
           },
         };
       },
-      update: function (cache, result) {
+      update(cache, result) {
         const topic = result.data?.topic;
         if (!topic) {
           return;
@@ -153,19 +147,6 @@ const useCreateTopic = () =>
             topics: (existing: Reference[]) =>
               existing.some((ref) => ref.__ref == newTopicRef.__ref) ? existing : existing.concat(newTopicRef),
           },
-        });
-        cache.writeQuery<RoomViewTopicQuery, RoomViewTopicQueryVariables>({
-          query: gql`
-            ${createTopicFragment}
-
-            query RoomViewTopic($id: uuid!) {
-              topics: topic(where: { id: { _eq: $id } }) {
-                ...TopicListCreateTopic
-              }
-            }
-          `,
-          data: { topics: [topic] },
-          variables: { id: topic.id },
         });
       },
     }

--- a/frontend/src/views/RoomView/TopicsList/shared.ts
+++ b/frontend/src/views/RoomView/TopicsList/shared.ts
@@ -39,6 +39,7 @@ export const useDeleteTopic = () =>
     `,
     {
       optimisticResponse: ({ id, roomId }) => ({
+        __typename: "mutation_root",
         topic: { __typename: "topic", id, room_id: roomId },
       }),
       update(cache, { data }) {

--- a/frontend/src/views/RoomView/editOptions.tsx
+++ b/frontend/src/views/RoomView/editOptions.tsx
@@ -50,6 +50,7 @@ export const usePopoverEditMenuOptions = withFragments(
       `,
       {
         optimisticResponse: (vars) => ({
+          __typename: "mutation_root",
           room: { __typename: "room", id: vars.id, is_private: vars.isPrivate },
         }),
       }

--- a/tooling/graphqlCodegen.ts
+++ b/tooling/graphqlCodegen.ts
@@ -56,6 +56,7 @@ export async function startGeneratingGraphqlTypes({ watch }: ToolingGenerateOpti
           apolloClientVersion: 3,
           useExplicitTyping: true,
           strictScalars: true,
+          nonOptionalTypename: true,
           scalars: {
             // Hasura has bunch of custom scalars. Let's inform gql codegen about corresponding typescript types.
             bigint: "number",


### PR DESCRIPTION
Adam was wondering why TS did not type error in over in https://github.com/weareacapela/monorepo/pull/393#pullrequestreview-743693441

Turns out `__typename` was optional, which appears to be contradicting the spec. I did not find a good reason why, but did find a config option for requiring, enabled that and fixed all resulting type errors.