### PR TITLE
fix: show resend invite button for existing users

### DIFF
--- a/backend/src/events/events.ts
+++ b/backend/src/events/events.ts
@@ -25,7 +25,7 @@ hasuraEvents.addHandler("attachment_updates", ["UPDATE"], handleAttachmentUpdate
 hasuraEvents.addHandler("message_updates", ["INSERT", "UPDATE", "DELETE"], handleMessageChanges);
 hasuraEvents.addHandler("task_updates", ["INSERT", "UPDATE"], handleTaskChanges);
 hasuraEvents.addHandler("team_member_updates", ["DELETE"], handleTeamMemberDeleted);
-hasuraEvents.addHandler("user_updates", ["UPDATE"], handleUserUpdates);
+hasuraEvents.addHandler("user_updates", ["INSERT", "UPDATE"], handleUserUpdates);
 hasuraEvents.addAnyEventHandler(handleCreateSyncRequests);
 
 router.post("/v1/events", middlewareAuthenticateHasura, async (req: Request, res: Response) => {

--- a/frontend/src/team/TeamMembersManager/index.tsx
+++ b/frontend/src/team/TeamMembersManager/index.tsx
@@ -38,8 +38,10 @@ export const TeamMembersManager = observer(({ team }: Props) => {
               <TeamMemberBasicInfo teamMember={teamMember} />
 
               <UIActionsHolder>
-                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-                {!teamMember.user?.has_account && <ResendInviteButton user={teamMember.user!} teamId={team.id} />}
+                {!(teamMember.user?.has_account && teamMember.has_joined) && (
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  <ResendInviteButton user={teamMember.user!} teamId={team.id} />
+                )}
                 {isCurrentUserTeamOwner && (
                   <CloseIconButton
                     isDisabled={false}


### PR DESCRIPTION
Previously we only showed the resend invite button for users without accounts. This makes it so that it's also shown for users with acounts that have not joined the team yet.

(also includes a file that should have been part of #629)