### PR TITLE
fix: day difference showing 0

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
@@ -1,4 +1,4 @@
-import { differenceInDays, differenceInHours, differenceInMinutes, isBefore, isToday } from "date-fns";
+import { differenceInDays, differenceInHours, differenceInMinutes, isBefore, isToday, startOfDay } from "date-fns";
 import { observer } from "mobx-react";
 import Link from "next/link";
 import React from "react";
@@ -23,18 +23,21 @@ const filterByUnfinishedTasksAssignedToCurrentUser = (task: TaskEntity) =>
   task.isAssignedToSelf && !!task.due_at && !task.isDone;
 
 const getRelativeDueTimeLabel = (rawDate: string) => {
-  const dueDate = new Date(rawDate);
   const now = new Date();
+  const dueDate = new Date(rawDate);
+  const dayOfDueDate = startOfDay(dueDate);
+  const today = startOfDay(now);
+
   const isPastDue = isBefore(dueDate, now);
-  const isDueToday = isToday(dueDate);
+  const isDueToday = isToday(dayOfDueDate);
 
   const isLessThan1HourFromNow = Math.abs(differenceInMinutes(now, dueDate)) < 60;
   if (isLessThan1HourFromNow) {
     return isPastDue ? "Recently past due" : "Due soon";
   }
 
-  const getHoursFromDueDate = () => (isPastDue ? differenceInHours(now, dueDate) : differenceInHours(dueDate, now));
-  const getDaysFromDueDate = () => (isPastDue ? differenceInDays(now, dueDate) : differenceInDays(dueDate, now));
+  const getHoursFromDueDate = () => Math.abs(differenceInHours(now, dueDate));
+  const getDaysFromDueDate = () => Math.abs(differenceInDays(today, dayOfDueDate));
 
   const amount = isDueToday ? getHoursFromDueDate() : getDaysFromDueDate();
   const hourOrDay = isDueToday ? "Hour" : "Day";


### PR DESCRIPTION
There was a bug that was allowing the relative date to be shown as "0 Days Left" or "0 Days Ago".

This happened because `date-fns`'s `differenceInDays` is calculating days as full 24 hour blocks between 2 dates. This was fixed by using `startOfDay` which makes the time component of the date to be "00:00:00", and thus making any distinct calendar day have blocks of 24h difference between them. 

This way we'll get "1 Day Ago" for any due dates that happened yesterday, even if that due date was less than 24 hours ago from now.