### PR TITLE
ACA-699 Open ssh connection for debugging if e2e tests fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
     concurrency:
       group: e2e-${{ github.ref }}
       cancel-in-progress: true
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
This will open an ssh server to debug flaky e2e tests. We will remove this once the stability has improved.