### PR TITLE
fix: make SideBarLayout > MainContent scrollable

### DIFF
--- a/frontend/src/layouts/SidebarLayout/index.tsx
+++ b/frontend/src/layouts/SidebarLayout/index.tsx
@@ -104,7 +104,7 @@ const UIMainContent = styled.div<{}>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-y: hidden;
+  overflow-y: auto;
 `;
 
 const UIMainContentBody = styled.div`


### PR DESCRIPTION
...thus making Settings scrollable again. TopicWithMessages still has its own scroller due to `min-height: 0`