### PR TITLE
refactor: move react-virtualized -> react-window

### DIFF
--- a/ui/EmojiPicker/EmojiPickerWindowInner.tsx
+++ b/ui/EmojiPicker/EmojiPickerWindowInner.tsx
@@ -1,7 +1,7 @@
 import { chunk } from "lodash";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Dispatch, SetStateAction, memo, useEffect, useMemo, useRef, useState } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
-import { List } from "react-virtualized";
+import { FixedSizeList as List, ListChildComponentProps } from "react-window";
 import styled, { css } from "styled-components";
 
 import { emojiByCategories, getEmojiSearchIndex, getEmojiSlug } from "~shared/emoji";
@@ -14,7 +14,9 @@ import { useFrequentlyUsedEmoji } from "./frequentlyUsed";
 const EMOJI_SIZE = 30;
 const EMOJI_IN_ROW_COUNT = 10;
 
-const PICKER_WIDTH = EMOJI_SIZE * EMOJI_IN_ROW_COUNT;
+// scrollbar width is very different depending on the browser. This kind works for the few I use
+const SCROLLBAR_WIDTH = 20;
+const PICKER_WIDTH = EMOJI_SIZE * EMOJI_IN_ROW_COUNT + SCROLLBAR_WIDTH;
 const PICKER_HEIGHT = EMOJI_SIZE * 7;
 
 /**
@@ -81,13 +83,29 @@ interface Point {
 // Keyboard direction
 type Direction = "up" | "down" | "left" | "right";
 
+interface ItemData {
+  allRows: VirtualizedRow[];
+  emojiOnlyRows: EmojiRow[];
+  selectedPosition: Point | null;
+  setSelectedPosition: Dispatch<SetStateAction<Point | null>>;
+  handleEmojiPicked: (emoji: string) => void;
+}
+
+function getItemKey(index: number, { allRows }: ItemData) {
+  const row = allRows[index];
+  if (row.type === "header") {
+    return row.label;
+  }
+  return row.emojiInRow[0];
+}
+
 export function EmojiPickerWindowInner({ onEmojiPicked }: EmojiPickerProps) {
   const listRef = useRef<List>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedPosition, setSelectedPosition] = useState<Point | null>(null);
   const { frequentlyUsedEmoji, markEmojiAsUsed } = useFrequentlyUsedEmoji();
 
-  const resultsToShow = useMemo<VirtualizedRow[]>(() => {
+  const allRows = useMemo<VirtualizedRow[]>(() => {
     // If we're not searching - prepare regular list of all emoji
     if (!searchTerm.trim()) {
       return [
@@ -108,10 +126,10 @@ export function EmojiPickerWindowInner({ onEmojiPicked }: EmojiPickerProps) {
   // To make navigation logic easier - create another list of virtualized rows, but ignoring headers.
   // This makes emoji x,y coordinates logic a lot simpler
   const emojiOnlyRows = useMemo(() => {
-    const emojiRows = resultsToShow.filter((row) => row.type === "emoji-row") as EmojiRow[];
+    const emojiRows = allRows.filter((row) => row.type === "emoji-row") as EmojiRow[];
 
     return emojiRows;
-  }, [resultsToShow]);
+  }, [allRows]);
 
   // When typing in search - reset selected position
   useEffect(() => {
@@ -133,11 +151,11 @@ export function EmojiPickerWindowInner({ onEmojiPicked }: EmojiPickerProps) {
     if (!emojiRow) return;
 
     // To scroll accurately - we need now to take index of row including headers
-    const realRow = resultsToShow.indexOf(emojiRow);
+    const realRow = allRows.indexOf(emojiRow);
 
     if (realRow < 0) return;
 
-    listRef.current?.scrollToRow(realRow);
+    listRef.current?.scrollToItem(realRow);
   }, [selectedPosition, emojiOnlyRows]);
 
   // Will calculate new position of selection basing on current position and direction of movement
@@ -245,6 +263,17 @@ export function EmojiPickerWindowInner({ onEmojiPicked }: EmojiPickerProps) {
     onEmojiPicked?.(emoji);
   }
 
+  const itemData = useMemo<ItemData>(
+    () => ({
+      allRows,
+      emojiOnlyRows,
+      selectedPosition,
+      setSelectedPosition,
+      handleEmojiPicked,
+    }),
+    [allRows, emojiOnlyRows, selectedPosition, setSelectedPosition, handleEmojiPicked]
+  );
+
   return (
     <UIHolder>
       <UISearch>
@@ -258,60 +287,67 @@ export function EmojiPickerWindowInner({ onEmojiPicked }: EmojiPickerProps) {
         />
       </UISearch>
       <UIEmojiList>
-        <List
+        <List<ItemData>
           ref={listRef}
-          rowCount={resultsToShow.length}
-          rowHeight={EMOJI_SIZE}
+          itemCount={allRows.length}
+          itemKey={getItemKey}
+          itemData={itemData}
+          itemSize={EMOJI_SIZE}
           height={PICKER_HEIGHT}
           width={PICKER_WIDTH}
-          rowRenderer={(row) => {
-            const { index, style, key } = row;
-
-            // Get row this emoji is part of (including headers rows)
-            const rowData = resultsToShow[index];
-
-            if (rowData.type === "header") {
-              return <UIHeader style={style}>{rowData.label}</UIHeader>;
-            }
-
-            // Get which emoji-only row is it in (excluding headers)
-            const emojiRowIndex = emojiOnlyRows.indexOf(rowData);
-
-            return (
-              <UIEmojiRow style={style} key={key}>
-                {rowData.emojiInRow.map((emoji, columnIndex) => {
-                  /**
-                   * Note - we decide if emoji is selected by x,y cords, not by emoji itself. It is because it is possible
-                   * that same emoji appears twice (eg as frequently used and on the list)
-                   */
-                  const isSelected =
-                    !!selectedPosition && selectedPosition.x === columnIndex && selectedPosition.y === emojiRowIndex;
-
-                  return (
-                    <UIEmojiButton
-                      tabIndex={0}
-                      onMouseEnter={() => {
-                        setSelectedPosition({ x: columnIndex, y: emojiRowIndex });
-                      }}
-                      title={getEmojiSlug(emoji) ?? undefined}
-                      key={emoji}
-                      isSelected={isSelected}
-                      onClick={() => {
-                        handleEmojiPicked(emoji);
-                      }}
-                    >
-                      {emoji}
-                    </UIEmojiButton>
-                  );
-                })}
-              </UIEmojiRow>
-            );
-          }}
-        />
+        >
+          {Row}
+        </List>
       </UIEmojiList>
     </UIHolder>
   );
 }
