### PR TITLE
fix: use z-index for fullscreen preview to avoid being covered by any element with 1+ z-index

### DIFF
--- a/frontend/src/message/attachment/MessageImageAttachment.tsx
+++ b/frontend/src/message/attachment/MessageImageAttachment.tsx
@@ -35,19 +35,23 @@ export const MessageImageAttachment = styled<AttachmentProps>(({ attachmentUrl, 
       </UIInlineAttachmentHolder>
       <AnimatePresence>
         {isFullscreenOpened && (
-          <ScreenCover isTransparent={false} onCloseRequest={closeFullscreen}>
+          <UIFullscreenBackground isTransparent={false} onCloseRequest={closeFullscreen}>
             <CornerButtonWrapper>
               <IconButton tooltip="Esc or Space" onClick={closeFullscreen} icon={<IconCross />} />
             </CornerButtonWrapper>
             <PopPresenceAnimator>
               <ImageWrapper src={attachmentUrl} className={className} />
             </PopPresenceAnimator>
-          </ScreenCover>
+          </UIFullscreenBackground>
         )}
       </AnimatePresence>
     </LayoutGroup>
   );
 })``;
+
+const UIFullscreenBackground = styled(ScreenCover)`
+  z-index: ${theme.zIndex.fullScreenPreview};
+`;
 
 const UIInlineAttachmentHolder = styled.div<{}>`
   display: flex;

--- a/frontend/src/ui/Modal/ScreenCover.tsx
+++ b/frontend/src/ui/Modal/ScreenCover.tsx
@@ -10,16 +10,23 @@ interface Props {
   children: ReactNode;
   onCloseRequest?: () => void;
   isTransparent?: boolean;
+  className?: string;
 }
 
 const BACKGROUND_BLUR_SIZE_PX = 8;
 
-export function ScreenCover({ children, onCloseRequest, isTransparent = true }: Props) {
+export const ScreenCover = styled(function ScreenCover({
+  children,
+  onCloseRequest,
+  isTransparent = true,
+  className,
+}: Props) {
   const isMounted = useUnmountPresence(200);
 
   return (
     <BodyPortal>
       <UIBodyCover
+        className={className}
         isCovering={isMounted && !isTransparent}
         onClick={handleWithStopPropagation(onCloseRequest)}
         enableBlur={isTransparent}
@@ -28,7 +35,7 @@ export function ScreenCover({ children, onCloseRequest, isTransparent = true }: 
       </UIBodyCover>
     </BodyPortal>
   );
-}
+})``;
 
 const background = theme.colors.primary;
 


### PR DESCRIPTION
We had regression ( I think I introduced when refactoring `theme` that fullscreen attachment preview was not using z-index at all)

This resulted in any element having z-index bigger than `1` to be on top of it

<img width="861" alt="CleanShot-Google Chrome-2021-11-23 at 14 54 53" src="https://user-images.githubusercontent.com/7311462/143036941-8c99afdb-4c71-4dc4-a768-d82ab154a6ea.png">
