### PR TITLE
fix: always use Mod+Enter for submit

### DIFF
--- a/frontend/src/views/NewRequestView/NewRequest.tsx
+++ b/frontend/src/views/NewRequestView/NewRequest.tsx
@@ -100,7 +100,7 @@ export const NewRequest = observer(function NewRequest() {
   });
 
   // Submitting can be done from the editor or from the topic input box
-  const sendShortcutDescription = useShortcut(["Meta", "Enter"], () => {
+  const sendShortcutDescription = useShortcut(["Mod", "Enter"], () => {
     submit();
     // Captures and prevents the event from getting to the editor
     return true;
@@ -216,7 +216,7 @@ export const NewRequest = observer(function NewRequest() {
             kind="primary"
             tooltip="Create Request"
             onClick={submit}
-            shortcut={["Meta", "Enter"]}
+            shortcut={["Mod", "Enter"]}
           >
             Create Request
           </Button>

--- a/ui/keyboard/describeShortcut.ts
+++ b/ui/keyboard/describeShortcut.ts
@@ -14,7 +14,6 @@ type KeyNiceVersion = string | Partial<Record<KeyboardPlatform, string>>;
  */
 const shortcutKeyNiceVersionMap: Partial<Record<Key, KeyNiceVersion>> = {
   Mod: { mac: "⌘", windows: "CTRL" },
-  Meta: { mac: "⌘", windows: "CTRL" },
   Alt: { mac: "⌥", windows: "ALT" },
   Enter: "↩︎",
   Shift: "⇧",


### PR DESCRIPTION
So technically "Meta" is the Windows key in Windows, but for some shortcuts are mapped to "Ctrl" in browser (have not found a reasoning yet). And for Meta+Enter I just got events as "Meta + Meta". Weird!
Anyway, more specific for our only Meta+Enter use case, we were using Mod+Enter in existing topics, and that works on Windows, so I thought, why not just re-use that?
Also dropped the labelling for Meta, so that we are not misled again (we could consider removing the key altogether, but I guess some of them are usable, we just need to test it beforehand and be conscious wrt how it will be remapped).

TL;DR: we should probably not use the Meta key, as it's not cross-platform enough (unless we test it on Windows before), or it is mapped through Ctrl which we could just use explicitly in those cases?