### PR TITLE
feat: post message action requests into threads

### DIFF
--- a/backend/src/slack/request-modal/index.tsx
+++ b/backend/src/slack/request-modal/index.tsx
@@ -58,6 +58,7 @@ export function setupRequestModal(app: App) {
     const { channel, message, trigger_id } = shortcut;
     const { user } = await tryOpenRequestModal(assertToken(context), trigger_id, {
       channelId: channel.id,
+      messageTs: message.ts,
       slackUserId: body.user.id,
       slackTeamId: assertDefined(body.team?.id, "must have slack team"),
       messageText: message.text || "",
@@ -171,6 +172,7 @@ export function setupRequestModal(app: App) {
       ...(await LiveTopicMessage(topic)),
       token,
       channel: channelId,
+      thread_ts: metadata.messageTs,
     });
 
     if (!response.ok) {

--- a/backend/src/slack/request-modal/tryOpenRequestModal.ts
+++ b/backend/src/slack/request-modal/tryOpenRequestModal.ts
@@ -127,7 +127,7 @@ async function checkHasTeamMemberAllSlackUserScopes(slackUserId: string) {
 }
 
 export async function tryOpenRequestModal(token: string, triggerId: string, data: ViewMetadata["open_request_modal"]) {
-  const { channelId, slackUserId, slackTeamId, messageText, origin } = data;
+  const { channelId, messageTs, slackUserId, slackTeamId, messageText, origin } = data;
   const openView = (view: View) => slackClient.views.open({ token, trigger_id: triggerId, view });
 
   const [user, team] = await Promise.all([
@@ -157,7 +157,7 @@ export async function tryOpenRequestModal(token: string, triggerId: string, data
     }
   }
 
-  await openView(TopicModal({ requestToSlackUserIds, messageText, channelId, origin }));
+  await openView(TopicModal({ requestToSlackUserIds, messageText, channelId, messageTs, origin }));
 
   return { user };
 }

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -83,12 +83,14 @@ export type ViewMetadata = {
     slackTeamId: string;
     origin: CreateRequestOrigin;
     channelId?: string;
+    messageTs?: string;
     messageText?: string;
   };
   create_request: {
     requestToSlackUserIds?: string[];
     messageText?: string;
     channelId?: string;
+    messageTs?: string;
     origin: CreateRequestOrigin;
   };
 };


### PR DESCRIPTION
Context: https://www.notion.so/acapela/Creating-a-request-in-existing-Slack-message-posts-it-in-the-main-channel-0dbd8192dde04a258a2e848351a08b60