### PR TITLE
fix: scroll to last message

### DIFF
--- a/frontend/src/views/RequestView/TopicWithMessages/index.tsx
+++ b/frontend/src/views/RequestView/TopicWithMessages/index.tsx
@@ -70,7 +70,7 @@ export const TopicWithMessages = observer(({ topic }: { topic: TopicEntity }) =>
           </UIParticipants>
         </UIHead>
 
-        <ScrollableMessages ref={scrollerRef as never}>
+        <ScrollableMessages key={topic.id} ref={scrollerRef as never}>
           <AnimateSharedLayout>
             <MessagesFeed onCloseTopicRequest={onCloseTopicRequest} messages={messages} />
             {/* TODO: Replace with events */}


### PR DESCRIPTION
Related to ACA-791

Previously we `key=`d `TopicWithMessages` thus causing re-creation of the component and its state, which is something `ScrollToBottomMonitor` depended on. Now I just keyed it directly.