### PR TITLE
fix: any topic member can update task

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
@@ -44,10 +44,9 @@ select_permissions:
     filter:
       message:
         topic:
-          team:
-            memberships:
-              user_id:
-                _eq: X-Hasura-User-Id
+          members:
+            user_id:
+              _eq: X-Hasura-User-Id
   role: user
 update_permissions:
 - permission:
@@ -57,12 +56,11 @@ update_permissions:
     - due_at
     - seen_at
     filter:
-      _or:
-      - user_id:
-          _eq: X-Hasura-User-Id
-      - message:
-          user_id:
-            _eq: X-Hasura-User-Id
+      message:
+        topic:
+          members:
+            user_id:
+              _eq: X-Hasura-User-Id
   role: user
 delete_permissions:
 - permission:


### PR DESCRIPTION
Fix: 

Before the permissions to update a task were only allowing the task assigner or assignee to update the task. Now, all topic members can update a task, and update a due date.

Before this, we had a bug in which the due date only changed for one person, as the user was only allowed to change the due date of his own task