### PR TITLE
feat(slack): show due dates in live message and home tab

### DIFF
--- a/backend/src/slack/actions.ts
+++ b/backend/src/slack/actions.ts
@@ -13,7 +13,7 @@ import { RequestType } from "~shared/types/mention";
 
 import { slackClient } from "./app";
 import { updateHomeView } from "./home-tab";
-import { createSlackLink } from "./md/utils";
+import { createSlackLink, mdDate } from "./md/utils";
 import { tryOpenRequestModal } from "./request-modal/tryOpenRequestModal";
 import { SlackActionIds, assertToken, findUserBySlackId } from "./utils";
 
@@ -167,11 +167,7 @@ export function setupSlackActionHandlers(slackApp: App) {
         origin: "slack-command",
       });
 
-      const unixTime = dueAtUTC.getTime() / 1000;
-      await respond({
-        replace_original: true,
-        text: `Due date was set to <!date^${unixTime}^{date_long_pretty} {time}|${dueAtUTC.toISOString()}>`,
-      });
+      await respond({ replace_original: true, text: `Due date was set to ${mdDate(dueAtUTC)}` });
     }
   );
 

--- a/backend/src/slack/home-tab.ts
+++ b/backend/src/slack/home-tab.ts
@@ -1,7 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { App } from "@slack/bolt";
 import { View } from "@slack/types";
-import { formatRelative } from "date-fns";
 import { flattenDeep, minBy, uniq } from "lodash";
 import { Blocks, Elements, HomeTab, Md } from "slack-block-builder";
 
@@ -15,7 +14,7 @@ import { RequestType } from "~shared/types/mention";
 
 import { slackClient } from "./app";
 import { GenerateContext, generateMarkdownFromTipTapJson } from "./md/generator";
-import { createSlackLink } from "./md/utils";
+import { createSlackLink, mdDate } from "./md/utils";
 import { REQUEST_TYPE_EMOJIS, SlackActionIds } from "./utils";
 
 const TOPICS_PER_CATEGORY = 10;
@@ -86,7 +85,7 @@ function RequestItem(topic: TopicWithOpenTask, context: GenerateContext) {
     Blocks.Section({
       text: [
         createSlackLink(process.env.FRONTEND_URL + routes.topic({ topicSlug: topic.slug }), topic.name) +
-          (mostUrgentDueDate ? " - " + Md.italic("due " + formatRelative(mostUrgentDueDate, new Date())) : ""),
+          (mostUrgentDueDate ? " - " + Md.italic("due " + mdDate(mostUrgentDueDate)) : ""),
         mostUrgentMessage?.content_text
           ? Md.bold(mostUrgentMessage.user.name + ":") +
             " " +

--- a/backend/src/slack/md/utils.ts
+++ b/backend/src/slack/md/utils.ts
@@ -4,3 +4,8 @@ export function createSlackLink(url: string, name?: string) {
   if (!name || url === name) return `<${escapeStringForSlackLink(url)}>`;
   return `<${escapeStringForSlackLink(url)}|${escapeStringForSlackLink(name)}>`;
 }
+
+export const mdDate = (date: Date, format = "date_long_pretty") => {
+  const unixTime = date.getTime() / 1000;
+  return `<!date^${unixTime}^{${format}} {time}|${date.toISOString()}>`;
+};


### PR DESCRIPTION
Adds date formatter utility and uses it for Slack Home and Live Topic Message to show their due dates. The ask-label is for Chris, otherwise I'd have ship'd it. 