### PR TITLE
Use hasura cli via yarn

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,6 @@
     "axios": "*",
     "date-fns": "*",
     "express": "*",
-    "hasura-cli": "*",
     "typescript": "*"
   },
   "dependencies": {

--- a/backend/scripts/migrate-hasura.sh
+++ b/backend/scripts/migrate-hasura.sh
@@ -13,8 +13,8 @@ set -eu
 }
 
 cd ../infrastructure/hasura
-hasura metadata apply --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
-hasura migrate apply --all-databases --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
-hasura seed apply --database-name default --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
-hasura metadata reload --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
+yarn hasura metadata apply --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
+yarn hasura migrate apply --all-databases --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
+yarn hasura seed apply --database-name default --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
+yarn hasura metadata reload --endpoint $HASURA_ENDPOINT --admin-secret $HASURA_ADMIN_SECRET
 cd -

--- a/monorepo.dockerfile
+++ b/monorepo.dockerfile
@@ -23,8 +23,6 @@ RUN yarn frontend:build
 # main image
 FROM node:16-buster
 
-RUN curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
-
 WORKDIR /app
 
 ARG BUILD_ID

--- a/yarn.lock
+++ b/yarn.lock
@@ -21041,7 +21041,6 @@ fsevents@^1.2.7:
     axios: "*"
     date-fns: "*"
     express: "*"
-    hasura-cli: "*"
     typescript: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This ensures that we use the same hasura cli version on staging and production, as we use in dev.