### PR TITLE
feat: notification through slack connect

### DIFF
--- a/backend/src/actions/actionHandlers.ts
+++ b/backend/src/actions/actionHandlers.ts
@@ -1,19 +1,20 @@
 import { getUploadUrl } from "~backend/src/attachments/attachments";
 import { roomInvitationView } from "~backend/src/roomInvitation/roomInvitationView";
-import { getTeamSlackInstallationURL } from "~backend/src/slack/install";
+import { findSlackUser, getTeamSlackInstallationURL } from "~backend/src/slack/install";
 import { lookupTeamName } from "~backend/src/teamInvitation/lookupTeamName";
 import { resendInvitation } from "~backend/src/teamInvitation/resendInvitation";
 
 export interface ActionHandler<DataT, ResponseT> {
   actionName: string;
-  handle: (userId: string | undefined, data: DataT) => Promise<ResponseT>;
+  handle: (userId: string | undefined, data: DataT) => Promise<Omit<ResponseT, "__typename">>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handlers: ActionHandler<any, any>[] = [
+  findSlackUser,
+  getTeamSlackInstallationURL,
   getUploadUrl,
   lookupTeamName,
   resendInvitation,
   roomInvitationView,
-  getTeamSlackInstallationURL,
 ];

--- a/backend/src/notifications/sendNotification.ts
+++ b/backend/src/notifications/sendNotification.ts
@@ -1,22 +1,15 @@
-import { SlackInstallation, slackClient } from "~backend/src/slack/app";
-import { TeamMember, User, db } from "~db";
+import { slackClient } from "~backend/src/slack/app";
+import { fetchTeamBotToken, findSlackUserId } from "~backend/src/slack/utils";
+import { TeamMember, User } from "~db";
 import { assert } from "~shared/assert";
 import { DEFAULT_NOTIFICATION_EMAIL, sendEmail } from "~shared/email";
 
-async function trySendSlackNotification(teamId: string, email: string, text: string) {
-  const slackInstallation = await db.team_slack_installation.findUnique({ where: { team_id: teamId } });
-  if (!slackInstallation) {
+async function trySendSlackNotification(teamId: string, user: User, text: string) {
+  const [token, slackUserId] = await Promise.all([fetchTeamBotToken(teamId), findSlackUserId(teamId, user)]);
+  if (!token || !slackUserId) {
     return;
   }
-  const botToken = (slackInstallation.data as unknown as SlackInstallation)?.bot?.token;
-  if (!botToken) {
-    return;
-  }
-  const { user: slackUser } = await slackClient.users.lookupByEmail({ token: botToken, email });
-  if (!slackUser || !slackUser.id) {
-    return;
-  }
-  await slackClient.chat.postMessage({ token: botToken, channel: slackUser.id, text });
+  await slackClient.chat.postMessage({ token, channel: slackUserId, text });
 }
 
 export const sendNotificationPerPreference = (
@@ -33,7 +26,7 @@ export const sendNotificationPerPreference = (
   const { email } = user;
   assert(email, "Every user should have an email");
   return Promise.all([
-    teamMember.notify_slack ? trySendSlackNotification(team_id, email, content) : undefined,
+    teamMember.notify_slack ? trySendSlackNotification(team_id, user, content) : undefined,
     teamMember.notify_email
       ? sendEmail({
           from: DEFAULT_NOTIFICATION_EMAIL,

--- a/backend/src/slack/app.ts
+++ b/backend/src/slack/app.ts
@@ -28,8 +28,7 @@ const sharedOptions: Options<typeof SlackBolt.ExpressReceiver> & Options<typeof 
   installationStore: {
     async storeInstallation(installation) {
       const { teamId, userId } = parseMetadata(installation);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const slackTeamId = installation.team!.id;
+      const slackTeamId = assertDefined(installation.team, "installation must have team").id;
       if (installation.bot) {
         const teamData = _.omit(installation, "user", "metadata");
         await db.team_slack_installation.upsert({

--- a/backend/src/slack/commands.ts
+++ b/backend/src/slack/commands.ts
@@ -4,8 +4,8 @@ import { db } from "~db";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
 import { isNotNullish } from "~shared/nullish";
 
+import { isChannelNotFoundError } from "./errors";
 import { getSlackInstallURL } from "./install";
-import { isChannelNotFoundError } from "./utils";
 
 export function setupSlackCommands(slackApp: SlackBolt.App) {
   slackApp.command("/" + process.env.SLACK_SLASH_COMMAND, async ({ command, ack, respond, client, context }) => {

--- a/backend/src/slack/errors.ts
+++ b/backend/src/slack/errors.ts
@@ -1,0 +1,8 @@
+import { WebAPICallError } from "@slack/web-api";
+
+export const isWebAPIErrorType = (error: unknown, errorType: string) => {
+  const webError = error as unknown as WebAPICallError;
+  return "data" in webError && webError.data.error == errorType;
+};
+
+export const isChannelNotFoundError = (error: unknown) => isWebAPIErrorType(error, "channel_not_found");

--- a/backend/src/slack/install.ts
+++ b/backend/src/slack/install.ts
@@ -1,8 +1,14 @@
 import { ActionHandler } from "~backend/src/actions/actionHandlers";
 import { UnprocessableEntityError } from "~backend/src/errors/errorTypes";
 import { getDevPublicTunnel } from "~backend/src/localtunnel";
+import { findSlackUserId } from "~backend/src/slack/utils";
 import { db } from "~db";
-import { GetTeamSlackInstallationUrlInput, GetTeamSlackInstallationUrlOutput } from "~gql";
+import {
+  FindSlackUserInput,
+  FindSlackUserOutput,
+  GetTeamSlackInstallationUrlInput,
+  GetTeamSlackInstallationUrlOutput,
+} from "~gql";
 import { assert } from "~shared/assert";
 import { isDev } from "~shared/dev";
 
@@ -31,19 +37,28 @@ export const getSlackInstallURL = async ({ withBot }: { withBot: boolean }, meta
   });
 };
 
+export const findSlackUser: ActionHandler<{ input: FindSlackUserInput }, FindSlackUserOutput> = {
+  actionName: "find_slack_user",
+
+  async handle(userId, { input: { team_id } }) {
+    const user = await db.user.findUnique({ where: { id: userId } });
+    return { has_slack_user: Boolean(user && (await findSlackUserId(team_id, user))) };
+  },
+};
+
 export const getTeamSlackInstallationURL: ActionHandler<
   { input: GetTeamSlackInstallationUrlInput },
-  Omit<GetTeamSlackInstallationUrlOutput, "__typename">
+  GetTeamSlackInstallationUrlOutput
 > = {
   actionName: "get_team_slack_installation_url",
 
-  async handle(userId, { input: { teamId, redirectURL } }) {
+  async handle(userId, { input: { team_id, redirectURL } }) {
     const team = await db.team.findFirst({
-      where: { id: teamId, team_member: { some: { user_id: userId } } },
+      where: { id: team_id, team_member: { some: { user_id: userId } } },
       include: { team_member: true },
     });
-    assert(team, new UnprocessableEntityError(`Team ${teamId} for member ${userId} not found`));
-    const url = await getSlackInstallURL({ withBot: true }, { teamId, redirectURL, userId });
+    assert(team, new UnprocessableEntityError(`Team ${team_id} for member ${userId} not found`));
+    const url = await getSlackInstallURL({ withBot: true }, { teamId: team_id, redirectURL, userId });
     assert(url, new UnprocessableEntityError("could not get Slack installation URL"));
     return { url };
   },

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -1,10 +1,34 @@
-import { WebAPICallError } from "@slack/web-api";
+import { SlackInstallation, slackClient } from "~backend/src/slack/app";
+import { isWebAPIErrorType } from "~backend/src/slack/errors";
+import { User, db } from "~db";
 
-const isWebAPIErrorType = (error: unknown, errorType: string) => {
-  const webError = error as unknown as WebAPICallError;
-  return "data" in webError && webError.data.error == errorType;
-};
+export async function fetchTeamBotToken(teamId: string) {
+  const slackInstallation = await db.team_slack_installation.findUnique({ where: { team_id: teamId } });
+  if (!slackInstallation) {
+    return;
+  }
+  return (slackInstallation.data as unknown as SlackInstallation)?.bot?.token;
+}
 
-export const isChannelNotFoundError = (error: unknown) => isWebAPIErrorType(error, "channel_not_found");
+// finds a slack user either through the team_member's slack installation or by email
+export async function findSlackUserId(teamId: string, user: User) {
+  const teamMemberSlackInstallation = await db.team_member_slack_installation.findFirst({
+    where: { team_member: { team_id: teamId, user_id: user.id } },
+  });
+  if (teamMemberSlackInstallation) {
+    return teamMemberSlackInstallation.slack_user_id;
+  }
 
-export const isNotInChannelError = (error: unknown) => isWebAPIErrorType(error, "not_in_channel");
+  const token = await fetchTeamBotToken(teamId);
+  if (!token || !user.email) {
+    return;
+  }
+  try {
+    const { user: slackUser } = await slackClient.users.lookupByEmail({ token, email: user.email });
+    return slackUser?.id;
+  } catch (error) {
+    if (!isWebAPIErrorType(error, "users_not_found")) {
+      throw error;
+    }
+  }
+}

--- a/frontend/src/views/TeamMembersView/SlackInstallationButton.tsx
+++ b/frontend/src/views/TeamMembersView/SlackInstallationButton.tsx
@@ -32,7 +32,15 @@ type Props = {
   isCurrentUserTeamOwner: boolean;
 };
 
-function AddSlackInstallationButton({ teamId }: { teamId: string }) {
+export function AddSlackInstallationButton({
+  teamId,
+  tooltip,
+  withBot,
+}: {
+  teamId: string;
+  tooltip: string;
+  withBot?: boolean;
+}) {
   const { data: slackInstallationData } = useQuery<GetSlackInstallationUrlQuery, GetSlackInstallationUrlQueryVariables>(
     gql`
       query GetSlackInstallationURL($input: GetTeamSlackInstallationURLInput!) {
@@ -43,7 +51,7 @@ function AddSlackInstallationButton({ teamId }: { teamId: string }) {
     `,
     {
       skip: isServer,
-      variables: { input: { teamId, redirectURL: isServer ? "" : location.href } },
+      variables: { input: { team_id: teamId, with_bot: !!withBot, redirectURL: isServer ? "" : location.href } },
     }
   );
 
@@ -57,7 +65,7 @@ function AddSlackInstallationButton({ teamId }: { teamId: string }) {
       }}
       icon={<IconPlus />}
       iconPosition="start"
-      tooltip="Enable your team to receive notifications through Slack"
+      tooltip={tooltip}
     >
       Add Slack integration
     </UISlackButton>
@@ -117,7 +125,13 @@ function _SlackInstallationButton({ team, isCurrentUserTeamOwner }: Props) {
   if (team.slack_installation) {
     return isCurrentUserTeamOwner ? <RemoveSlackInstallationButton teamId={team.id} /> : null;
   } else {
-    return <AddSlackInstallationButton teamId={team.id} />;
+    return (
+      <AddSlackInstallationButton
+        teamId={team.id}
+        tooltip="Enable your team to receive notifications through Slack"
+        withBot
+      />
+    );
   }
 }
 

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -1,4 +1,8 @@
 type Query {
+  find_slack_user(input: FindSlackUserInput!): FindSlackUserOutput
+}
+
+type Query {
   get_team_slack_installation_url(input: GetTeamSlackInstallationURLInput!): GetTeamSlackInstallationURLOutput
 }
 
@@ -24,7 +28,12 @@ type Mutation {
 
 input GetTeamSlackInstallationURLInput {
   redirectURL: String!
-  teamId: uuid!
+  team_id: uuid!
+  with_bot: Boolean!
+}
+
+input FindSlackUserInput {
+  team_id: uuid!
 }
 
 type UpgradeUserResponse {
@@ -57,4 +66,8 @@ type ResendInvitationResponse {
 
 type GetTeamSlackInstallationURLOutput {
   url: String!
+}
+
+type FindSlackUserOutput {
+  has_slack_user: Boolean!
 }

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -1,4 +1,13 @@
 actions:
+- name: find_slack_user
+  definition:
+    kind: ""
+    handler: '{{HASURA_ACTIONS_WEBHOOK_URL}}'
+    headers:
+    - name: Authorization
+      value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
+  permissions:
+  - role: user
 - name: get_team_slack_installation_url
   definition:
     kind: ""
@@ -59,6 +68,7 @@ custom_types:
   enums: []
   input_objects:
   - name: GetTeamSlackInstallationURLInput
+  - name: FindSlackUserInput
   objects:
   - name: UpgradeUserResponse
     relationships:
@@ -76,4 +86,5 @@ custom_types:
   - name: RoomInvitationViewResponse
   - name: ResendInvitationResponse
   - name: GetTeamSlackInstallationURLOutput
+  - name: FindSlackUserOutput
   scalars: []


### PR DESCRIPTION
My first stab notification implementation was a tad naive, in so far that it would only notify via Slack if it found a user with the same email as the user's acapela email. This here implementation first tries to find an individual's slack installation (`team_member_slack_installation`) when sending out notifications, and only falls back to email if there is none.

Additionally I've reused the add-slack-installation button, for when no slack user is found for a given email. Example:

https://user-images.githubusercontent.com/4051932/134030050-08a1ec72-4d50-436a-81b0-dbe381ba5603.mov

