### PR TITLE
fix: clientdb unconditional user sync to make invites work again

### DIFF
--- a/frontend/src/clientdb/user.ts
+++ b/frontend/src/clientdb/user.ts
@@ -36,7 +36,7 @@ export const userEntity = defineEntity<UserFragment>({
     // TODO currently clientdb is not working for user updates, as user insert is not allowed on db (so upsert as well)
     insertColumns: [],
     updateColumns: [],
-    teamScopeCondition: (teamId) => ({ team_memberships: { team_id: { _eq: teamId } } }),
+    // teamScopeCondition: (teamId) => ({ team_memberships: { team_id: { _eq: teamId } } }),
   }),
 }).addConnections((user, { getEntity, getContextValue }) => {
   return {


### PR DESCRIPTION
This fix is more of a hack with some assumptions. With this we now unconditionally (independent of the selected team) sync users. What this is fixing is that inviting existing users to a team wouldn't lead to them showing up, because they were excluded by the teamScopeCondition.
The assumption this makes is that we're only accessing users through `team_member.user`/`team.owner`/etc. so, in contrast to topics, this shouldn't lead to team-unrelated data being shown.

I think this might hint at a more fundamental problem with teamScopeCondition where data that is being connected to a team, without it bumping its `updated_at`, won't show up. I'm wondering if we should just sync everything instead and just make sure to query things appropriately in the frontend (we do have `useCurrentTeamId` after all).