### PR TITLE
fix: properly display participants preview layout depending on participants count

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestParticipants.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestParticipants.tsx
@@ -4,7 +4,6 @@ import styled, { css } from "styled-components";
 import { TopicEntity } from "~frontend/clientdb/topic";
 import { UserEntity } from "~frontend/clientdb/user";
 import { UserAvatar } from "~frontend/ui/users/UserAvatar";
-import { isClient } from "~shared/document";
 import { theme } from "~ui/theme";
 
 interface Props {
@@ -77,14 +76,12 @@ export const RequestParticipants = observer(function RequestParticipants({ topic
 
   const [participantsToShow, notShownParticipants] = getParticipantsToShow(participants);
 
-  const participantsCount = participantsToShow.length;
-  const participantsLayoutCount = Math.min(participantsCount, MAX_PARTICIPANTS_TO_SHOW);
-
-  if (isClient) Reflect.set(window, "topic", topic);
+  const participantsLayoutCount = Math.min(participants.length, MAX_PARTICIPANTS_TO_SHOW);
 
   if (!participants.length) {
     return null;
   }
+
   const layout = avatarLayoutByCount[participantsLayoutCount];
 
   if (!layout) {


### PR DESCRIPTION
Before we were choosing layout depending on 'how many avatars are we showing' instead of how many participants there are.

This made it work incorrectly on 4+ participants:

![image](https://user-images.githubusercontent.com/7311462/141480549-19e6975a-0c4c-4d9b-818e-9ac323b766b9.png)

