### PR TITLE
feat: updated at index in db for all missing tables

### DIFF
--- a/infrastructure/hasura/migrations/default/1634889129443_indexes_for_updated_at_columns/down.sql
+++ b/infrastructure/hasura/migrations/default/1634889129443_indexes_for_updated_at_columns/down.sql
@@ -1,0 +1,20 @@
+
+DROP INDEX IF EXISTS "user_updated_at_key";
+
+DROP INDEX IF EXISTS "transcription_updated_at_key";
+
+DROP INDEX IF EXISTS "team_slack_installation_updated_at_key";
+
+DROP INDEX IF EXISTS "team_member_slack_installation_updated_at_key";
+
+DROP INDEX IF EXISTS "team_member_updated_at_key";
+
+DROP INDEX IF EXISTS "team_updated_at_key";
+
+DROP INDEX IF EXISTS "message_reaction_updated_at_key";
+
+DROP INDEX IF EXISTS "last_seen_message_updated_at_key";
+
+DROP INDEX IF EXISTS "attachment_updated_at_key";
+
+DROP INDEX IF EXISTS "account_updated_at_key";

--- a/infrastructure/hasura/migrations/default/1634889129443_indexes_for_updated_at_columns/up.sql
+++ b/infrastructure/hasura/migrations/default/1634889129443_indexes_for_updated_at_columns/up.sql
@@ -1,0 +1,30 @@
+
+CREATE  INDEX "account_updated_at_key" on
+  "public"."account" using btree ("updated_at");
+
+CREATE  INDEX "attachment_updated_at_key" on
+  "public"."attachment" using btree ("updated_at");
+
+CREATE  INDEX "last_seen_message_updated_at_key" on
+  "public"."last_seen_message" using btree ("updated_at");
+
+CREATE  INDEX "message_reaction_updated_at_key" on
+  "public"."message_reaction" using btree ("updated_at");
+
+CREATE  INDEX "team_updated_at_key" on
+  "public"."team" using btree ("updated_at");
+
+CREATE  INDEX "team_member_updated_at_key" on
+  "public"."team_member" using btree ("updated_at");
+
+CREATE  INDEX "team_member_slack_installation_updated_at_key" on
+  "public"."team_member_slack" using btree ("updated_at");
+
+CREATE  INDEX "team_slack_installation_updated_at_key" on
+  "public"."team_slack_installation" using btree ("updated_at");
+
+CREATE  INDEX "transcription_updated_at_key" on
+  "public"."transcription" using btree ("updated_at");
+
+CREATE  INDEX "user_updated_at_key" on
+  "public"."user" using btree ("updated_at");


### PR DESCRIPTION
Might possibly increase initial loading time by a lot.

We heavily search basing on updated_at, and now we had no indexes for that field in many tables