### PR TITLE
k8s: improve readiness and liveness probe healthchecks

### DIFF
--- a/infrastructure/kubernetes/api/base/deployment.yaml
+++ b/infrastructure/kubernetes/api/base/deployment.yaml
@@ -33,12 +33,16 @@ spec:
             port: 8080
             path: /healthz
           initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 3
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             port: 8080
             path: /healthz
           initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 3
           timeoutSeconds: 5
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.19.2

--- a/infrastructure/kubernetes/frontend/base/deployment.yaml
+++ b/infrastructure/kubernetes/frontend/base/deployment.yaml
@@ -27,11 +27,21 @@ spec:
         env:
         - name: FRONTEND_HOST
           value: "localhost:3030"
+        livenessProbe:
+          httpGet:
+            port: 3000
+            path: /healthz
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 3
+          timeoutSeconds: 5
         readinessProbe:
           httpGet:
             port: 3000
             path: /healthz
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 3
           timeoutSeconds: 5
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.19.2
@@ -58,10 +68,14 @@ spec:
             port: 3030
             path: /
           initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 3
           timeoutSeconds: 15
         readinessProbe:
           httpGet:
             port: 3030
             path: /
           initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 3
           timeoutSeconds: 15


### PR DESCRIPTION
We require now three successful health checks to enable traffic for a new deployment