### PR TITLE
fix(task): stop multiple notifications for same task

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_task.yaml
@@ -87,6 +87,6 @@ event_triggers:
   name: task_updates
   retry_conf:
     interval_sec: 10
-    num_retries: 5
+    num_retries: 0
     timeout_sec: 30
   webhook_from_env: HASURA_EVENTS_WEBHOOK_URL


### PR DESCRIPTION
I got multiple notifications, while I was having a flaky internet connection. My explanation was: both Hasura events for tasks were being retried, while slack-bolt also comes with a retry mechanism (while still failing the initial call).

It turns out the only other hasura model change event with retries we had, was for messages, where the handler is already idempotent. Longer term we would probably want to make sure all our change handlers are idempotent and make them retry, but for now this should be a good hotfix.