### PR TITLE
feat: add existing-user invite and task creation notifications

### DIFF
--- a/backend/src/events/events.ts
+++ b/backend/src/events/events.ts
@@ -4,6 +4,7 @@ import { handleAttachmentUpdates } from "~backend/src/attachments/events";
 import { extractAndAssertBearerToken } from "~backend/src/authentication";
 import { AuthenticationError } from "~backend/src/errors/errorTypes";
 import { handleMessageChanges } from "~backend/src/messages/events";
+import { handleTaskChanges } from "~backend/src/tasks/taskHandlers";
 import { handleTeamMemberDeleted } from "~backend/src/teamMember/events";
 import { handleTeamUpdates } from "~backend/src/teams/events";
 import { handleTopicUpdates } from "~backend/src/topics/events";
@@ -21,6 +22,7 @@ hasuraEvents.addHandler("topic_updates", ["UPDATE"], handleTopicUpdates);
 hasuraEvents.addHandler("attachment_updates", ["UPDATE"], handleAttachmentUpdates);
 // Create plain text version of each message so it can be used by search views.
 hasuraEvents.addHandler("message_updates", ["INSERT", "UPDATE", "DELETE"], handleMessageChanges);
+hasuraEvents.addHandler("task_updates", ["INSERT"], handleTaskChanges);
 hasuraEvents.addHandler("team_member_updates", ["DELETE"], handleTeamMemberDeleted);
 hasuraEvents.addAnyEventHandler(handleCreateSyncRequests);
 

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -14,7 +14,7 @@ export async function fetchTeamBotToken(teamId: string) {
 }
 
 // finds a slack user either through the team_member's slack installation or by email
-export async function findSlackUserId(teamId: string, user: User) {
+export async function findSlackUserId(teamId: string, user: User): Promise<string | undefined> {
   const teamMemberSlack = await db.team_member_slack.findFirst({
     where: { team_member: { team_id: teamId, user_id: user.id } },
   });
@@ -70,3 +70,8 @@ export const createLinkSlackWithAcapelaView = ({ triggerId }: { triggerId: strin
     ],
   },
 });
+
+export async function getSlackUserMentionOrLabel(user: User, teamId: string) {
+  const invitingUserSlackId = await findSlackUserId(teamId, user);
+  return invitingUserSlackId ? `<@${invitingUserSlackId}>` : user.name;
+}

--- a/backend/src/tasks/taskHandlers.ts
+++ b/backend/src/tasks/taskHandlers.ts
@@ -1,4 +1,9 @@
-import { Topic, db } from "~db";
+import { HasuraEvent } from "~backend/src/hasura";
+import { sendNotificationPerPreference } from "~backend/src/notifications/sendNotification";
+import { getSlackUserMentionOrLabel } from "~backend/src/slack/utils";
+import { Task, Topic, db } from "~db";
+import { assert } from "~shared/assert";
+import { routes } from "~shared/routes";
 
 export async function markAllOpenTasksAsDone(topic: Topic) {
   const nowInTimestamp = new Date().toISOString();
@@ -15,5 +20,31 @@ export async function markAllOpenTasksAsDone(topic: Topic) {
         done_at: { equals: null },
       },
     },
+  });
+}
+
+export async function handleTaskChanges(event: HasuraEvent<Task>) {
+  if (event.type !== "create") {
+    return;
+  }
+  const task = event.item;
+  const [fromUser, toUser, topic] = await Promise.all([
+    db.user.findFirst({ where: { message: { some: { id: task.message_id } } } }),
+    db.user.findUnique({ where: { id: task.user_id } }),
+    db.topic.findFirst({ where: { message: { some: { id: task.message_id } } } }),
+  ]);
+
+  assert(fromUser && toUser && topic, "must have users and topic");
+
+  const teamId = topic.team_id;
+  const topicURL = `${process.env.FRONTEND_URL}${routes.topic({ topicSlug: topic.slug })}`;
+  const slackFrom = await getSlackUserMentionOrLabel(fromUser, teamId);
+  const taskLabel = task.type == "request-response" ? "feedback" : "confirmation";
+  await sendNotificationPerPreference(toUser, teamId, {
+    email: {
+      subject: `${fromUser.name} created a request for you in ${topic.name}`,
+      html: `Click <a href="${topicURL}">here</a> to find out what they need.`,
+    },
+    slack: `${slackFrom} has asked for your ${taskLabel} in <${topicURL}|${topic.name}>`,
   });
 }


### PR DESCRIPTION
Looks like we threw the baby out with the bath water and didn't have email/slack notifications for task creation anymore. This adds it back plus team notifications for pre-existing users.

Fixes ACA-752, ACA-794