### PR TITLE
fix: apply team scope to client db graphql queries

### DIFF
--- a/frontend/src/clientdb/lastSeenMessage.ts
+++ b/frontend/src/clientdb/lastSeenMessage.ts
@@ -38,6 +38,7 @@ export const lastSeenMessageEntity = defineEntity<LastSeenMessageFragment>({
   sync: createHasuraSyncSetupFromFragment<LastSeenMessageFragment>(lastSeenMessageFragment, {
     insertColumns: ["id", "message_id", "seen_at", "topic_id"],
     updateColumns: ["message_id", "topic_id", "seen_at"],
+    teamScopeCondition: (teamId) => ({ topic: { team_id: { _eq: teamId } } }),
   }),
 }).addConnections((lastSeenMessage, { getEntity }) => {
   return {

--- a/frontend/src/clientdb/message.ts
+++ b/frontend/src/clientdb/message.ts
@@ -47,6 +47,7 @@ export const messageEntity = defineEntity<MessageFragment>({
   sync: createHasuraSyncSetupFromFragment<MessageFragment>(messageFragment, {
     insertColumns: ["id", "content", "replied_to_message_id", "topic_id", "type"],
     updateColumns: ["content"],
+    teamScopeCondition: (teamId) => ({ topic: { team_id: { _eq: teamId } } }),
   }),
   customObservableAnnotations: {
     // Content might be very nested and we dont want to observe any single change in it. We always change content as a whole.

--- a/frontend/src/clientdb/messageReaction.ts
+++ b/frontend/src/clientdb/messageReaction.ts
@@ -35,6 +35,7 @@ export const messageReactionEntity = defineEntity<MessageReactionFragment>({
   sync: createHasuraSyncSetupFromFragment<MessageReactionFragment>(messageReactionFragment, {
     insertColumns: ["id", "emoji", "user_id", "message_id"],
     updateColumns: ["emoji"],
+    teamScopeCondition: (teamId) => ({ message: { topic: { team_id: { _eq: teamId } } } }),
   }),
 }).addConnections((reaction, { getEntity, getContextValue }) => {
   return {

--- a/frontend/src/clientdb/task.ts
+++ b/frontend/src/clientdb/task.ts
@@ -42,6 +42,7 @@ export const taskEntity = defineEntity<TaskFragment>({
   sync: createHasuraSyncSetupFromFragment<TaskFragment>(taskFragment, {
     insertColumns: ["done_at", "due_at", "user_id", "seen_at", "type", "message_id", "id"],
     updateColumns: ["done_at", "due_at", "seen_at"],
+    teamScopeCondition: (teamId) => ({ message: { topic: { team_id: { _eq: teamId } } } }),
   }),
 }).addConnections((task, { getEntity, getContextValue }) => {
   const connections = {

--- a/frontend/src/clientdb/teamMember.ts
+++ b/frontend/src/clientdb/teamMember.ts
@@ -31,6 +31,7 @@ export const teamMemberEntity = defineEntity<TeamMemberFragment>({
   sync: createHasuraSyncSetupFromFragment<TeamMemberFragment>(teamMemberFragment, {
     insertColumns: ["id", "team_id", "user_id", "notify_email", "notify_slack"],
     updateColumns: ["notify_email", "notify_slack"],
+    teamScopeCondition: (teamId) => ({ team_id: { _eq: teamId } }),
   }),
 }).addConnections((teamMember, { getEntity }) => ({
   get user() {

--- a/frontend/src/clientdb/teamMemberSlack.ts
+++ b/frontend/src/clientdb/teamMemberSlack.ts
@@ -28,5 +28,6 @@ export const teamMemberSlackEntity = defineEntity<TeamMemberSlackFragment>({
   sync: createHasuraSyncSetupFromFragment<TeamMemberSlackFragment>(teamMemberSlackFragment, {
     insertColumns: [],
     updateColumns: [],
+    teamScopeCondition: (teamId) => ({ team_member: { team_id: { _eq: teamId } } }),
   }),
 });

--- a/frontend/src/clientdb/topic.ts
+++ b/frontend/src/clientdb/topic.ts
@@ -79,6 +79,7 @@ export const topicEntity = defineEntity<TopicFragment>({
       "owner_id",
       "slug",
     ],
+    teamScopeCondition: (teamId) => ({ team_id: { _eq: teamId } }),
   }),
   search: { fields: { name: true } },
 })

--- a/frontend/src/clientdb/transcription.ts
+++ b/frontend/src/clientdb/transcription.ts
@@ -29,6 +29,7 @@ export const transcriptionEntity = defineEntity<TranscriptionFragment>({
   sync: createHasuraSyncSetupFromFragment<TranscriptionFragment>(transcriptionFragment, {
     insertColumns: [],
     updateColumns: [],
+    teamScopeCondition: (teamId) => ({ attachments: { message: { topic: { team_id: { _eq: teamId } } } } }),
   }),
 });
 

--- a/frontend/src/clientdb/user.ts
+++ b/frontend/src/clientdb/user.ts
@@ -36,6 +36,7 @@ export const userEntity = defineEntity<UserFragment>({
     // TODO currently clientdb is not working for user updates, as user insert is not allowed on db (so upsert as well)
     insertColumns: [],
     updateColumns: [],
+    teamScopeCondition: (teamId) => ({ team_memberships: { team_id: { _eq: teamId } } }),
   }),
 }).addConnections((user, { getEntity, getContextValue }) => {
   return {

--- a/infrastructure/hasura/metadata/databases/default/tables/public_last_seen_message.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_last_seen_message.yaml
@@ -1,6 +1,16 @@
 table:
   name: last_seen_message
   schema: public
+object_relationships:
+- name: message
+  using:
+    foreign_key_constraint_on: message_id
+- name: topic
+  using:
+    foreign_key_constraint_on: topic_id
+- name: user
+  using:
+    foreign_key_constraint_on: user_id
 insert_permissions:
 - permission:
     backend_only: false


### PR DESCRIPTION
Previously we did fetch all items we had access to using clientdb.

This adds option for setting additional 'where' conditions basing on current team id.