### PR TITLE
Aca 859 marking things as done flow copy

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestItem.tsx
@@ -70,7 +70,7 @@ export const RequestItem = observer(function RequestItem({ topic }: Props) {
       </AnimatePresence>
 
       <Link passHref href={routes.topic({ topicSlug: topic.slug })}>
-        <UIFeedItem isHighlighted={isHighlighted} ref={elementRef}>
+        <UIFeedItem $isHighlighted={isHighlighted} ref={elementRef}>
           <RequestParticipants topic={topic} />
           <UIFeedItemLabels>
             <HStack alignItems="center">
@@ -97,7 +97,7 @@ export const RequestItem = observer(function RequestItem({ topic }: Props) {
   );
 });
 
-const UIFeedItem = styled.a<{ isHighlighted?: boolean }>`
+const UIFeedItem = styled.a<{ $isHighlighted?: boolean }>`
   display: flex;
   ${theme.box.item};
   ${theme.spacing.actions.asGap};
@@ -112,7 +112,7 @@ const UIFeedItem = styled.a<{ isHighlighted?: boolean }>`
   }
 
   ${(props) =>
-    props.isHighlighted &&
+    props.$isHighlighted &&
     css`
       &&& {
         ${theme.colors.layout.backgroundAccent.active.asBg}
@@ -131,7 +131,7 @@ const UIFeedItemTitle = styled.h6`
   ${theme.typo.content.semibold.resetLineHeight};
 `;
 
-const UIBubble = styled.div`
+const UIBubble = styled.div<{}>`
   ${theme.radius.circle}
   margin-left: 6px;
   width: 16px;

--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestMessagePreview.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestMessagePreview.tsx
@@ -9,15 +9,22 @@ import { MessageLikeContent } from "~frontend/message/feed/MessageLikeContent";
 import { styledObserver } from "~shared/component";
 import { MentionType, getMentionTypeLabel } from "~shared/types/mention";
 import { PopPresenceAnimator } from "~ui/animations";
-import { Popover } from "~ui/popovers/Popover";
+import { Popover, PopoverPlacement } from "~ui/popovers/Popover";
 import { theme } from "~ui/theme";
 
 interface Props {
   topic: TopicEntity;
+  placement?: PopoverPlacement;
+  maxLines?: number;
   anchorRef: RefObject<HTMLElement>;
 }
 
-export const RequestMessagePreview = styledObserver(function RequestMessagePreview({ topic, anchorRef }: Props) {
+export const RequestMessagePreview = styledObserver(function RequestMessagePreview({
+  topic,
+  placement,
+  maxLines = 20,
+  anchorRef,
+}: Props) {
   const currentUser = useAssertCurrentUser();
   const lastCurrentUserTask = topic.tasks.query({ isAssignedToSelf: true, isDone: false }).last;
 
@@ -30,7 +37,7 @@ export const RequestMessagePreview = styledObserver(function RequestMessagePrevi
   if (!messageToPreview.user) return null;
 
   return (
-    <Popover anchorRef={anchorRef}>
+    <Popover anchorRef={anchorRef} placement={placement}>
       <UIHolder $currentUserId={currentUser.id}>
         <UIHint>
           <strong>{getMentionTypeLabel(lastCurrentUserTask.type as MentionType)}</strong> task from{" "}
@@ -38,14 +45,13 @@ export const RequestMessagePreview = styledObserver(function RequestMessagePrevi
         </UIHint>
 
         <MessageLikeContent user={messageToPreview.user} date={new Date(messageToPreview.created_at)}>
-          <UIMessagePreview>
+          <UIMessagePreview $maxLines={maxLines}>
             <MessageText content={messageToPreview.content} />
           </UIMessagePreview>
         </MessageLikeContent>
       </UIHolder>
     </Popover>
   );
-  return null;
 })``;
 
 const WIGGLE_MAX = 1;
@@ -91,10 +97,11 @@ const UIHolder = styled(PopPresenceAnimator)<{ $currentUserId: string }>`
   }}
 `;
 
-const UIMessagePreview = styled.div`
+const UIMessagePreview = styled.div<{ $maxLines: number }>`
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 20;
+  -webkit-line-clamp: ${(props) => props.$maxLines};
+  line-clamp: ${(props) => props.$maxLines};
   overflow: hidden;
 `;
 


### PR DESCRIPTION
Updates copy of the task completion button to:

| Request type      | Action label    |
|-------------------|-----------------|
| Read confirmation | Mark as read    |
| Action required   | Mark as done    |
| Response required | Mark as replied |


### Additionally

Adds a preview of the message that contains the task when hovering over the button. Only works when a single task is pending for the user.

<img width="977" alt="Screenshot 2021-11-10 at 14 29 12" src="https://user-images.githubusercontent.com/4765697/141113754-0019cac5-361c-4d44-ac6c-131cd9a434d9.png">
