### PR TITLE
fix: check for undefined emails when finding users through slack

### DIFF
--- a/backend/src/slack/LiveTopicMessage.ts
+++ b/backend/src/slack/LiveTopicMessage.ts
@@ -37,8 +37,8 @@ export async function LiveTopicMessage(topic: Topic) {
     .blocks(
       Blocks.Section({ text }),
       Blocks.Divider(),
-      topic.closed_at
-        ? Blocks.Section({ text: "🎉 All requests have been actioned. The topic is now closed. 💪" })
+      topic.closed_at || tasks.length == 0
+        ? Blocks.Section({ text: "🎉 All requests have been actioned. 💪" })
         : [
             Blocks.Section({
               text: Object.entries(groupBy(tasks, (task) => task.type))
@@ -54,17 +54,19 @@ export async function LiveTopicMessage(topic: Topic) {
                 })
                 .join("\n"),
             }),
-            Blocks.Actions().elements(
-              tasks.map((task) =>
-                Elements.Button({
-                  actionId: "toggle_task_done_at:" + task.id,
-                  value: task.id,
-                  text: `${task.done_at ? "✅️" : REQUEST_TYPE_EMOJIS[task.type as RequestType]} ${task.user.name}:  ${
-                    task.done_at ? "Undo" : "Mark as complete"
-                  }`,
-                })
-              )
-            ),
+            tasks.length == 0
+              ? undefined
+              : Blocks.Actions().elements(
+                  tasks.map((task) =>
+                    Elements.Button({
+                      actionId: "toggle_task_done_at:" + task.id,
+                      value: task.id,
+                      text: `${task.done_at ? "✅️" : REQUEST_TYPE_EMOJIS[task.type as RequestType]} ${
+                        task.user.name
+                      }:  ${task.done_at ? "Undo" : "Mark as complete"}`,
+                    })
+                  )
+                ),
           ]
     )
     .buildToObject();

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -57,7 +57,7 @@ export async function findUserBySlackId(token: string, slackUserId: string, team
   }
 
   const { profile } = await slackClient.users.profile.get({ token, user: slackUserId });
-  if (!profile) {
+  if (!profile?.email) {
     return;
   }
   return await db.user.findFirst({ where: { team_member: { some: { team_id: teamId } }, email: profile.email } });


### PR DESCRIPTION
[Context](https://weareacapela.slack.com/archives/C027RS14F0T/p1636536533038600)

There was a missing check for whether the profiles returned from Slack have an email, thus for finding users based on slack id seemingly random users from Acapela were returned if they had no email (prisma just ignored fields with undefined values). This is only the case for bot users and for inviting not-found users we already have an early-exit in place, so this check should do.
I also had to modify LiveMessage template as it assumed that the topic always has tasks, a constraint that can't be upheld if someone chooses a bot user as a target or edits the first message to remove the tasks.