### PR TITLE
fix: allow copy pasting content with mentions

### DIFF
--- a/richEditor/autocomplete/index.tsx
+++ b/richEditor/autocomplete/index.tsx
@@ -146,9 +146,7 @@ export function createAutocompletePlugin<D>(options: AutocompletePluginOptions<D
             const rawDataJSON = element.getAttribute(DATA_ATTRIBUTE_NAME);
 
             const data = rawDataJSON ? JSON.parse(rawDataJSON) : {};
-            return {
-              data,
-            };
+            return data;
           },
 
           renderHTML: (attributes) => {


### PR DESCRIPTION
Master:
![CleanShot-Google Chrome-2021-11-23 at 14 14 15](https://user-images.githubusercontent.com/7311462/143030572-5d87ad93-419c-448c-99e4-9e1ad6831a99.gif)

Fixed:
![CleanShot-Google Chrome-2021-11-23 at 14 14 26](https://user-images.githubusercontent.com/7311462/143030565-eaa8916e-c4cb-4ac3-9c9c-c16cb2b1253b.gif)

Context, we incorrectly provided 'parseHTML' callback to tiptap plugin. As 'copy pasting' lives completly in 'dom' world (not react nor tiptap) - it has no other way to pick data than to properly parse html

