### PR TITLE
feat: unread message only if open topic

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_transcription.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_transcription.yaml
@@ -26,3 +26,27 @@ select_permissions:
                   user_id:
                     _eq: X-Hasura-User-Id
     role: user
+event_triggers:
+  - definition:
+      delete:
+        columns: "*"
+      enable_manual: false
+      insert:
+        columns: "*"
+      update:
+        columns:
+          - updated_at
+          - id
+          - sonix_media_id
+          - status
+          - transcript
+          - created_at
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENTS_WEBHOOK_AUTHORIZATION_HEADER
+    name: transcription_updates
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook_from_env: HASURA_EVENTS_WEBHOOK_URL


### PR DESCRIPTION
Add `AND topic.closed_at IS NULL` to `unread_messages` view, to not show messages from closed topics in unread ones.