### PR TITLE
fix: typo in button case

### DIFF
--- a/frontend/src/views/RequestView/TopicWithMessages/NewMessageButtons.tsx
+++ b/frontend/src/views/RequestView/TopicWithMessages/NewMessageButtons.tsx
@@ -45,7 +45,7 @@ function getTaskCompletionCTA(pendingTasks: TaskEntity[]): string {
   }
 
   if (pendingTasks.length > 1) {
-    return "Mark All as Done";
+    return "Mark all as done";
   }
   const taskType = pendingTasks[0].type;
   if (taskType === REQUEST_READ) {


### PR DESCRIPTION
"Mark All as Done" => "Mark all as done"