### PR TITLE
fix: error when trying to link same slack

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/secret-manager": "^3.10.1",
     "@google-cloud/storage": "^5.14.3",
     "@sentry/node": "^6.13.2",
-    "@slack/bolt": "^3.6.0",
+    "@slack/bolt": "^3.8.1",
     "@slack/web-api": "^6.4.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/backend/src/slack/installMetadata.ts
+++ b/backend/src/slack/installMetadata.ts
@@ -1,5 +1,3 @@
-import * as SlackBolt from "@slack/bolt";
-
 export type InstallMetadata = { teamId: string; redirectURL?: string; userId?: string };
 
 /**
@@ -9,7 +7,7 @@ export type InstallMetadata = { teamId: string; redirectURL?: string; userId?: s
  * - redirecting the user back to where they came from
  */
 
-export function parseMetadata({ metadata }: SlackBolt.Installation): InstallMetadata {
+export function parseMetadata({ metadata }: { metadata?: string }): InstallMetadata {
   if (!metadata) {
     throw new Error("Missing metadata");
   }

--- a/shared/slack/index.ts
+++ b/shared/slack/index.ts
@@ -6,3 +6,6 @@ export const { bot: botScopes, user: userScopes } = manifest.oauth_config.scopes
 
 export const checkHasAllSlackUserScopes = (scopes: string[]) =>
   _.intersection(scopes, userScopes).length === userScopes.length;
+
+export const SLACK_INSTALL_ERROR_KEY = "slack_install_error";
+export const SLACK_WORKSPACE_ALREADY_USED_ERROR = "slack_workspace_already_used";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,26 +3231,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slack/bolt@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@slack/bolt@npm:3.6.0"
+"@slack/bolt@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@slack/bolt@npm:3.8.1"
   dependencies:
     "@slack/logger": ^3.0.0
-    "@slack/oauth": ^2.2.0
-    "@slack/socket-mode": ^1.1.0
+    "@slack/oauth": ^2.3.0
+    "@slack/socket-mode": ^1.2.0
     "@slack/types": ^2.2.0
     "@slack/web-api": ^6.4.0
     "@types/express": ^4.16.1
     "@types/node": ">=12"
     "@types/promise.allsettled": ^1.0.3
     "@types/tsscmp": ^1.0.0
-    axios: ^0.21.1
+    axios: ^0.21.4
     express: ^4.16.4
     please-upgrade-node: ^3.2.0
     promise.allsettled: ^1.0.2
     raw-body: ^2.3.3
     tsscmp: ^1.0.6
-  checksum: 80c282167ea89610a6b65efd6220a9ce8f3ca45d664ddb7b6bb64f78baa26cc1fc796372dfc93f33880cec26cf36a8210fa1da6787c6ed3843ad41f9505b33bc
+  checksum: 765183b344b72a3f53c6f5052cc7bc511a6329fde743a9830572e74550534bba13681a7082f9e3a6bc1f0aa4aeaa54c7f1816a92189b907641ea126028b2d959
   languageName: node
   linkType: hard
 
@@ -3263,35 +3263,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slack/oauth@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@slack/oauth@npm:2.2.0"
+"@slack/oauth@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@slack/oauth@npm:2.3.0"
   dependencies:
     "@slack/logger": ^3.0.0
-    "@slack/web-api": ^6.0.0
+    "@slack/web-api": ^6.3.0
     "@types/jsonwebtoken": ^8.3.7
     "@types/node": ">=12"
     jsonwebtoken: ^8.5.1
     lodash.isstring: ^4.0.1
-  checksum: 7ea00d23bb7da1b42b476c269e36d2d918694528b016ef008c2e8c2a6379586618101855cff4ee2191ed4bdc8103ecd06c7ff803245b4a233309ee529601665f
+  checksum: 0b7eb80ca7c0e70a61b7aec6a1e5c9cd6d2072bfe0e85253b981cbcf4556a3f41eb46018e329d2a409b30cd128ee0596419480fa5d6ced9ce97e3ae868644ffa
   languageName: node
   linkType: hard
 
-"@slack/socket-mode@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@slack/socket-mode@npm:1.1.0"
+"@slack/socket-mode@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@slack/socket-mode@npm:1.2.0"
   dependencies:
     "@slack/logger": ^3.0.0
     "@slack/web-api": ^6.2.3
     "@types/node": ">=12.0.0"
     "@types/p-queue": ^2.3.2
-    "@types/ws": ^7.2.5
+    "@types/ws": ^7.4.7
     eventemitter3: ^3.1.0
     finity: ^0.5.4
     p-cancelable: ^1.1.0
     p-queue: ^2.4.2
-    ws: ^7.3.1
-  checksum: a5f913809bc93a2692c3827894eb00175928130b2a0065ad427e2b2bd80727f596aeb5a8dc654d74db60c046072e38447a4282fbf467c73498d253e1c6bf5f7d
+    ws: ^7.5.3
+  checksum: e3bd98fbe913d26feafe5682c48e1b68e6f4deec7e45b730f295aab0789366bcb2aedb6b2d42747e0427758b5f62c7c06d9ca904a8acece560f4c6273b491f56
   languageName: node
   linkType: hard
 
@@ -3302,7 +3302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slack/web-api@npm:^6.0.0, @slack/web-api@npm:^6.2.3, @slack/web-api@npm:^6.4.0":
+"@slack/web-api@npm:^6.2.3, @slack/web-api@npm:^6.3.0, @slack/web-api@npm:^6.4.0":
   version: 6.4.0
   resolution: "@slack/web-api@npm:6.4.0"
   dependencies:
@@ -4741,7 +4741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^7.2.5, @types/ws@npm:^7.4.7":
+"@types/ws@npm:^7.4.7":
   version: 7.4.7
   resolution: "@types/ws@npm:7.4.7"
   dependencies:
@@ -19699,7 +19699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0, ws@npm:^7, ws@npm:^7.2.5, ws@npm:^7.3.1, ws@npm:^7.4.6":
+"ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0, ws@npm:^7, ws@npm:^7.2.5, ws@npm:^7.3.1, ws@npm:^7.4.6, ws@npm:^7.5.3":
   version: 7.5.5
   resolution: "ws@npm:7.5.5"
   peerDependencies:
@@ -19953,7 +19953,7 @@ __metadata:
     "@google-cloud/secret-manager": ^3.10.1
     "@google-cloud/storage": ^5.14.3
     "@sentry/node": ^6.13.2
-    "@slack/bolt": ^3.6.0
+    "@slack/bolt": ^3.8.1
     "@slack/web-api": ^6.4.0
     "@types/cookie-parser": ^1.4.2
     "@types/cors": ^2.8.12


### PR DESCRIPTION
Shows an error toast when trying to link a Slack workspace that is already linked to another Acapela team. It also now redirects to the settings page for any error during install, and shows a generic error, while reporting it to sentry (in the backend).