### PR TITLE
fix: new request draft is unique per team member

### DIFF
--- a/frontend/src/hooks/usePersistedState.ts
+++ b/frontend/src/hooks/usePersistedState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
-import { useAssertCurrentTeam } from "~frontend/team/CurrentTeam";
+import { useCurrentUserTokenData } from "~frontend/authentication/useCurrentUser";
+import { useCurrentTeam } from "~frontend/team/CurrentTeam";
 import { getHash } from "~shared/hash";
 import { useDependencyChangeEffect } from "~shared/hooks/useChangeEffect";
 import { createTimeout } from "~shared/time";
@@ -13,9 +13,16 @@ interface Input<S> {
 }
 
 function useTeamMemberHash() {
-  const currentUser = useAssertCurrentUser();
-  const team = useAssertCurrentTeam();
-  return useMemo(() => getHash(`${currentUser.id}$$${team.id}`), [currentUser, team]);
+  const user = useCurrentUserTokenData();
+  const team = useCurrentTeam();
+
+  return useMemo(() => {
+    if (!user || !team) {
+      return "";
+    }
+
+    return getHash(`${user.id}$$${team.id}`);
+  }, [user, team]);
 }
 
 function readLocalStorageJSON<S>(key: string) {

--- a/frontend/src/message/composer/useMessageEditorManager.ts
+++ b/frontend/src/message/composer/useMessageEditorManager.ts
@@ -2,7 +2,7 @@ import { JSONContent } from "@tiptap/core";
 import { RefObject, useMemo } from "react";
 import { useList } from "react-use";
 
-import { usePersistedState } from "~frontend/hooks/useLocalStorageState";
+import { usePersistedState } from "~frontend/hooks/usePersistedState";
 import { isRichEditorContentEmpty } from "~richEditor/content/isEmpty";
 import { RichEditorNode } from "~richEditor/content/types";
 import { Editor, getEmptyRichContent } from "~richEditor/RichEditor";

--- a/frontend/src/views/NewRequestView/NewRequest.tsx
+++ b/frontend/src/views/NewRequestView/NewRequest.tsx
@@ -9,7 +9,7 @@ import styled, { css } from "styled-components";
 
 import { PageLayoutAnimator, layoutAnimations } from "~frontend/animations/layout";
 import { ClientDb, useDb } from "~frontend/clientdb";
-import { usePersistedState } from "~frontend/hooks/useLocalStorageState";
+import { usePersistedState } from "~frontend/hooks/usePersistedState";
 import { MessageContentEditor } from "~frontend/message/composer/MessageContentComposer";
 import { MessageTools } from "~frontend/message/composer/Tools";
 import { useMessageEditorManager } from "~frontend/message/composer/useMessageEditorManager";


### PR DESCRIPTION
Now the persisted cache is appending to the `key` a hash of `user.id + team.id`