### PR TITLE
fix: drop localStorage persist

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "@segment/snippet": "^4.14.2",
     "@sentry/nextjs": "^6.8.0",
     "@sentry/node": "^6.8.0",
-    "apollo3-cache-persist": "^0.10.0",
     "clipboard-polyfill": "^3.0.3",
     "escape-html": "^1.0.3",
     "express-http-proxy": "^1.6.2",

--- a/frontend/src/apollo/client.tsx
+++ b/frontend/src/apollo/client.tsx
@@ -12,7 +12,6 @@ import {
 import { onError } from "@apollo/client/link/error";
 import { WebSocketLink } from "@apollo/client/link/ws";
 import { getMainDefinition } from "@apollo/client/utilities";
-import { LocalStorageWrapper, persistCache } from "apollo3-cache-persist";
 import { GraphQLError } from "graphql";
 import { memoize } from "lodash";
 import { NextApiRequest } from "next";
@@ -99,8 +98,6 @@ export function clearApolloCache() {
   cache = new InMemoryCache({ typePolicies });
 }
 
-const localStorageCacheWrapper = typeof window !== "undefined" ? new LocalStorageWrapper(window.localStorage) : null;
-
 export function readTokenFromRequest(req?: IncomingMessage): string | null {
   if (!req) return null;
 
@@ -168,8 +165,7 @@ function formatGraphqlErrorMessage(error: GraphQLError) {
 }
 
 // Log any GraphQL errors or network error that occurred
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const errorLink = onError(({ graphQLErrors = [], networkError }) => {
+onError(({ graphQLErrors = [], networkError }) => {
   for (const graphqlError of graphQLErrors) {
     const message = formatGraphqlErrorMessage(graphqlError);
 
@@ -223,14 +219,6 @@ export const getApolloClient = memoize((options: ApolloClientOptions = {}): Apol
 
   if (initialCacheState) {
     cache.restore(initialCacheState);
-  }
-
-  if (localStorageCacheWrapper) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    persistCache<any>({
-      cache: cache,
-      storage: localStorageCacheWrapper,
-    });
   }
 
   return new ApolloClient({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,11 +3473,6 @@ anymatch@^3.0.3, anymatch@~3.1.1, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo3-cache-persist@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/apollo3-cache-persist/-/apollo3-cache-persist-0.10.0.tgz#8dd186818898bd433a9952fe4055adf3f4fb16a4"
-  integrity sha512-3W558cKQ9OymUaLMD3Mv8FuUmIDu/GP6aJA+5iLH6fw5MxG4dwF09fFz8NBHn/qfa/zrxv8AtDzKehZUPm107A==
-
 app-root-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.0.0.tgz#210b6f43873227e18a4b810a032283311555d5ad"


### PR DESCRIPTION
As alluded to in the [Acapela](https://app.acape.la/space/bbafe64e-d4aa-40a8-8345-e4d2a90cecf9/cf9197da-a54f-4735-b942-771424d3983d/470680b5-bae0-4b84-9a99-4eda507f1efc) I think this degrades UX on the homepage where one gets a flash of old content. Our backend is plenty fast in responding, so I think upside > downside here.

Also Heiki just experience a bug where he did not see a messages in a topic, which was fixed after clearing localStorage. Unfortunately I acted too quickly and did not save his broken state, to debug if it `apollo-cache-persist` for sure, but my gut says it's the best explanation.

My vague sense is also that we are looking into approaching offline from a new angle anyway (start with caching the leaf-nodes), where e.g. the homepage is fairly non-leafy.