### PR TITLE
fix: cut-down SSR for most the heavy pages

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,10 @@
-import TopicOrNewRequestPage from "./topic/[topicSlug]";
+import dynamic from "next/dynamic";
 
-// Reuse reference to same component to avoid full re-mount (including sidebar) when navigating topic<>new-topic page
-export default TopicOrNewRequestPage;
+const TopicOrNewRequestPageDynamic = dynamic(
+  async () => (await import("~frontend/views/TopicOrNewRequestPage")).TopicOrNewRequestPage,
+  { ssr: false }
+);
+
+export default function Foo() {
+  return <TopicOrNewRequestPageDynamic />;
+}

--- a/frontend/pages/new.tsx
+++ b/frontend/pages/new.tsx
@@ -1,4 +1,10 @@
-import TopicOrNewRequestPage from "./topic/[topicSlug]";
+import dynamic from "next/dynamic";
 
-// Reuse reference to same component to avoid full re-mount (including sidebar) when navigating topic<>new-topic page
-export default TopicOrNewRequestPage;
+const TopicOrNewRequestPageDynamic = dynamic(
+  async () => (await import("~frontend/views/TopicOrNewRequestPage")).TopicOrNewRequestPage,
+  { ssr: false }
+);
+
+export default function Foo() {
+  return <TopicOrNewRequestPageDynamic />;
+}

--- a/frontend/pages/topic/[topicSlug].tsx
+++ b/frontend/pages/topic/[topicSlug].tsx
@@ -1,25 +1,10 @@
-import React from "react";
+import dynamic from "next/dynamic";
 
-import { useRouteParams } from "~frontend/hooks/useRouteParams";
-import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
-import { NewRequestView } from "~frontend/views/NewRequestView";
-import { RequestView } from "~frontend/views/RequestView";
-import { routes } from "~shared/routes";
+const TopicOrNewRequestPageDynamic = dynamic(
+  async () => (await import("~frontend/views/TopicOrNewRequestPage")).TopicOrNewRequestPage,
+  { ssr: false }
+);
 
-export default function TopicOrNewRequestPage(): JSX.Element {
-  const { topicSlug } = useRouteParams(routes.topic);
-
-  if (!topicSlug) {
-    return (
-      <SidebarLayout>
-        <NewRequestView />
-      </SidebarLayout>
-    );
-  }
-
-  return (
-    <SidebarLayout>
-      <RequestView topicSlug={topicSlug} />
-    </SidebarLayout>
-  );
+export default function Foo() {
+  return <TopicOrNewRequestPageDynamic />;
 }

--- a/frontend/src/views/TopicOrNewRequestPage.tsx
+++ b/frontend/src/views/TopicOrNewRequestPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { useRouteParams } from "~frontend/hooks/useRouteParams";
+import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
+import { NewRequestView } from "~frontend/views/NewRequestView";
+import { RequestView } from "~frontend/views/RequestView";
+import { routes } from "~shared/routes";
+
+export function TopicOrNewRequestPage(): JSX.Element {
+  const { topicSlug } = useRouteParams(routes.topic);
+
+  if (!topicSlug) {
+    return (
+      <SidebarLayout>
+        <NewRequestView />{" "}
+      </SidebarLayout>
+    );
+  }
+
+  return (
+    <SidebarLayout>
+      <RequestView topicSlug={topicSlug} />
+    </SidebarLayout>
+  );
+}


### PR DESCRIPTION
Inspired by my OOM challenges of yester- and today (as well as Omar's pain last week). Thanks to Adam & Omar, for working with me on it! The heavy hitters, memory wise, seem to be in the TopicRequest page, e.g. Adam identified `RichEditor`. With skipping SSR and loading those components dynamically I could run the build with only 1.5 gig (where `master` already needs 1.9+). And build times seem to have decreased by 25%. yay!