### PR TITLE
fix: use non-rich message for topic title

### DIFF
--- a/backend/src/slack/request-modal/createTopicForSlackUsers.ts
+++ b/backend/src/slack/request-modal/createTopicForSlackUsers.ts
@@ -3,6 +3,8 @@ import { Account, User, db } from "~db";
 import { convertMessageContentToPlainText } from "~richEditor/content/plainText";
 import { MENTION_TYPE_KEY, getUniqueRequestMentionDataFromContent } from "~shared/editor/mentions";
 import { slugify } from "~shared/slugify";
+import { DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH, truncateTextWithEllipsis } from "~shared/text/ellipsis";
+import { Maybe } from "~shared/types";
 import { EditorMentionData } from "~shared/types/editor";
 import { MentionType, REQUEST_TYPES, RequestType } from "~shared/types/mention";
 
@@ -163,7 +165,7 @@ export async function createTopicForSlackUsers({
   teamId: string;
   ownerId: string;
   slackTeamId: string;
-  topicName: string;
+  topicName: Maybe<string>;
   rawTopicMessage: string;
   slackUserIdsWithMentionType: SlackUserIdWithRequestType[];
 }) {
@@ -181,6 +183,7 @@ export async function createTopicForSlackUsers({
   );
   const messageContentText = convertMessageContentToPlainText(messageContent);
   const userIds = new Set(usersWithMentionType.map(({ userId }) => userId).concat(ownerId));
+  topicName = topicName || truncateTextWithEllipsis(messageContentText, DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH);
   return await db.topic.create({
     data: {
       team_id: teamId,

--- a/backend/src/slack/request-modal/index.tsx
+++ b/backend/src/slack/request-modal/index.tsx
@@ -7,7 +7,6 @@ import { db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
 import { routes } from "~shared/routes";
-import { DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH, truncateTextWithEllipsis } from "~shared/text/ellipsis";
 import { MentionType } from "~shared/types/mention";
 
 import { LiveTopicMessage } from "../LiveTopicMessage";
@@ -133,7 +132,7 @@ export function setupRequestModal(app: App) {
       ownerId: owner.id,
       slackTeamId,
       rawTopicMessage: messageText,
-      topicName: topicName ?? truncateTextWithEllipsis(messageText, DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH),
+      topicName,
       slackUserIdsWithMentionType,
     });
 

--- a/richEditor/content/plainText.ts
+++ b/richEditor/content/plainText.ts
@@ -9,11 +9,8 @@ function normalizePlainTextOutput(plainText: string) {
   return plainText.replace(/\n{2,}/, `\n`).trim();
 }
 
-export function recursiveConvertMessageContentToPlainText(
-  content: RichEditorNode,
-  isRoot: boolean,
-  plainTextParts: string[]
-) {
+function recursiveConvertMessageContentToPlainText(content: RichEditorNode): string[] {
+  const plainTextParts: string[] = [];
   if (newLineNodeTypes.includes(content.type)) {
     plainTextParts.push("\n");
   }
@@ -27,19 +24,15 @@ export function recursiveConvertMessageContentToPlainText(
   }
 
   if (content.content) {
-    for (const childNode of content.content) {
-      recursiveConvertMessageContentToPlainText(childNode, false, plainTextParts);
-    }
+    plainTextParts.push(
+      ...content.content.flatMap((childNode) => recursiveConvertMessageContentToPlainText(childNode))
+    );
   }
 
-  if (isRoot) {
-    const plainText = plainTextParts.join("");
-    return normalizePlainTextOutput(plainText);
-  }
+  return plainTextParts;
 }
 
 export function convertMessageContentToPlainText(content: RichEditorNode): string {
-  const result = recursiveConvertMessageContentToPlainText(content, true, []) as string;
-
-  return result;
+  const plainText = recursiveConvertMessageContentToPlainText(content).join("");
+  return normalizePlainTextOutput(plainText);
 }


### PR DESCRIPTION
Taxes the rich content to make it more readable.

Previously we used stringified rich content straight from slack for the topic title. This here does not resolving mention names yet, but it's better than the broken text version we currently have (note that it only happens for topics without a title and rich text in their message).

Also used this as an opportunity to make `convertMessageContentToPlainText` more straightforward.