+
+const Row = memo(function Row({
+  index,
+  style,
+  data: { allRows, emojiOnlyRows, selectedPosition, setSelectedPosition, handleEmojiPicked },
+}: ListChildComponentProps<ItemData>) {
+  // Get row this emoji is part of (including headers rows)
+  const rowData = allRows[index];
+
+  if (rowData.type === "header") {
+    return <UIHeader style={style}>{rowData.label}</UIHeader>;
+  }
+
+  // Get which emoji-only row is it in (excluding headers)
+  const emojiRowIndex = emojiOnlyRows.indexOf(rowData);
+
+  return (
+    <UIEmojiRow style={style}>
+      {rowData.emojiInRow.map((emoji, columnIndex) => {
+        /**
+         * Note - we decide if emoji is selected by x,y cords, not by emoji itself. It is because it is possible
+         * that same emoji appears twice (eg as frequently used and on the list)
+         */
+        const isSelected =
+          !!selectedPosition && selectedPosition.x === columnIndex && selectedPosition.y === emojiRowIndex;
+
+        return (
+          <UIEmojiButton
+            tabIndex={0}
+            onMouseEnter={() => {
+              setSelectedPosition({ x: columnIndex, y: emojiRowIndex });
+            }}
+            title={getEmojiSlug(emoji) ?? undefined}
+            key={emoji}
+            isSelected={isSelected}
+            onClick={() => {
+              handleEmojiPicked(emoji);
+            }}
+          >
+            {emoji}
+          </UIEmojiButton>
+        );
+      })}
+    </UIEmojiRow>
+  );
+});
 
 const UIHolder = styled.div<{}>``;
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,12 +16,12 @@
     "emoji-mart": "^3.0.1",
     "eva-icons": "^1.1.3",
     "proxy-deep": "^3.1.1",
