### PR TITLE
feat: add slack command help

### DIFF
--- a/backend/src/slack/request-modal/index.tsx
+++ b/backend/src/slack/request-modal/index.tsx
@@ -30,10 +30,11 @@ export function setupRequestModal(app: App) {
     if (body.text.toLowerCase() == "help") {
       await ack({
         response_type: "ephemeral",
-        text:
-          "To create a request type the Acapela command and the text for the initial message. " +
-          "You can also @-tag people that should receive the request. For example:\n" +
-          Md.codeBlock(`/acapela ${Md.user(slackUserId)} can you forward the documentation to me?`),
+        text: [
+          `To create a request type ${Md.codeInline("/acapela")} with the text for the initial message.`,
+          "You can also @-tag people that should receive the request.",
+          `For example:\n${Md.codeBlock(`/acapela can you forward the documentation to me, ${Md.user(slackUserId)}?`)}`,
+        ].join(" "),
       });
       return;
     }


### PR DESCRIPTION
As per the check-list to get us into the Slack App Directory:

> If my app uses a slash command, there’s a way for a user to ask for help or send feedback. For example, the slash command should respond to "/mycommand help" with information about using the app.

this shows the following when sending `/acapela help`

<img width="763" alt="Screenshot 2021-11-18 at 13 00 59" src="https://user-images.githubusercontent.com/4051932/142411834-30289916-2fc7-4c1f-82b5-d9a47ce3ab8a.png">
