### PR TITLE
fix(clientdb): stop cached computed disposal timeout when re-observed

### DIFF
--- a/clientdb/entity/utils/biddableTimeout.ts
+++ b/clientdb/entity/utils/biddableTimeout.ts
@@ -1,16 +1,16 @@
 export function createBiddableTimeout(time: number, endCallback: () => void) {
   let currentBidTimeout: ReturnType<typeof setTimeout>;
 
-  function stopBid() {
+  function stopCurrentBid() {
     if (currentBidTimeout) {
       clearTimeout(currentBidTimeout);
     }
   }
 
   function bid() {
-    stopBid();
+    stopCurrentBid();
     currentBidTimeout = setTimeout(endCallback, time);
   }
 
-  return [bid, stopBid];
+  return [bid, stopCurrentBid] as const;
 }

--- a/clientdb/entity/utils/cachedComputedWithoutArgs.ts
+++ b/clientdb/entity/utils/cachedComputedWithoutArgs.ts
@@ -11,7 +11,7 @@ export type LazyComputed<T> = {
 
 const SECOND = 1000;
 
-const KEEP_ALIVE_TIME_AFTER_UNOBSERVED = 15 * SECOND;
+export const KEEP_ALIVE_TIME_AFTER_UNOBSERVED = 15 * SECOND;
 
 /**
  * Normally we keep not used computed alive for KEEP_ALIVE_TIME_AFTER_UNOBSERVED time.
@@ -33,26 +33,19 @@ let isDisposalCascadeRunning = false;
  */
 export function cachedComputedWithoutArgs<T>(
   getter: () => T,
-  {
-    name = "LazyComputed",
-    equals,
-    customKeepAliveTime,
-  }: IComputedValueOptions<T> & { customKeepAliveTime?: number } = {}
+  { name = "LazyComputed", equals }: IComputedValueOptions<T> = {}
 ): LazyComputed<T> {
   let latestValue: T;
   let needsRecomputing = true;
   let currentReaction: Reaction | null;
 
   // This works like a 'bid' - after KEEP_ALIVE_TIME_AFTER_UNOBSERVED timeout since last time this is called - we'll dispose
-  const [scheduleDisposal, stopDisposal] = createBiddableTimeout(
-    customKeepAliveTime ?? KEEP_ALIVE_TIME_AFTER_UNOBSERVED,
-    dispose
-  );
+  const [scheduleDisposal, cancelScheduledDisposal] = createBiddableTimeout(KEEP_ALIVE_TIME_AFTER_UNOBSERVED, dispose);
 
   const updateSignal = createAtom(
     name,
     () => {
-      stopDisposal();
+      cancelScheduledDisposal();
       aliveLazyReactions++;
     },
     handleBecameUnobserved

--- a/clientdb/tests/lazyComputed.spec.ts
+++ b/clientdb/tests/lazyComputed.spec.ts
@@ -1,7 +1,9 @@
 import { ObservableMap, autorun, observable, runInAction } from "mobx";
 
-import { cachedComputedWithoutArgs } from "~clientdb/entity/utils/cachedComputedWithoutArgs";
-import { wait } from "~shared/time";
+import {
+  KEEP_ALIVE_TIME_AFTER_UNOBSERVED,
+  cachedComputedWithoutArgs,
+} from "~clientdb/entity/utils/cachedComputedWithoutArgs";
 
 import { runObserved } from "./utils";
 
@@ -112,9 +114,11 @@ describe("lazyComputed", () => {
   });
 
   it("gets most recent value after disposing", async () => {
+    jest.useFakeTimers();
+
     const meanings = new ObservableMap();
     meanings.set("life", -2);
-    const realMeaning = cachedComputedWithoutArgs(() => meanings.get("life") + 2, { customKeepAliveTime: 10 });
+    const realMeaning = cachedComputedWithoutArgs(() => meanings.get("life") + 2);
 
     let values: number[] = [];
     const watcher = () => {
@@ -133,7 +137,7 @@ describe("lazyComputed", () => {
 
     autorun(watcher);
 
-    await wait(10);
+    jest.advanceTimersByTime(KEEP_ALIVE_TIME_AFTER_UNOBSERVED);
 
     runInAction(() => {
       meanings.set("life", 1335);


### PR DESCRIPTION
This should _fix_ some out-of-date UI issues we've been seeing. At least the one I had most success in reproducing, namely the request item last-message being out of date.

This PR is "ask" for @pie6k and "whatever you feel like" for the rest