### PR TITLE
[ship] chore: use buildx for docker builds

### DIFF
--- a/infrastructure/kubernetes/docker/graphql-engine/build.sh
+++ b/infrastructure/kubernetes/docker/graphql-engine/build.sh
@@ -16,5 +16,5 @@ image_name_version="$image_name:$version"
 
 echo "image: $image_name_version"
 
-docker build -t $image_name_version .
+docker buildx build --platform linux/amd64 -t $image_name_version .
 docker tag $image_name_version $image_name


### PR DESCRIPTION
This is required for build `amd64` images on a `arm64` M1 mac.