### PR TITLE
feat: show slack link button for insufficient user scopes

### DIFF
--- a/backend/src/slack/request-modal/tryOpenRequestModal.ts
+++ b/backend/src/slack/request-modal/tryOpenRequestModal.ts
@@ -1,17 +1,14 @@
 import { View } from "@slack/types";
-import _ from "lodash";
 import { Bits, Blocks, Elements, Md, Modal } from "slack-block-builder";
 
 import { createSlackLink } from "~backend/src/notifications/sendNotification";
 import { db } from "~db";
 import { routes } from "~shared/routes";
-import { Maybe } from "~shared/types";
 import { MENTION_OBSERVER, MENTION_TYPE_PICKER_LABELS, REQUEST_READ } from "~shared/types/mention";
 
-import { SlackInstallation, slackClient } from "../app";
+import { slackClient } from "../app";
 import { isChannelNotFoundError } from "../errors";
-import { userScopes } from "../install";
-import { ViewMetadata, attachToViewWithMetadata, findUserBySlackId } from "../utils";
+import { ViewMetadata, attachToViewWithMetadata, checkHasUserSlackScopes, findUserBySlackId } from "../utils";
 
 const MissingTeamModal = Modal({ title: "Four'O'Four" })
   .blocks(
@@ -107,12 +104,6 @@ async function checkHasChannelAccess(token: string, channelId: string) {
       throw error;
     }
   }
