### PR TITLE
fix: create entity for teamSlackInstallation

### DIFF
--- a/frontend/src/clientdb/index.tsx
+++ b/frontend/src/clientdb/index.tsx
@@ -19,6 +19,7 @@ import { messageEntity } from "./message";
 import { messageReactionEntity } from "./messageReaction";
 import { taskEntity } from "./task";
 import { teamEntity } from "./team";
+import { teamSlackInstallationEntity } from "./teamSlackInstallation";
 import { topicEntity } from "./topic";
 import { transcriptionEntity } from "./transcription";
 import { userEntity } from "./user";
@@ -49,6 +50,7 @@ export function createNewClientDb(userId: string, teamId: string | null, apolloC
       team: teamEntity,
       teamMember: teamMemberEntity,
       teamMemberSlack: teamMemberSlackEntity,
+      teamSlackInstallation: teamSlackInstallationEntity,
       task: taskEntity,
       messageReaction: messageReactionEntity,
       lastSeenMessage: lastSeenMessageEntity,

--- a/frontend/src/clientdb/team.ts
+++ b/frontend/src/clientdb/team.ts
@@ -5,6 +5,7 @@ import { EntityByDefinition } from "~clientdb/entity/entity";
 import { TeamFragment } from "~gql";
 
 import { teamMemberEntity } from "./teamMember";
+import { teamSlackInstallationEntity } from "./teamSlackInstallation";
 import { getFragmentKeys } from "./utils/analyzeFragment";
 import { userIdContext } from "./utils/context";
 import { getGenericDefaultData } from "./utils/getGenericDefaultData";
@@ -17,9 +18,6 @@ const teamFragment = gql`
     slug
     owner_id
     updated_at
-    slack_installation {
-      team_id
-    }
   }
 `;
 
@@ -41,7 +39,9 @@ export const teamEntity = defineEntity<TeamFragment>({
     updateColumns: [],
   }),
 }).addConnections((team, { getEntity }) => ({
-  hasSlackInstallation: !!team.slack_installation?.team_id,
+  get hasSlackInstallation() {
+    return getEntity(teamSlackInstallationEntity).query({ team_id: team.id }).count > 0;
+  },
   members: getEntity(teamMemberEntity).query({ team_id: team.id }),
 }));
 

--- a/frontend/src/clientdb/teamSlackInstallation.ts
+++ b/frontend/src/clientdb/teamSlackInstallation.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+
+import { defineEntity } from "~clientdb";
+import { EntityByDefinition } from "~clientdb/entity/entity";
+import { TeamSlackInstallationFragment } from "~gql";
+
+import { getFragmentKeys } from "./utils/analyzeFragment";
+import { createHasuraSyncSetupFromFragment } from "./utils/sync";
+
+const teamSlackInstallationFragment = gql`
+  fragment TeamSlackInstallation on team_slack_installation {
+    id
+    team_id
+    updated_at
+  }
+`;
+
+export const teamSlackInstallationEntity = defineEntity<TeamSlackInstallationFragment>({
+  name: "team_slack_installation",
+  updatedAtField: "updated_at",
+  keyField: "id",
+  keys: getFragmentKeys<TeamSlackInstallationFragment>(teamSlackInstallationFragment),
+  sync: createHasuraSyncSetupFromFragment<TeamSlackInstallationFragment>(teamSlackInstallationFragment, {
+    insertColumns: [],
+    updateColumns: [],
+  }),
+});
+
+export type TeamSlackInstallationEntity = EntityByDefinition<typeof teamSlackInstallationEntity>;

--- a/infrastructure/hasura/metadata/databases/default/tables/public_team_slack_installation.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_team_slack_installation.yaml
@@ -8,7 +8,9 @@ object_relationships:
 select_permissions:
 - permission:
     columns:
+    - id
     - team_id
+    - updated_at
     filter:
       team:
         memberships:

--- a/infrastructure/hasura/migrations/default/1634578460243_add_team_slack_installation_entity_fields/up.sql
+++ b/infrastructure/hasura/migrations/default/1634578460243_add_team_slack_installation_entity_fields/up.sql
@@ -1,0 +1,24 @@
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+alter table "public"."team_slack_installation" add column "id" uuid
+ not null default gen_random_uuid();
+
+alter table "public"."team_slack_installation" add column "updated_at" timestamptz
+ not null default now();
+
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_team_slack_installation_updated_at"
+BEFORE UPDATE ON "public"."team_slack_installation"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_team_slack_installation_updated_at" ON "public"."team_slack_installation" 
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';


### PR DESCRIPTION
This way we get a sync when slack installs. Currently this is buggin on stage/prod since after adding the slack installation, the buttons are still showing (and the flow is erroring out when run again)