### PR TITLE
chore: error out on eslint warnings

### DIFF
--- a/backend/src/notifications/sendNotification.ts
+++ b/backend/src/notifications/sendNotification.ts
@@ -1,7 +1,7 @@
 import { slackClient } from "~backend/src/slack/app";
 import { fetchTeamBotToken, findSlackUserId } from "~backend/src/slack/utils";
-import { TeamMember, User, db } from "~db";
-import { assert, assertDefined } from "~shared/assert";
+import { User, db } from "~db";
+import { assertDefined } from "~shared/assert";
 import { DEFAULT_NOTIFICATION_EMAIL, sendEmail } from "~shared/email";
 import { Sentry } from "~shared/sentry";
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "hasura:console:proxy": "./scripts/hasura-console-proxy.sh",
     "hasura:update": "yarn hasura:meta && yarn hasura:migrations && yarn hasura:seeds && yarn hasura:meta:reload",
     "tooling:gql-types": "tooling gql frontend --watch",
-    "lint": "eslint . && prettier --check .",
+    "lint": "eslint --max-warnings=0 . && prettier --check .",
     "test": "yarn frontend:test && yarn backend:test",
     "format": "eslint --fix . && prettier --write .",
     "postinstall": "husky install",


### PR DESCRIPTION
For me eslint pre-commit warnings don't rise to the level of attention. Given us being quite diligent and our eslint not being too strict, I'd prefer it erroring out on the rules we have. Also with the new ship-PRs system there's fewer opportunities  for team mates to re-raise eslint issues.