### PR TITLE
fix: prevent search message access errors

### DIFF
--- a/frontend/src/ui/search/SearchBar.tsx
+++ b/frontend/src/ui/search/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from "@sentry/nextjs";
 import { useState } from "react";
 import { useDebounce } from "react-use";
 import styled from "styled-components";
@@ -34,7 +35,11 @@ const PureSearchBar = namedForwardRef<HTMLInputElement, Props>(({ className }, r
   return (
     <div className={className} onClick={(event) => event.stopPropagation()}>
       <SearchInput autoFocus ref={ref} value={value} onChangeText={(text) => setValue(text)} />
-      {term && results && <SearchResults {...{ term, results }} />}
+      {term && results && (
+        <ErrorBoundary fallback={<>An error occurred while searching. We are looking into it!</>}>
+          <SearchResults {...{ term, results }} />
+        </ErrorBoundary>
+      )}
     </div>
   );
 });

--- a/infrastructure/hasura/metadata/databases/default/tables/public_message.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_message.yaml
@@ -91,11 +91,21 @@ select_permissions:
       filter:
         topic:
           room:
-            space:
-              team:
-                memberships:
-                  user_id:
-                    _eq: X-Hasura-User-Id
+            _or:
+              - _and:
+                  - is_private:
+                      _eq: true
+                  - members:
+                      user_id:
+                        _eq: X-Hasura-User-Id
+              - _and:
+                  - is_private:
+                      _eq: false
+                  - space:
+                      team:
+                        memberships:
+                          user_id:
+                            _eq: X-Hasura-User-Id
     role: user
 update_permissions:
   - permission:


### PR DESCRIPTION
This does two things:

- adds an error boundary to the search bar so that most of the site survives errors like the one we saw in prod...
- ...which is also fixed here, it was related to users having access to private messages, not their rooms though, thus receiving null fields