### PR TITLE
fix: add missing task_pkey constraint

### DIFF
--- a/infrastructure/hasura/migrations/default/1634368156001_alter_table_public_task_add_primary_key_constraint/down.sql
+++ b/infrastructure/hasura/migrations/default/1634368156001_alter_table_public_task_add_primary_key_constraint/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ONLY public.task DROP CONSTRAINT IF EXISTS task_pkey;

--- a/infrastructure/hasura/migrations/default/1634368156001_alter_table_public_task_add_primary_key_constraint/up.sql
+++ b/infrastructure/hasura/migrations/default/1634368156001_alter_table_public_task_add_primary_key_constraint/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ONLY public.task DROP CONSTRAINT IF EXISTS task_pkey;
+ALTER TABLE ONLY public.task
+    ADD CONSTRAINT task_pkey PRIMARY KEY (id);


### PR DESCRIPTION
Whenever we're trying to update a task, we're getting this error:

```json
{
   "errors":[
      {
         "extensions":{
            "path":"$.selectionSet.insert_task_one.args.object",
            "code":"permission-error"
         },
         "message":"check constraint of an insert/update permission has failed"
      }
   ]
}
```

We're adding a `task_pkey` constraint into our gql mutation:

<img width="429" alt="Screenshot 2021-10-16 at 10 18 47" src="https://user-images.githubusercontent.com/4765697/137577940-26ca351e-0c70-4533-9a9f-d0a26bb5be9b.png">

I've checked in our codebase and into our past migration files and I couldn't find any indication of a `task_pkey` added as constraint in the task table. It seems that it got lost during a migration squash.

This PR re-adds the constraint.