### PR TITLE
chore: guard playwright page reading with network idle waiting

### DIFF
--- a/e2e/helper/utils.ts
+++ b/e2e/helper/utils.ts
@@ -1,1 +1,33 @@
+import { Page } from "@playwright/test";
+
+import { wait } from "~shared/time";
+
 export const isSentryStoreURL = (url: URL) => url.host.endsWith("sentry.io") && url.pathname.includes("/store");
+
+export async function createNetworkListener(page: Page, thresholdMs = 500) {
+  let lastActivityAt = Date.now();
+  await page.on("request", () => {
+    lastActivityAt = Date.now();
+  });
+  await page.on("response", () => {
+    lastActivityAt = Date.now();
+  });
+  await page.on("websocket", (socket) => {
+    socket.on("framereceived", () => {
+      lastActivityAt = Date.now();
+    });
+  });
+
+  const networkListener = {
+    waitForIdle(): Promise<void> {
+      const msSinceLastActivity = Date.now() - lastActivityAt;
+      if (msSinceLastActivity > thresholdMs) {
+        return Promise.resolve();
+      } else {
+        return wait(msSinceLastActivity).then(networkListener.waitForIdle);
+      }
+    },
+  };
+
+  return networkListener;
+}


### PR DESCRIPTION
This guards any playwright page-reading function like `click`, `waitForSelector` and `fill` from reading the page "too early" when it might only be seeing an "optimistic flash" (a local update that wasn't cleared by the server yet). It achieves that by waiting for a threshold amount of time without network requests.