### PR TITLE
fix: sets date for all tasks in request

### DIFF
--- a/frontend/src/ui/message/messagesFeed/tasks/MessageTasks.tsx
+++ b/frontend/src/ui/message/messagesFeed/tasks/MessageTasks.tsx
@@ -38,7 +38,7 @@ export const MessageTasks = styledObserver(({ message }: Props) => {
   return (
     <UIHolder>
       <AnimateSharedLayout>
-        <TaskDueDateSetter task={firstTask}>
+        <TaskDueDateSetter message={message}>
           <Button
             kind="secondary"
             icon={<IconClock />}


### PR DESCRIPTION
MessagesFeed → MessageTasks → TaskDueDateSetter was only updating the first task in the message. Now we update the due dates of all of the tasks in that request.