### PR TITLE
feat: no tooltips in topic preview

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestContentSnippet.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestContentSnippet.tsx
@@ -94,7 +94,7 @@ export const RequestContentSnippet = observer(({ topic }: Props) => {
   }
 
   return (
-    <UIHolder>
+    <UIHolder data-no-tooltips>
       <MessageText content={contentSnippet} />
     </UIHolder>
   );

--- a/ui/popovers/TooltipsRenderer.tsx
+++ b/ui/popovers/TooltipsRenderer.tsx
@@ -33,6 +33,9 @@ export function TooltipsRenderer() {
       const tooltipInfo = getClosestElementTooltipInfo(target);
 
       if (!tooltipInfo) return;
+
+      if (tooltipInfo.element.matches("[data-no-tooltips] *")) return;
+
       setCurrentTooltipAnchor(tooltipInfo.element);
     },
     { capture: true }


### PR DESCRIPTION
It is managed by adding special `data-no-tooltips` attribute to parent element. 