### PR TITLE
fix: bring back user-through-message permission

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
@@ -88,11 +88,20 @@ select_permissions:
         - id
         - name
       filter:
-        team_memberships:
-          team:
-            memberships:
-              user_id:
-                _eq: X-Hasura-User-Id
+        _or:
+          - team_memberships:
+              team:
+                memberships:
+                  user_id:
+                    _eq: X-Hasura-User-Id
+          - messages:
+              topic:
+                room:
+                  space:
+                    team:
+                      memberships:
+                        user_id:
+                          _eq: X-Hasura-User-Id
     role: user
 update_permissions:
   - permission:


### PR DESCRIPTION
Looks like https://github.com/weareacapela/monorepo/pull/367 got lost in the fire