### PR TITLE
fix: topic & task indexes for heavily queried fields

### DIFF
--- a/infrastructure/hasura/migrations/default/1632907042461_topic-task-indexes/down.sql
+++ b/infrastructure/hasura/migrations/default/1632907042461_topic-task-indexes/down.sql
@@ -1,0 +1,8 @@
+
+DROP INDEX IF EXISTS "task_updated_at_index";
+
+DROP INDEX IF EXISTS "task_done_at_index";
+
+DROP INDEX IF EXISTS "topic_updated_at_index";
+
+DROP INDEX IF EXISTS "topic_closed_at_index";

--- a/infrastructure/hasura/migrations/default/1632907042461_topic-task-indexes/up.sql
+++ b/infrastructure/hasura/migrations/default/1632907042461_topic-task-indexes/up.sql
@@ -1,0 +1,12 @@
+
+CREATE  INDEX "topic_closed_at_index" on
+  "public"."topic" using btree ("closed_at");
+
+CREATE  INDEX "topic_updated_at_index" on
+  "public"."topic" using btree ("updated_at");
+
+CREATE  INDEX "task_done_at_index" on
+  "public"."task" using btree ("done_at");
+
+CREATE  INDEX "task_updated_at_index" on
+  "public"."task" using btree ("updated_at");


### PR DESCRIPTION
Some glaring omissions from our indexing. Wish we could lint against writing subscriptions conditional on non-indexed fields.

@pie6k I happened to stumble over these while looking at query plans, hope it was alright that I picked that from your plate. 