### PR TITLE
fix: add more slack home tab analytics events

### DIFF
--- a/backend/src/slack/home-tab.ts
+++ b/backend/src/slack/home-tab.ts
@@ -9,6 +9,7 @@ import { createSlackLink } from "~backend/src/notifications/sendNotification";
 import { slackClient } from "~backend/src/slack/app";
 import { Message, Task, Topic, User, db } from "~db";
 import { assertDefined } from "~shared/assert";
+import { backendUserEventToJSON } from "~shared/backendAnalytics";
 import { routes } from "~shared/routes";
 import { pluralize } from "~shared/text/pluralize";
 import { RequestType } from "~shared/types/mention";
@@ -158,7 +159,10 @@ export async function updateHomeView(botToken: string, slackUserId: string) {
         }),
         Blocks.Actions().elements(
           Elements.Button({ text: "+ New Request", actionId: SlackActionIds.CreateTopic }).primary(true),
-          Elements.Button({ text: "Open web app" }).url(process.env.FRONTEND_URL)
+          Elements.Button({ text: "Open web app" })
+            .url(process.env.FRONTEND_URL)
+            .actionId(SlackActionIds.TrackEvent)
+            .value(backendUserEventToJSON(user.id, "Open from Slack Home Tab"))
         ),
         RequestsList("🔥 Received", received),
         RequestsList("📤 Sent", sent),

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -72,6 +72,7 @@ export const SlackActionIds = {
   CreateTopic: "create-topic",
   ReOpenTopic: "reopen-topic",
   ArchiveTopic: "archive-topic",
+  TrackEvent: "track-event",
 } as const;
 
 export type CreateRequestOrigin = AnalyticsEventsMap["Created Topic"]["origin"];

--- a/frontend/src/message/feed/tasks/MessageTask.tsx
+++ b/frontend/src/message/feed/tasks/MessageTask.tsx
@@ -46,7 +46,11 @@ export const MessageTask = observer(({ task }: Props) => {
           label: "Mark as Complete",
           onSelect: () => {
             task.update({ done_at: new Date().toISOString() });
-            trackEvent("Mark Task As Done", { taskType: task.type as RequestType, topicId: task.topic?.id ?? "" });
+            trackEvent("Mark Task As Done", {
+              taskType: task.type as RequestType,
+              topicId: task.topic?.id ?? "",
+              origin: "webapp",
+            });
           },
         },
       ];

--- a/shared/backendAnalytics.ts
+++ b/shared/backendAnalytics.ts
@@ -54,6 +54,12 @@ export function trackBackendUserEvent<N extends keyof AnalyticsEventsMap>(
   }
 }
 
+export const backendUserEventToJSON = <N extends keyof AnalyticsEventsMap>(
+  userId: string,
+  eventName: N,
+  payload?: AnalyticsEventsMap[N]
+) => JSON.stringify([userId, eventName, payload]);
+
 export function identifyBackendUserTeam<N extends keyof AnalyticsGroupsMap>(
   userId: string,
   groupId: string,

--- a/shared/types/analytics.ts
+++ b/shared/types/analytics.ts
@@ -60,7 +60,11 @@ export type AnalyticsEventsMap = {
   // Mention and task related events
 
   "Created Task": { taskType: RequestType; topicId: string; mentionedUserId: string };
-  "Mark Task As Done": { taskType: RequestType; topicId: string };
+  "Mark Task As Done": {
+    taskType: RequestType;
+    topicId: string;
+    origin: "webapp" | "slack-home" | "slack-live-message";
+  };
   "Added Due Date": { topicId: string; messageId: string };
 
   // Slack
@@ -68,6 +72,7 @@ export type AnalyticsEventsMap = {
   "Used Slack Message Action": { slackUserName: string };
   "Used Slack Slash Command": { slackUserName: string; commandName: string };
   "Used Slack Home Tab New Request": { slackUserName: string };
+  "Open from Slack Home Tab": void;
 };
 
 export type AnalyticsEventName = keyof AnalyticsEventsMap;


### PR DESCRIPTION
This adds events for the Slack Home Tab, namely:
- the web app button
- marking received tasks as done

For the textual links (to topics) I did not find a way to create events for them. We could change the link to go through an internal tracking URL. Wdyt @heikir?