### PR TITLE
hacky: scroll to task next action message and highlight it

### DIFF
--- a/frontend/src/topics/TopicStore.ts
+++ b/frontend/src/topics/TopicStore.ts
@@ -6,13 +6,13 @@ import { createStoreContext } from "~shared/sharedState";
 interface State {
   currentlyReplyingToMessageId: string | null;
   editedMessageId: string | null;
-  firstUnreadMessageElement: HTMLElement | null;
+  scrolledMessageId: string | null;
   editorRef: React.RefObject<Editor> | null;
 }
 
 export const [TopicStoreContext, useTopicStoreContext] = createStoreContext<State>(() => ({
   currentlyReplyingToMessageId: null,
   editedMessageId: null,
-  firstUnreadMessageElement: null,
+  scrolledMessageId: null,
   editorRef: null,
 }));


### PR DESCRIPTION
I'm a bit puzzled how to best manage semi-controlled scroll state. I don't want to bring this attempt to master. While it does what it should, it does so in a brittle way, by depending on `setTimeout` to make sure `<Message>` "has enough time" to pick up that it was scrolled to, thus triggering its "here I am"-animation.
This is what it looks like:

https://user-images.githubusercontent.com/4051932/140394733-87239c14-2124-495c-bf79-7a35dd2780c1.mov

So this is more of a Request For Ideas, how to better implement it. Vague concepts, blog posts, papers,... I take it all!