### PR TITLE
feat: improve creating new team flow for new users

### DIFF
--- a/frontend/src/clientdb/LoadingScreen.tsx
+++ b/frontend/src/clientdb/LoadingScreen.tsx
@@ -3,19 +3,33 @@ import styled, { keyframes } from "styled-components";
 
 import { Logo } from "~frontend/ui/Logo";
 import { useUnmountPresence } from "~frontend/ui/presence";
+import { BodyPortal } from "~ui/BodyPortal";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
 import { theme } from "~ui/theme";
 
-export function LoadingScreen() {
+interface Props {
+  loadingNotice?: string;
+}
+
+export function LoadingScreen({ loadingNotice }: Props) {
   const isMounted = useUnmountPresence(200);
 
+  const shouldShowNoticeInstantly = !!loadingNotice;
+
+  const loadingNoticeToShow = loadingNotice ?? "Acapela is loading...";
+
   return (
-    <UIHolder isVisible={isMounted}>
-      <Logo />
-      <UILoadingLabel presenceStyles={{ opacity: [0, 0.6] }} transition={{ delay: 1, duration: 1 }}>
-        Acapela is loading...
-      </UILoadingLabel>
-    </UIHolder>
+    <BodyPortal>
+      <UIHolder $isVisible={isMounted}>
+        <Logo />
+        <UILoadingLabel
+          presenceStyles={{ opacity: [0, 0.6] }}
+          transition={{ delay: shouldShowNoticeInstantly ? 0 : 1, duration: 1 }}
+        >
+          {loadingNoticeToShow}
+        </UILoadingLabel>
+      </UIHolder>
+    </BodyPortal>
   );
 }
 
@@ -28,7 +42,7 @@ const scaleDown = keyframes`
   }
 `;
 
-const UIHolder = styled(motion.div)<{ isVisible: boolean }>`
+const UIHolder = styled(motion.div)<{ $isVisible: boolean }>`
   background-color: ${theme.colors.layout.background()};
   position: fixed;
   top: 0;
@@ -40,8 +54,8 @@ const UIHolder = styled(motion.div)<{ isVisible: boolean }>`
   align-items: center;
   justify-content: center;
   ${theme.spacing.close.multiply(2).asGap};
-  opacity: ${(props) => (props.isVisible ? 1 : 0)};
-  pointer-events: ${(props) => (props.isVisible ? "all" : "none")};
+  opacity: ${(props) => (props.$isVisible ? 1 : 0)};
+  pointer-events: ${(props) => (props.$isVisible ? "all" : "none")};
   will-change: opacity;
   transition: 0.2s all;
 

--- a/frontend/src/layouts/FocusedActionLayout/FocusedActionLayout.tsx
+++ b/frontend/src/layouts/FocusedActionLayout/FocusedActionLayout.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
 import styled, { css } from "styled-components";
 
-import { phone } from "~frontend/../../ui/responsive";
 import { Logo } from "~frontend/ui/Logo";
 import { PopPresenceAnimator } from "~ui/animations";
+import { phone } from "~ui/responsive";
 import { theme } from "~ui/theme";
 
 interface Props {

--- a/frontend/src/layouts/SidebarLayout/index.tsx
+++ b/frontend/src/layouts/SidebarLayout/index.tsx
@@ -3,6 +3,7 @@ import router from "next/router";
 import React, { ReactNode, useEffect } from "react";
 import styled, { css } from "styled-components";
 
+import { LoadingScreen } from "~frontend/clientdb/LoadingScreen";
 import { HorizontalSpacingContainer } from "~frontend/ui/layout";
 import { useWindowEvent } from "~shared/domEvents";
 import { useBoolean } from "~shared/hooks/useBoolean";
@@ -30,10 +31,14 @@ export const SidebarLayout = observer(({ children }: Props) => {
     };
   }, [closeMobileMenu]);
 
-  useAppRedirects();
+  const willRedirect = useAppRedirects();
 
   // Close mobile menu if user rotates the screen
   useWindowEvent("orientationchange", closeMobileMenu);
+
+  if (willRedirect) {
+    return <LoadingScreen loadingNotice="Setting up Acapela..." />;
+  }
 
   return (
     <UIHolder>

--- a/frontend/src/layouts/SidebarLayout/useAppRedirects.tsx
+++ b/frontend/src/layouts/SidebarLayout/useAppRedirects.tsx
@@ -1,5 +1,6 @@
 import { signOut } from "next-auth/react";
 import router from "next/router";
+import { useState } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 
 import { useCurrentUserTokenData } from "~frontend/authentication/useCurrentUser";
@@ -13,6 +14,7 @@ import { routes } from "~shared/routes";
  * eg. if there is no team - will force redirect to create new team flow.
  */
 export function useAppRedirects() {
+  const [willRedirect, setWillRedirect] = useState(false);
   const userTokenData = useCurrentUserTokenData();
 
   const db = useNullableDb();
@@ -22,12 +24,14 @@ export function useAppRedirects() {
 
   useIsomorphicLayoutEffect(() => {
     if (isUserWithoutAccount) {
+      setWillRedirect(false);
       signOut();
       return;
     }
 
     if (!userTokenData || !user) {
       router.push(routes.login);
+      setWillRedirect(true);
       return;
     }
 
@@ -37,7 +41,10 @@ export function useAppRedirects() {
 
     if (!teamInfo.teamId) {
       router.push(routes.teamSelect);
+      setWillRedirect(true);
       return;
     }
   }, [isUserWithoutAccount, userTokenData, user, teamInfo]);
+
+  return willRedirect;
 }

--- a/frontend/src/ui/presence.ts
+++ b/frontend/src/ui/presence.ts
@@ -1,5 +1,6 @@
 import { usePresence } from "framer-motion";
 import { useEffect, useState } from "react";
+import { useIsomorphicLayoutEffect } from "react-use";
 
 import { createTimeout } from "~shared/time";
 
@@ -8,10 +9,8 @@ export function useUnmountPresence(time: number) {
 
   const [isNotRemoved, safeToRemove] = usePresence();
 
-  useEffect(() => {
-    return createTimeout(() => {
-      setIsMounted(true);
-    }, 10);
+  useIsomorphicLayoutEffect(() => {
+    setIsMounted(true);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/views/ConnectTeamWithSlackView/ConnectTeamWithSlackView.tsx
+++ b/frontend/src/views/ConnectTeamWithSlackView/ConnectTeamWithSlackView.tsx
@@ -3,20 +3,29 @@ import router from "next/router";
 import { useEffect } from "react";
 import styled from "styled-components";
 
-import { useAssertCurrentTeam } from "~frontend/team/CurrentTeam";
+import { LoadingScreen } from "~frontend/clientdb/LoadingScreen";
+import { useCurrentTeam } from "~frontend/team/CurrentTeam";
 import { AddSlackInstallationButton } from "~frontend/team/SlackInstallationButton";
 import { ActionWithAlternative } from "~frontend/ui/ButtonWithAlternative";
 import { routes } from "~shared/routes";
 import { TextButton } from "~ui/buttons/TextButton";
 
 export const ConnectTeamWithSlackView = observer(() => {
-  const currentTeam = useAssertCurrentTeam();
+  const currentTeam = useCurrentTeam();
 
   useEffect(() => {
+    if (!currentTeam) {
+      router.push(routes.teamSelect);
+      return;
+    }
     if (!currentTeam.hasSlackInstallation) return;
 
     router.push(routes.teamInviteMembers);
-  }, [currentTeam.hasSlackInstallation]);
+  }, [currentTeam]);
+
+  if (!currentTeam) {
+    return <LoadingScreen />;
+  }
 
   return (
     <UIHolder>

--- a/infrastructure/hasura/migrations/default/1636102819840_set_fk_public_user_current_team_id/down.sql
+++ b/infrastructure/hasura/migrations/default/1636102819840_set_fk_public_user_current_team_id/down.sql
@@ -1,0 +1,5 @@
+alter table "public"."user" drop constraint "user_current_team_id_fkey",
+  add constraint "user_current_team_id_fkey"
+  foreign key ("current_team_id")
+  references "public"."team"
+  ("id") on update restrict on delete restrict;

--- a/infrastructure/hasura/migrations/default/1636102819840_set_fk_public_user_current_team_id/up.sql
+++ b/infrastructure/hasura/migrations/default/1636102819840_set_fk_public_user_current_team_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."user" drop constraint "user_current_team_id_fkey",
+  add constraint "user_current_team_id_fkey"
+  foreign key ("current_team_id")
+  references "public"."team"
+  ("id") on update restrict on delete set null;

--- a/ui/buttons/Button.tsx
+++ b/ui/buttons/Button.tsx
@@ -66,12 +66,12 @@ export const Button = styledForwardRef<HTMLButtonElement, ButtonProps>(function 
   return (
     <UIButton
       ref={ref}
-      isLoading={isLoading}
-      isDisabled={isDisabledBoolean}
+      $isLoading={isLoading}
+      $isDisabled={isDisabledBoolean}
       disabled={isDisabledBoolean}
-      isWide={isWide}
+      $isWide={isWide}
       data-tooltip={getTooltipLabel()}
-      kind={kind}
+      $kind={kind}
       onClick={onClick}
       {...htmlProps}
     >
@@ -103,10 +103,10 @@ const UIIconHolder = styled.div<{}>`
 `;
 
 export const UIButton = styled(motion.button)<{
-  kind: ButtonKind;
-  isLoading?: boolean;
-  isDisabled?: boolean;
-  isWide?: boolean;
+  $kind: ButtonKind;
+  $isLoading?: boolean;
+  $isDisabled?: boolean;
+  $isWide?: boolean;
 }>`
   display: inline-flex;
   align-items: center;
@@ -126,11 +126,11 @@ export const UIButton = styled(motion.button)<{
 
   ${theme.transitions.hover()}
 
-  ${(props) => getButtonKindtyles(props.kind)}
+  ${(props) => getButtonKindtyles(props.$kind)}
 
-  ${(props) => (props.isDisabled || props.isLoading) && disabledCss};
+  ${(props) => (props.$isDisabled || props.$isLoading) && disabledCss};
   ${(props) =>
-    props.isWide &&
+    props.$isWide &&
     css`
       width: 100%;
     `}


### PR DESCRIPTION
Fixed incorrect new team flow that allowed showing the app even if you had no team or no current team.

Note about screen recording - you see old flicker of the same screen twice only because next is building it in dev mode before redirecting
![CleanShot-Google Chrome app-2021-11-05 at 10 14 58](https://user-images.githubusercontent.com/7311462/140487093-d0e7d5d7-aef2-4f88-a418-f82f996de747.gif)

