### PR TITLE
feat: redirect to /team page after team is created

### DIFF
--- a/frontend/src/layouts/AppLayout/TeamPicker/index.tsx
+++ b/frontend/src/layouts/AppLayout/TeamPicker/index.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
-import { routes } from "~frontend/../router";
 import { trackEvent } from "~frontend/analytics/tracking";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { createTeam, useTeamsQuery } from "~frontend/gql/teams";
 import { changeCurrentTeamId } from "~frontend/gql/user";
+import { routes } from "~frontend/router";
 import { openUIPrompt } from "~frontend/utils/prompt";
 import { createLengthValidator } from "~shared/validation/inputValidation";
 import { Button } from "~ui/buttons/Button";


### PR DESCRIPTION
Improve onboarding experience by going directly to `/team` page after team is created.