### PR TITLE
fix: update has_joined for newly created users too

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
@@ -75,16 +75,18 @@ update_permissions:
 event_triggers:
 - definition:
     enable_manual: false
+    insert:
+      columns: "*"
     update:
       columns:
-      - id
       - avatar_url
-      - current_team_id
-      - name
-      - updated_at
-      - email_verified
-      - created_at
       - email
+      - name
+      - created_at
+      - email_verified
+      - updated_at
+      - current_team_id
+      - id
   headers:
   - name: Authorization
     value_from_env: HASURA_EVENTS_WEBHOOK_AUTHORIZATION_HEADER


### PR DESCRIPTION
Fixes ACA-885

The event updating `has_joined` was only run for `UPDATE`, but we need to run it for `INSERT` too (so that the flag does not just get toggled for pre-existing users switching teams).