### PR TITLE
fix: always scroll to head of last unread message (even if last message)

### DIFF
--- a/frontend/src/message/feed/Message.tsx
+++ b/frontend/src/message/feed/Message.tsx
@@ -101,7 +101,7 @@ export const Message = styledObserver<Props>(
     useIsomorphicLayoutEffect(
       action(() => {
         const { topic, isUnread } = message;
-        if (!isUnread || topic?.messages.last?.id === message.id || !rootRef.current || !topicContext) {
+        if (!isUnread || !rootRef.current || !topicContext) {
           return;
         }
         const isOldestUnread = !topic?.unreadMessages.query(

--- a/frontend/src/views/RequestView/TopicWithMessages/ScrollToBottomMonitor.tsx
+++ b/frontend/src/views/RequestView/TopicWithMessages/ScrollToBottomMonitor.tsx
@@ -56,33 +56,36 @@ const _ScrollToBottomMonitor = React.forwardRef<ScrollHandle, Props>(
         if (!parentNode) {
           return;
         }
-        onScrollBegin?.();
 
         if (behavior === "auto") {
           parentNode.scrollTop = parentNode.scrollHeight - parentNode.clientHeight;
         } else {
           parentNode.scroll({ top: parentNode.scrollHeight - parentNode.clientHeight, behavior });
         }
-        onScrollEnd?.();
       },
-      [parentRef, onScrollBegin, onScrollEnd]
+      [parentRef]
     );
 
     const tryAutoScroll = useCallback(() => {
       runInAction(() => {
         if (!preventAutoScroll && isScrolledToBottom.current) {
+          onScrollBegin?.();
           didAutoScroll.current = true;
           if (firstUnreadMessageElement) {
-            firstUnreadMessageElement.scrollIntoView();
+            const scrollToTopOfElement = true;
+            firstUnreadMessageElement.scrollIntoView(scrollToTopOfElement);
             isScrolledToBottom.current = false;
 
             if (topicContext) {
               topicContext.firstUnreadMessageElement = null;
             }
-          } else scrollToBottom("auto");
+          } else {
+            scrollToBottom("auto");
+          }
+          onScrollEnd?.();
         }
       });
-    }, [firstUnreadMessageElement, preventAutoScroll, scrollToBottom, topicContext]);
+    }, [firstUnreadMessageElement, preventAutoScroll, scrollToBottom, topicContext, onScrollBegin, onScrollEnd]);
 
     useImperativeHandle(ref, () => ({ scrollToBottom }));
 


### PR DESCRIPTION
# Problem

There was a check that prevented scrolling to the "last unread message" if that message was the very last one in the list.

This is not apparent given that the vast majority of messages have 5 lines of content, and the default behaviour would make the message feed scroll to the very bottom. When you scroll to the bottom, every short message will appear in its entirety.

The issue comes in when you have have very long messages (that take on the whole vertical height). 

# Fix

Always scroll to the top of the last unread message, even if that message is the last of the list.

P.S. **ask** tag for @Gregoor as he was a reporter