### PR TITLE
feat: remap shortcuts

### DIFF
--- a/frontend/src/layouts/SidebarLayout/SidebarContent.tsx
+++ b/frontend/src/layouts/SidebarLayout/SidebarContent.tsx
@@ -39,7 +39,7 @@ export const SidebarContent = observer(function SidebarContent() {
           ref={searchInputRef}
         ></UISearchPlaceholder>
         <Shortcut
-          shortcut={["Mod", "/"]}
+          shortcut={["Mod", "K"]}
           callback={() => {
             searchInputRef.current?.focus();
           }}

--- a/frontend/src/views/RequestView/TopicWithMessages/NewMessageButtons.tsx
+++ b/frontend/src/views/RequestView/TopicWithMessages/NewMessageButtons.tsx
@@ -71,7 +71,7 @@ export const NewMessageButtons = observer(({ topic, onSendRequest, onCompleteReq
       )}
       {actions.includes("complete") && (
         <Button
-          shortcut={["Mod", "C"]}
+          shortcut={["Mod", "Enter"]}
           kind={primaryAction === "complete" ? "primary" : "secondary"}
           tooltip="Send and complete pending tasks"
           onClick={onCompleteRequest}
@@ -81,7 +81,7 @@ export const NewMessageButtons = observer(({ topic, onSendRequest, onCompleteReq
       )}
       {actions.includes("close-request") && (
         <Button
-          shortcut={["Mod", "X"]}
+          shortcut={["Mod", "J"]}
           kind={primaryAction === "close-request" ? "primary" : "secondary"}
           tooltip="Close entire request"
           onClick={onCloseRequest}

--- a/richEditor/RichEditor.tsx
+++ b/richEditor/RichEditor.tsx
@@ -218,7 +218,6 @@ export const RichEditor = namedForwardRef<Editor, RichEditorProps>(function Rich
   }
 
   useShortcut(["Shift", "Enter"], handleEnterShortcut, { isEnabled: isFocused });
-  useShortcut(["Meta", "Enter"], handleEnterShortcut, { isEnabled: isFocused });
 
   /**
    * Let's use any key pressed to instantly focus inside the editor


### PR DESCRIPTION
I think the shortcuts are mapped in unfortunate ways at the moment, namely they overwrite copy/cut and Safari/Firefox's show statusbar action (Cmd+J). I tried my hand at at it, comments inline.