### PR TITLE
chore: remove pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint


### PR DESCRIPTION
For me it does not serve a purpose, but it does annoy me a little because it slows down pushing & errors out on eslint problems for files that might not even be committed. Okay the latter one I exacerbated over in #539.

We already lint what's staged before commit, and then lint everything in each PR. So I don't think this will be controversial, but for everybody's-workflow-affecting things I like going with the ask-label.