### PR TITLE
refactor: make topic.room optional

### DIFF
--- a/backend/src/messages/events.ts
+++ b/backend/src/messages/events.ts
@@ -66,7 +66,7 @@ export async function handleMessageChanges(event: HasuraEvent<Message>) {
   assert(topicInfo, "Message has no topic attached");
 
   await Promise.all([
-    updateRoomLastActivityDate(topicInfo.room_id),
+    topicInfo.room_id ? updateRoomLastActivityDate(topicInfo.room_id) : Promise.resolve(),
     prepareMessagePlainTextData(event.item),
     // In case message includes @mentions, create notifications for them
     createMessageMentionNotifications(event.item, event.itemBefore),

--- a/backend/src/notifications/create-and-send.ts
+++ b/backend/src/notifications/create-and-send.ts
@@ -86,7 +86,9 @@ export async function createAndSendTopicMentionNotification({
 
   const authorName = getNormalizedUserName(mentioningUser);
   const topicName = topic.name || "a topic";
-  const link = `${process.env.FRONTEND_URL}/space/${topic.room.space_id}/${topic.room.id}/${topic.id}`;
+  const link =
+    process.env.FRONTEND_URL +
+    (topic.room ? `/space/${topic.room.space_id}/${topic.room.id}/${topic.id}` : `/topic/${topic.id}`);
   await sendNotificationPerPreference(mentionedTeamMember, {
     subject: `${authorName} has tagged you in ${topicName}`,
     content: [

--- a/backend/src/topics/events.ts
+++ b/backend/src/topics/events.ts
@@ -5,7 +5,9 @@ import { updateRoomLastActivityDate } from "../rooms/rooms";
 import { markAllOpenTasksAsDone } from "../tasks/taskHandlers";
 
 export async function handleTopicUpdates(event: HasuraEvent<Topic>) {
-  await updateRoomLastActivityDate(event.item.room_id);
+  if (event.item.room_id) {
+    await updateRoomLastActivityDate(event.item.room_id);
+  }
 
   if (event.type === "create") {
     await inheritTopicMembersFromParentRoom(event.item);

--- a/db/index.ts
+++ b/db/index.ts
@@ -11,7 +11,6 @@ export type {
   room_member as RoomMember,
   topic as Topic,
   user as User,
-  verification_requests as VerificationRequest,
   attachment as Attachment,
   transcription_status as TranscriptionStatus,
   transcription as Transcription,
@@ -26,8 +25,6 @@ export type {
   team_member as TeamMember,
   whitelist as Whitelist,
   notification as Notification,
-  notification_room_added_to as NotificationRoomAddedTo,
-  notification_topic_mention as NotificationTopicMention,
   PrismaPromise,
   Prisma,
 } from "@prisma/client";

--- a/frontend/router/index.ts
+++ b/frontend/router/index.ts
@@ -8,6 +8,9 @@ export const routes = {
   home: createRoute("/", {}),
   team: createRoute("/team", {}),
   logout: createRoute("/logout", {}),
+  topic: createRoute("/topics/:topicId", { topicId: "string" }),
+
+  // <likely-to-be-deprecated>
   spaces: createRoute("/spaces", {}),
   calendar: createRoute("/calendar", {}),
   space: createRoute("/space/[spaceId]", { spaceId: "string" }),
@@ -19,6 +22,8 @@ export const routes = {
     roomId: "string",
     topicId: "string",
   }),
+  // </likely-to-be-deprecated>
+
   invitePage: createRoute("/invites/[inviteCode]", { inviteCode: "string" }),
 };
 

--- a/frontend/src/ui/notifications/NotificationLabel/NotificationLabel.tsx
+++ b/frontend/src/ui/notifications/NotificationLabel/NotificationLabel.tsx
@@ -197,11 +197,13 @@ export const NotificationLabel = withFragments(fragments, ({ notification }: Pro
   const { user, titleNode } = data;
   const url =
     "topic" in data
-      ? routes.spaceRoomTopic.getUrlWithParams({
-          spaceId: data.topic.room.space_id,
-          roomId: data.topic.room.id,
-          topicId: data.topic.id,
-        })
+      ? data.topic.room
+        ? routes.spaceRoomTopic.getUrlWithParams({
+            spaceId: data.topic.room.space_id,
+            roomId: data.topic.room.id,
+            topicId: data.topic.id,
+          })
+        : routes.topic.getUrlWithParams({ topicId: data.topic.id })
       : routes.spaceRoom.getUrlWithParams({ spaceId: data.room.space_id, roomId: data.room.id });
 
   return (

--- a/frontend/src/ui/rooms/RoomsList/ExpandableTopicsList.tsx
+++ b/frontend/src/ui/rooms/RoomsList/ExpandableTopicsList.tsx
@@ -6,6 +6,7 @@ import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { RoomBasicInfoFragment } from "~frontend/gql/rooms";
 import { getIndexBetweenCurrentAndLast } from "~frontend/rooms/order";
 import { routes } from "~frontend/router";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import { openUIPrompt } from "~frontend/utils/prompt";
 import { useDetailedRoomMessagesCount } from "~frontend/utils/unreadMessages";
 import { CreateTopicMutation, CreateTopicMutationVariables, TopicDetailedInfoFragment } from "~gql";
@@ -28,6 +29,7 @@ interface Props {
 const MINIMIZED_TOPICS_SHOWN_LIMIT = 3;
 
 function useStartCreateNewTopicFlow() {
+  const teamId = useAssertCurrentTeamId();
   const [createTopic] = useMutation<CreateTopicMutation, CreateTopicMutationVariables>(gql`
     mutation CreateTopic($input: topic_insert_input!) {
       insert_topic_one(object: $input) {
@@ -52,6 +54,7 @@ function useStartCreateNewTopicFlow() {
     return createTopic({
       variables: {
         input: {
+          team_id: teamId,
           name,
           slug: name.split(" ").join("-").toLowerCase(),
           ...input,

--- a/frontend/src/ui/rooms/RoomsList/TopicCard.tsx
+++ b/frontend/src/ui/rooms/RoomsList/TopicCard.tsx
@@ -37,8 +37,10 @@ export const TopicCard = styled(function TopicCard({ topic, className }: Props) 
 
   return (
     <RouteLink
-      route={routes.spaceRoomTopic}
-      params={{ roomId: topic.room.id, spaceId: topic.room.space_id, topicId: topic.id }}
+      route={topic.room ? routes.spaceRoomTopic : routes.topic}
+      params={
+        topic.room ? { roomId: topic.room.id, spaceId: topic.room.space_id, topicId: topic.id } : { topicId: topic.id }
+      }
     >
       <UIHolder className={className}>
         <UIInfo>

--- a/frontend/src/ui/search/SearchResults.tsx
+++ b/frontend/src/ui/search/SearchResults.tsx
@@ -38,18 +38,22 @@ function getItemURL(result: ResultItem): string {
 
     case "topic": {
       const { room } = result;
-      return routes.spaceRoomTopic.getUrlWithParams({
-        spaceId: room.space.id,
-        roomId: room.id,
-        topicId: result.id,
-      });
+      return room
+        ? routes.spaceRoomTopic.getUrlWithParams({
+            spaceId: room.space.id,
+            roomId: room.id,
+            topicId: result.id,
+          })
+        : routes.topic.getUrlWithParams({ topicId: result.id });
     }
 
     case "message": {
       const {
         topic: { room, id: topicId },
       } = result;
-      return routes.spaceRoomTopic.getUrlWithParams({ spaceId: room.space.id, roomId: room.id, topicId });
+      return room
+        ? routes.spaceRoomTopic.getUrlWithParams({ spaceId: room.space.id, roomId: room.id, topicId })
+        : routes.topic.getUrlWithParams({ topicId });
     }
   }
 }
@@ -65,14 +69,14 @@ function composeBreadcrumb(result: ResultItem): string[] {
 
     case "topic": {
       const { room } = result;
-      return [room.space.name, room.name, result.name];
+      return room ? [room.space.name, room.name, result.name] : [result.name];
     }
 
     case "message": {
       const {
         topic: { room, ...topic },
       } = result;
-      return [room.space.name, room.name, topic.name];
+      return room ? [room.space.name, room.name, topic.name] : [topic.name];
     }
   }
 }

--- a/frontend/src/views/RoomView/TopicsList/index.tsx
+++ b/frontend/src/views/RoomView/TopicsList/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "~frontend/rooms/order";
 import { useRoomStoreContext } from "~frontend/rooms/RoomStore";
 import { RouteLink, routes } from "~frontend/router";
+import { useAssertCurrentTeamId } from "~frontend/team/useCurrentTeamId";
 import { byIndexAscending } from "~frontend/topics/utils";
 import { TopicWithMessages } from "~frontend/views/RoomView/TopicWithMessages";
 import { CreateRoomViewTopicMutation, CreateRoomViewTopicMutationVariables, TopicList_RoomFragment } from "~gql";
@@ -94,6 +95,7 @@ const useCreateTopic = () =>
 
       mutation CreateRoomViewTopic(
         $id: uuid!
+        $team_id: uuid!
         $name: String!
         $slug: String!
         $index: String!
@@ -101,7 +103,15 @@ const useCreateTopic = () =>
         $owner_id: uuid!
       ) {
         topic: insert_topic_one(
-          object: { id: $id, name: $name, slug: $slug, index: $index, room_id: $room_id, owner_id: $owner_id }
+          object: {
+            id: $id
+            team_id: $team_id
+            name: $name
+            slug: $slug
+            index: $index
+            room_id: $room_id
+            owner_id: $owner_id
+          }
         ) {
           ...TopicListCreateTopic
         }
@@ -158,6 +168,7 @@ const _TopicsList = observer(function TopicsList({
   isRoomOpen,
 }: Props) {
   const user = useAssertCurrentUser();
+  const teamId = useAssertCurrentTeamId();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const { id: roomId, space_id: spaceId, topics } = roomWithoutAppliedFilters;
@@ -192,6 +203,7 @@ const _TopicsList = observer(function TopicsList({
         slug: "new-topic",
         owner_id: user.id,
         room_id: roomId,
+        team_id: teamId,
         index: getNewTopicIndex(topics, activeTopicId),
       },
     });

--- a/frontend/src/views/ToDoView/OpenTopics.tsx
+++ b/frontend/src/views/ToDoView/OpenTopics.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useTopicsQuery } from "~frontend/gql/topics";
 import { routes } from "~frontend/router";
-import { fillParamsInUrl } from "~frontend/router/utils";
 import { CollapsePanel } from "~ui/collapse/CollapsePanel";
 import { theme } from "~ui/theme";
 import { CategoryNameLabel } from "~ui/theme/functional";
@@ -34,14 +33,19 @@ export const OpenTopics = () => {
         {topics?.map((topic) => (
           <ToDoItem
             key={topic.id}
-            href={fillParamsInUrl(routes.spaceRoomTopic.path, {
-              topicId: topic.id,
-              roomId: topic.room.id,
-              spaceId: topic.room.space.id,
-            })}
+            href={
+              topic.room
+                ? routes.spaceRoomTopic.getUrlWithParams({
+                    topicId: topic.id,
+                    roomId: topic.room.id,
+                    spaceId: topic.room.space.id,
+                  })
+                : routes.topic.getUrlWithParams({ topicId: topic.id })
+            }
           >
             <UITopic>
-              {topic.room.space.name} / {topic.room.name} / <UITopicName>{topic.name}</UITopicName>
+              {topic.room && `${topic.room.space.name} / ${topic.room.name} / `}
+              <UITopicName>{topic.name}</UITopicName>
             </UITopic>
           </ToDoItem>
         ))}

--- a/frontend/src/views/ToDoView/UnresolvedRequests.tsx
+++ b/frontend/src/views/ToDoView/UnresolvedRequests.tsx
@@ -81,11 +81,15 @@ export const UnresolvedRequests = () => {
         return (
           <Fragment key={id}>
             <ToDoItem
-              href={fillParamsInUrl(routes.spaceRoomTopic.path, {
-                topicId: topic.id,
-                roomId: topic.room.id,
-                spaceId: topic.room.space.id,
-              })}
+              href={
+                topic.room
+                  ? fillParamsInUrl(routes.spaceRoomTopic.path, {
+                      topicId: topic.id,
+                      roomId: topic.room.id,
+                      spaceId: topic.room.space.id,
+                    })
+                  : routes.topic.getUrlWithParams({ topicId: topic.id })
+              }
             >
               <UIInfo>
                 <UITopArea data-tooltip={tooltip}>

--- a/infrastructure/hasura/metadata/databases/default/tables/public_topic.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_topic.yaml
@@ -59,6 +59,7 @@ insert_permissions:
         - owner_id
         - room_id
         - slug
+        - team_id
     role: user
 select_permissions:
   - permission:
@@ -74,6 +75,7 @@ select_permissions:
         - owner_id
         - room_id
         - slug
+        - team_id
       filter:
         _and:
           - room:

--- a/infrastructure/hasura/migrations/default/1632130582355_optional_room/down.sql
+++ b/infrastructure/hasura/migrations/default/1632130582355_optional_room/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."topic"
+  alter column "room_id" set not null,
+  drop column "team_id";

--- a/infrastructure/hasura/migrations/default/1632130582355_optional_room/up.sql
+++ b/infrastructure/hasura/migrations/default/1632130582355_optional_room/up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "public"."topic"
+  ADD COLUMN "team_id" UUID;
+
+UPDATE "public"."topic"
+SET team_id = (
+  SELECT space.team_id
+  FROM room
+  LEFT JOIN space ON space.id = room.space_id
+  WHERE room.id = topic.room_id
+);
+
+ALTER TABLE "public"."topic"
+  ALTER COLUMN "room_id" DROP NOT NULL,
+  ALTER COLUMN "team_id" SET NOT NULL;


### PR DESCRIPTION
This also adds a `topic.team_id` column so that we still know which topics belong to which team. In the future we might want to have associations completely go through mentions, but this seems like a good enough compromise for now. This field is also required and, for existing topics, populdated through `topic.room.space.team_id`.

An assumption in here is that we will have a `/topic/:id` view, which some views now conditionally link to if a topic does not have a room. The view does not exist yet, but there is also no UI-way to create such a topic so I think that's fine.

LMKWYT!