### PR TITLE
feat: prevent first topic message to be removed

### DIFF
--- a/frontend/src/message/feed/Message.tsx
+++ b/frontend/src/message/feed/Message.tsx
@@ -30,14 +30,23 @@ import { MessageTasks } from "./tasks/MessageTasks";
 
 interface Props extends MotionProps {
   message: MessageEntity;
+
   isBundledWithPreviousMessage?: boolean;
+  isRemoveDisabled?: boolean;
   isReadonly?: boolean;
   className?: string;
   contentLayoutId?: string;
 }
 
 export const Message = styledObserver<Props>(
-  ({ message, className, isReadonly, isBundledWithPreviousMessage = false, contentLayoutId }) => {
+  ({
+    message,
+    className,
+    isReadonly,
+    isBundledWithPreviousMessage = false,
+    contentLayoutId,
+    isRemoveDisabled = false,
+  }) => {
     const rootRef = useRef<HTMLDivElement>(null);
     const topicContext = useTopicStoreContext();
 
@@ -85,7 +94,7 @@ export const Message = styledObserver<Props>(
         options.push({ label: "Edit message", onSelect: handleStartEditing, icon: <IconEdit /> });
       }
 
-      if (message.isOwn) {
+      if (message.isOwn && !isRemoveDisabled) {
         options.push({
           label: "Delete message",
           onSelect: handleDeleteWithConfirm,

--- a/frontend/src/message/feed/MessagesFeed.tsx
+++ b/frontend/src/message/feed/MessagesFeed.tsx
@@ -79,6 +79,7 @@ export const MessagesFeed = observer(({ feedItems, isReadonly }: Props) => {
               <Message
                 contentLayoutId={isFirstMessage ? layoutAnimations.newTopic.message(message.topic_id) : undefined}
                 isReadonly={isReadonly}
+                isRemoveDisabled={isFirstMessage}
                 message={message}
                 key={message.id}
                 isBundledWithPreviousMessage={shouldBundleCurrentMessageWithPrevious(message, previousMessage)}


### PR DESCRIPTION
Deleting the first request in the feed was messing everything up. Let's prevent users from deleting it in the frontend.

<img width="573" alt="Screenshot 2021-11-17 at 16 54 49" src="https://user-images.githubusercontent.com/4765697/142224000-bef91933-2d39-4d30-9834-1ad749a949f5.png">

