### PR TITLE
feat: remove members counter in team select view

### DIFF
--- a/frontend/src/views/SelectTeamView/SelectTeamView.tsx
+++ b/frontend/src/views/SelectTeamView/SelectTeamView.tsx
@@ -47,8 +47,6 @@ export const SelectTeamView = observer(() => {
               <UITeam key={team.id}>
                 <UITeamInfo>
                   <UITeamName>{team.name}</UITeamName>
-                  <UITeamMeta>•</UITeamMeta>
-                  <UITeamMeta>{team.members.count + ` ${team.members.count === 1 ? "member" : "members"}`}</UITeamMeta>
                 </UITeamInfo>
                 {!isCurrentTeam && (
                   <Button kind="primary" onClick={() => handleSelectExistingTeam(team)}>
@@ -100,8 +98,4 @@ const UITeamInfo = styled.div`
 
 const UITeamName = styled.div`
   ${theme.typo.item.title};
-`;
-
-const UITeamMeta = styled.div`
-  ${theme.typo.content.secondary};
 `;


### PR DESCRIPTION
It is to avoid having to enlarge sync scope to non active team members in clientdb