### PR TITLE
feat: show due date label on request item

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
@@ -18,8 +18,8 @@ interface Props {
   topic: TopicEntity;
 }
 
-const sortByEarliestDueDate = (task: TaskEntity) => task.due_at;
-const filterByUnfinishedTasksAssingedToCurrentUser = (task: TaskEntity) =>
+const sortByEarliestTaskDueDate = (task: TaskEntity) => task.due_at;
+const filterByUnfinishedTasksAssignedToCurrentUser = (task: TaskEntity) =>
   task.isAssignedToSelf && !!task.due_at && !task.isDone;
 
 const getRelativeDueTimeLabel = (rawDate: string) => {
@@ -56,8 +56,8 @@ export const RequestItem = observer(function RequestItem({ topic }: Props) {
 
   const unreadMessagesCount = topic.unreadMessages.count;
   const unfinishedTaskWithEarliestDueDate = topic.tasks.query(
-    filterByUnfinishedTasksAssingedToCurrentUser,
-    sortByEarliestDueDate
+    filterByUnfinishedTasksAssignedToCurrentUser,
+    sortByEarliestTaskDueDate
   ).first;
 
   return (


### PR DESCRIPTION
<img width="299" alt="Screenshot 2021-10-17 at 16 06 14" src="https://user-images.githubusercontent.com/4765697/137628516-6217a599-c2cb-4a11-b7d5-0c6568c1ff5e.png">

All possible due date labels are (ordered from time asc):
- X Days Ago
- 1 Day Ago
- X Hours Ago
- 1 Hour Ago
- Recently past due
- Due soon
- 1 Hour Left
- X Hours Left
- 1 Day Left
- X Days Left