### PR TITLE
fix: add quick-fix message informing how to sign-up for invites

### DIFF
--- a/frontend/pages/auth/error.tsx
+++ b/frontend/pages/auth/error.tsx
@@ -18,7 +18,8 @@ const errors: {
     ),
   },
   OAuthAccountNotLinked: {
-    title: "An account with your email address is already exists.",
+    title:
+      "An account with your email address already exists. If you were invited into Acapela, please use the link from the invitation message to signup.",
     description: () => (
       <>
         <p>Please try again and use a different login provider.</p>


### PR DESCRIPTION
This surfaced in the most unfortunate ways, in an on-boarding call. With my invite-changes, users can only signup through the invite link. Kind of a glaring omission, and I'm a bit surprised I did not notice it earlier.
Anyway, this is a copy informing users how to sign-up. I'm working now also on figuring out how to make it "just work" for signing up, hopefully without having to figure out account linking, which next-auth does not support yet.