-    "react-virtualized": "^9.22.3",
+    "react-window": "^1.8.6",
     "~shared": "0.1.0"
   },
   "devDependencies": {
     "@svgr/cli": "^5.5.0",
     "@types/emoji-mart": "^3.0.6",
-    "@types/react-virtualized": "^9.21.13"
+    "@types/react-window": "^1.8.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,7 +908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.15.4, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.15.4, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.9.2":
   version: 7.15.4
   resolution: "@babel/runtime@npm:7.15.4"
   dependencies:
@@ -4630,13 +4630,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-virtualized@npm:^9.21.13":
-  version: 9.21.13
-  resolution: "@types/react-virtualized@npm:9.21.13"
+"@types/react-window@npm:^1.8.5":
+  version: 1.8.5
+  resolution: "@types/react-window@npm:1.8.5"
   dependencies:
-    "@types/prop-types": "*"
     "@types/react": "*"
-  checksum: 49f5a605d374d61b42c0f9dae9a0fbbedf41ec0871a72051569c29347c17f73eacae0b98e527e0031e7f1eb48be57521660565cc0f3b8ecd9732f8c78a0e32d7
+  checksum: 5f519e1402300d11b6e6595223feb6499f3227e38da166cbc565773cd7f71862abcf855b7835d391b5119fcfacdfba79d73a965b45f60a293fc1ff25986319ed
   languageName: node
   linkType: hard
 
@@ -6815,13 +6814,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.4":
-  version: 1.1.1
-  resolution: "clsx@npm:1.1.1"
-  checksum: ff052650329773b9b245177305fc4c4dc3129f7b2be84af4f58dc5defa99538c61d4207be7419405a5f8f3d92007c954f4daba5a7b74e563d5de71c28c830063
-  languageName: node
-  linkType: hard
-
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -8226,16 +8218,6 @@ __metadata:
   version: 0.5.7
   resolution: "dom-accessibility-api@npm:0.5.7"
   checksum: 16161688087510bc31e9103be3a0b0b7d3b044fd4ca03059ac97950f391958008198627c688bd94346757169de91c2500903b14ee9e420c006961a25770b8c62
-  languageName: node
-  linkType: hard
-
-"dom-helpers@npm:^5.1.3":
-  version: 5.2.1
-  resolution: "dom-helpers@npm:5.2.1"
-  dependencies:
-    "@babel/runtime": ^7.8.7
-    csstype: ^3.0.2
-  checksum: 863ba9e086f7093df3376b43e74ce4422571d404fc9828bf2c56140963d5edf0e56160f9b2f3bb61b282c07f8fc8134f023c98fd684bddcb12daf7b0f14d951c
   languageName: node
   linkType: hard
 
@@ -14123,6 +14105,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:>=3.1.1 <6":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
+  languageName: node
+  linkType: hard
+
 "memory-fs@npm:^0.5.0":
   version: 0.5.0
   resolution: "memory-fs@npm:0.5.0"
@@ -17292,13 +17281,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-lifecycles-compat@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "react-lifecycles-compat@npm:3.0.4"
-  checksum: a904b0fc0a8eeb15a148c9feb7bc17cec7ef96e71188280061fc340043fd6d8ee3ff233381f0e8f95c1cf926210b2c4a31f38182c8f35ac55057e453d6df204f
-  languageName: node
-  linkType: hard
-
 "react-popper@npm:^2.2.5":
   version: 2.2.5
   resolution: "react-popper@npm:2.2.5"
@@ -17368,20 +17350,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-virtualized@npm:^9.22.3":
-  version: 9.22.3
-  resolution: "react-virtualized@npm:9.22.3"
+"react-window@npm:^1.8.6":
+  version: 1.8.6
+  resolution: "react-window@npm:1.8.6"
   dependencies:
-    "@babel/runtime": ^7.7.2
-    clsx: ^1.0.4
-    dom-helpers: ^5.1.3
-    loose-envify: ^1.4.0
-    prop-types: ^15.7.2
-    react-lifecycles-compat: ^3.0.4
+    "@babel/runtime": ^7.0.0
+    memoize-one: ">=3.1.1 <6"
   peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha
-    react-dom: ^15.3.0 || ^16.0.0-alpha
-  checksum: 5e3b566592293bc0057bc6be4f6ee29c58c8931421d2882a3ef45ca9b24c6f3ea78bbc5a182c2916af6520845e5a90f569b3a63c9b5e89428720913e6d6239cc
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0
+    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 54ccf2b16c921a1acfadbe6de5dc19fe0981d84c5a913e4607afbf24448b96e938020704bf5125ec528e43a710643fc05e86fc117219fc4936e231ecd19be0b2
   languageName: node
   linkType: hard
 
@@ -21269,11 +21247,11 @@ fsevents@^1.2.7:
   dependencies:
     "@svgr/cli": ^5.5.0
     "@types/emoji-mart": ^3.0.6
-    "@types/react-virtualized": ^9.21.13
+    "@types/react-window": ^1.8.5
     emoji-mart: ^3.0.1
     eva-icons: ^1.1.3
     proxy-deep: ^3.1.1
-    react-virtualized: ^9.22.3
+    react-window: ^1.8.6
     ~shared: 0.1.0
   peerDependencies:
     react: "*"


### PR DESCRIPTION
The author of `react-virtualized` recommends to use `react-window` instead. 

I'll be using this in my work with archived topics, so I decided to move the emoji-picker to [react-window](https://github.com/bvaughn/react-window) instead.

P.S: Safari has some weird perf issues when scrolling. I added all of the [performance recommendations](https://react-window.vercel.app/#/examples/list/memoized-list-items) from the library.