### PR TITLE
fix: route to Acapela for linking slack

### DIFF
--- a/backend/src/slack/app.ts
+++ b/backend/src/slack/app.ts
@@ -8,7 +8,7 @@ import { assertDefined } from "~shared/assert";
 import { isDev } from "~shared/dev";
 
 import { HttpStatus } from "../http";
-import { parseMetadata } from "./metadata";
+import { parseMetadata } from "./installMetadata";
 
 type Options<T extends { new (...p: never[]): unknown }> = ConstructorParameters<T>[0];
 

--- a/backend/src/slack/install.ts
+++ b/backend/src/slack/install.ts
@@ -2,12 +2,12 @@ import { getDevPublicTunnel } from "~backend/src/localtunnel";
 import { isDev } from "~shared/dev";
 
 import { slackReceiver } from "./app";
+import { InstallMetadata } from "./installMetadata";
 import manifest from "./manifest.json";
-import { Metadata } from "./metadata";
 
 export const { bot: botScopes, user: userScopes } = manifest.oauth_config.scopes;
 
-export const getSlackInstallURL = async ({ withBot }: { withBot: boolean }, metadata: Metadata) => {
+export const getSlackInstallURL = async ({ withBot }: { withBot: boolean }, metadata: InstallMetadata) => {
   const basePath = isDev() ? (await getDevPublicTunnel(3000)).url + "/api/backend" : process.env.BACKEND_API_ENDPOINT;
   return slackReceiver.installer?.generateInstallUrl({
     userScopes,

--- a/backend/src/slack/installMetadata.ts
+++ b/backend/src/slack/installMetadata.ts
@@ -1,6 +1,6 @@
 import * as SlackBolt from "@slack/bolt";
 
-export type Metadata = { teamId: string; redirectURL?: string; userId?: string };
+export type InstallMetadata = { teamId: string; redirectURL?: string; userId?: string };
 
 /**
  * When getting a Slack OAuth installation URL, one can supply metadata which Slack will
@@ -9,7 +9,7 @@ export type Metadata = { teamId: string; redirectURL?: string; userId?: string }
  * - redirecting the user back to where they came from
  */
 
-export function parseMetadata({ metadata }: SlackBolt.Installation): Metadata {
+export function parseMetadata({ metadata }: SlackBolt.Installation): InstallMetadata {
   if (!metadata) {
     throw new Error("Missing metadata");
   }

--- a/frontend/src/views/SettingsView/NotificationSettings.tsx
+++ b/frontend/src/views/SettingsView/NotificationSettings.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useDb } from "~frontend/clientdb";
 import { useCurrentTeam } from "~frontend/team/CurrentTeam";
-import { AddSlackInstallationButton } from "~frontend/team/SlackInstallationButton";
 import { SlackUserQuery, SlackUserQueryVariables } from "~gql";
 import { theme } from "~ui/theme";
 import { Toggle } from "~ui/toggle";
@@ -88,20 +87,16 @@ export const NotificationSettings = observer(() => {
             onChange={noop}
             isDisabled
           />
-        ) : teamMember.teamMemberSlack || data?.slack_user?.slackUserId ? (
-          <LabeledToggle
-            key="slack"
-            title="Slack"
-            description={getNotificationChannelDescription("slack")}
-            isSet={teamMember.notify_slack}
-            onChange={(isChecked) => teamMember.update({ notify_slack: isChecked })}
-          />
         ) : (
-          <AddSlackInstallationButton
-            label="Link your Slack account"
-            teamId={team.id}
-            tooltip="Connect Slack to receive notifications through it"
-          />
+          (teamMember.teamMemberSlack || data?.slack_user?.slackUserId) && (
+            <LabeledToggle
+              key="slack"
+              title="Slack"
+              description={getNotificationChannelDescription("slack")}
+              isSet={teamMember.notify_slack}
+              onChange={(isChecked) => teamMember.update({ notify_slack: isChecked })}
+            />
+          )
         ))}
     </UIPanel>
   );

--- a/frontend/src/views/SettingsView/SlackSettings.tsx
+++ b/frontend/src/views/SettingsView/SlackSettings.tsx
@@ -1,0 +1,87 @@
+import { observer } from "mobx-react";
+import React from "react";
+import styled from "styled-components";
+
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
+import { useDb } from "~frontend/clientdb";
+import { useCurrentTeam } from "~frontend/team/CurrentTeam";
+import { AddSlackInstallationButton } from "~frontend/team/SlackInstallationButton";
+import { theme } from "~ui/theme";
+
+export const SlackSettings = observer(() => {
+  const currentUser = useAssertCurrentUser();
+
+  const db = useDb();
+  const team = useCurrentTeam();
+  const teamMember = db.teamMember.query((teamMember) => teamMember.user_id == currentUser.id).all[0];
+
+  if (!team || !teamMember || !team.hasSlackInstallation || teamMember.teamMemberSlack) {
+    return null;
+  }
+
+  return (
+    <UIPanel>
+      <UITitle>Slack</UITitle>
+
+      <Paragraph>
+        With Slack linked to your Acapela you get these extra features:
+        <List>
+          <li>Receive notifications as direct messages (can also be turned off)</li>
+          <li>
+            Create requests directly from your Slack conversation with
+            <List>
+              <li>
+                the <Code>/acapela</Code> command or
+              </li>
+              <li>
+                through{" "}
+                <ExternalLink href="https://slack.com/help/articles/360057554553-Take-actions-quickly-from-the-shortcuts-menu-in-Slack">
+                  Slack's shortcuts
+                </ExternalLink>
+              </li>
+            </List>
+          </li>
+        </List>
+      </Paragraph>
+
+      <AddSlackInstallationButton label="Link your Slack account" teamId={team.id} />
+    </UIPanel>
+  );
+});
+
+const UIPanel = styled.div<{}>`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px;
+
+  ${theme.colors.layout.background.withBorder.asBg};
+  ${theme.radius.primaryItem};
+
+  width: 100%;
+`;
+
+const UITitle = styled.h3<{}>`
+  ${theme.typo.secondaryTitle};
+`;
+
+const Paragraph = styled.p<{}>`
+  ${theme.typo.content.medium}
+`;
+
+const List = styled.ul<{}>`
+  list-style: circle inside;
+  margin-left: 15px;
+`;
+
+const Code = styled.code<{}>`
+  padding: 3px;
+  border-radius: 5px;
+  ${theme.font.speziaMono};
+  background: #f5f5f5;
+`;
+
+const ExternalLink = styled.a<{}>`
+  color: blue;
+  text-decoration: underline;
+`;

--- a/frontend/src/views/SettingsView/index.tsx
+++ b/frontend/src/views/SettingsView/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { useAssertCurrentTeam } from "~frontend/team/CurrentTeam";
+import { SlackSettings } from "~frontend/views/SettingsView/SlackSettings";
 import { theme } from "~ui/theme";
 
 import { NotificationSettings } from "./NotificationSettings";
@@ -22,6 +23,7 @@ export const SettingsView = observer(function SettingsView({
       <UIHolder>
         <UIHeader>Settings</UIHeader>
         <NotificationSettings />
+        <SlackSettings />
         <TeamManagerSettingsPanel team={currentTeam} />
 
         {version && (


### PR DESCRIPTION
Thanks to Omar I was made aware of an assumption I made for the auth modal within Slack, namely that emails between Slack and Acapela match. If that's not the case, it's not really possible to generate an install URL on the spot.

So instead I now just link to the Acapela settings page where you can set-up the linking. I've created a separate section with some copy for it, as it's now not just notifications related:

<img width="711" alt="Screenshot 2021-11-01 at 14 24 12" src="https://user-images.githubusercontent.com/4051932/139678640-8e362e7c-e1a0-4ecf-a8b9-80f0bb81abec.png">