-}
-
-async function checkHasUserSlackScopes(slackUserId: string) {
-  const teamMemberSlack = await db.team_member_slack.findFirst({ where: { slack_user_id: slackUserId } });
-  const installationData = teamMemberSlack?.installation_data as Maybe<SlackInstallation["user"]>;
-  return _.intersection(installationData?.scopes ?? [], userScopes).length === userScopes.length;
 }
 
 export async function tryOpenRequestModal(token: string, triggerId: string, data: ViewMetadata["open_request_modal"]) {

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -1,7 +1,10 @@
 import { App, Context, Middleware, SlackViewAction, SlackViewMiddlewareArgs } from "@slack/bolt";
+import _ from "lodash";
 
+import { userScopes } from "~backend/src/slack/install";
 import { User, db } from "~db";
 import { assertDefined } from "~shared/assert";
+import { Maybe } from "~shared/types";
 import { AnalyticsEventsMap } from "~shared/types/analytics";
 
 import { SlackInstallation, slackClient } from "./app";
@@ -99,4 +102,10 @@ export function listenToViewWithMetadata<Key extends keyof ViewMetadata>(
   listener: Middleware<SlackViewMiddlewareArgs<SlackViewAction> & { metadata: ViewMetadata[Key] }>
 ) {
   app.view(key, (data) => listener({ ...data, metadata: JSON.parse(data.view.private_metadata) }));
+}
+
+export async function checkHasUserSlackScopes(slackUserId: string) {
+  const teamMemberSlack = await db.team_member_slack.findFirst({ where: { slack_user_id: slackUserId } });
+  const installationData = teamMemberSlack?.installation_data as Maybe<SlackInstallation["user"]>;
+  return _.intersection(installationData?.scopes ?? [], userScopes).length === userScopes.length;
 }

--- a/frontend/src/views/SettingsView/SlackSettings.tsx
+++ b/frontend/src/views/SettingsView/SlackSettings.tsx
@@ -6,16 +6,19 @@ import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { useDb } from "~frontend/clientdb";
 import { useCurrentTeam } from "~frontend/team/CurrentTeam";
 import { AddSlackInstallationButton } from "~frontend/team/SlackInstallationButton";
+import { SlackUserQuery } from "~gql";
 import { theme } from "~ui/theme";
 
-export const SlackSettings = observer(() => {
+export const SlackSettings = observer(({ slackUser }: { slackUser: SlackUserQuery["slackUser"] }) => {
   const currentUser = useAssertCurrentUser();
 
   const db = useDb();
   const team = useCurrentTeam();
   const teamMember = db.teamMember.query((teamMember) => teamMember.user_id == currentUser.id).all[0];
 
-  if (!team || !teamMember || !team.hasSlackInstallation || teamMember.teamMemberSlack) {
+  const hasMissingScopes = teamMember.teamMemberSlack && !slackUser?.hasAllScopes;
+
+  if (!team?.hasSlackInstallation || !teamMember || !slackUser || (teamMember.teamMemberSlack && !hasMissingScopes)) {
     return null;
   }
 
@@ -23,28 +26,37 @@ export const SlackSettings = observer(() => {
     <UIPanel>
       <UITitle>Slack</UITitle>
 
-      <Paragraph>
-        With Slack linked to your Acapela you get these extra features:
-        <List>
-          <li>Receive notifications as direct messages (can also be turned off)</li>
-          <li>
-            Create requests directly from your Slack conversation with
-            <List>
-              <li>
-                the <Code>/acapela</Code> command or
-              </li>
-              <li>
-                through{" "}
-                <ExternalLink href="https://slack.com/help/articles/360057554553-Take-actions-quickly-from-the-shortcuts-menu-in-Slack">
-                  Slack's shortcuts
-                </ExternalLink>
-              </li>
-            </List>
-          </li>
-        </List>
-      </Paragraph>
+      {hasMissingScopes && (
+        <UIParagraph>
+          <UINote>Note:</UINote> You have linked your Slack account before but the permissions have changed. To use
+          Acapela in Slack, please re-link your account below.
+        </UIParagraph>
+      )}
 
-      <AddSlackInstallationButton label="Link your Slack account" teamId={team.id} />
+      <UIParagraph>With Slack linked to your Acapela you get these extra features:</UIParagraph>
+
+      <UIList>
+        <li>Receive notifications as direct messages (can also be turned off)</li>
+        <li>
+          Create requests directly from your Slack conversation with
+          <UIList>
+            <li>
+              the <UICode>/acapela</UICode> command or
+            </li>
+            <li>
+              through{" "}
+              <UIExternalLink href="https://slack.com/help/articles/360057554553-Take-actions-quickly-from-the-shortcuts-menu-in-Slack">
+                Slack's shortcuts
+              </UIExternalLink>
+            </li>
+          </UIList>
+        </li>
+      </UIList>
+
+      <AddSlackInstallationButton
+        label={(hasMissingScopes ? "Re-" : "") + "Link your Slack account"}
+        teamId={team.id}
+      />
     </UIPanel>
   );
 });
@@ -65,23 +77,28 @@ const UITitle = styled.h3<{}>`
   ${theme.typo.secondaryTitle};
 `;
 
-const Paragraph = styled.p<{}>`
+const UIParagraph = styled.p<{}>`
   ${theme.typo.content.medium}
 `;
 
-const List = styled.ul<{}>`
+const UINote = styled.span<{}>`
+  ${theme.typo.content.medium.semibold};
+`;
+
+const UIList = styled.ul<{}>`
+  ${theme.typo.content.medium}
   list-style: circle inside;
   margin-left: 15px;
 `;
 
-const Code = styled.code<{}>`
+const UICode = styled.code<{}>`
   padding: 3px;
   border-radius: 5px;
   ${theme.font.speziaMono};
   background: #f5f5f5;
 `;
 
-const ExternalLink = styled.a<{}>`
+const UIExternalLink = styled.a<{}>`
   color: blue;
   text-decoration: underline;
 `;

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -68,4 +68,5 @@ type InviteUserOutput {
 
 type SlackUserOutput {
   slack_user_id: String
+  has_all_scopes: Boolean!
 }


### PR DESCRIPTION
<img width="703" alt="Screenshot 2021-11-02 at 12 03 36" src="https://user-images.githubusercontent.com/4051932/139835399-9ecfe1d2-7010-438c-827b-2c36bd4626c6.png">

This is somewhat blocking to get slack live messages live, so I want to get it in for today's deploy. But I'm not super happy with all the async-relayouting I had to introduce to the Settings view. Some of that is data which can't be exposed to the client (user scopes are in a JSON with sensitive data), some is clientdb limitation (deleted data gets only syncd when a user triggers the delete, which is not the case for slack installation removal). Will work on it after this is merged though.