### PR TITLE
fix: relaxes insert permissions for tasks

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
@@ -12,9 +12,14 @@ insert_permissions:
 - permission:
     backend_only: false
     check:
-      message:
-        user_id:
-          _eq: X-Hasura-User-Id
+      _or:
+      - message:
+          user_id:
+            _eq: X-Hasura-User-Id
+      - message:
+          tasks:
+            user_id:
+              _eq: X-Hasura-User-Id
     columns:
     - done_at
     - due_at

--- a/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
@@ -13,6 +13,5 @@
 - "!include public_topic.yaml"
 - "!include public_transcription.yaml"
 - "!include public_transcription_status.yaml"
-- "!include public_unread_messages.yaml"
 - "!include public_user.yaml"
 - "!include public_whitelist.yaml"


### PR DESCRIPTION
# Problem

ClientDB is using upsert to insert or update data.

The Hasura permissions to Update a task allows the task assignee to modify the data. However, the the insert permission for the Task only allows the message owner to insert a task attached to that message.

I removed the permissions for insert task. And everything worked again

My theory is that the upsert is trying to insert first, but couldn’t even reach the conflict as it doesn’t even have a permission to add a task.

# FIX
Relaxed permissions. Allowing any owners of tasks that are related to a message to insert more tasks.

# Other

I think this only works temp. We have to take a good look if we're opening up security holes just to make permissions work with upserts 👀  and refactor if that's the case