### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-* @heikir @pie6k @omarduarte @Gregoor
-
-/infrastructure/kubernetes @christophwitzko
-/infrastructure/hasura @heikir @Gregoor
-/backend @heikir @christophwitzko @Gregoor @pie6k @omarduarte
-/frontend @heikir @pie6k @omarduarte @Gregoor


### PR DESCRIPTION
I'd like assigning people as reviewers to be a meaningful action again. It feels like CODEOWNERS are not serving our current working model, and are obscuring who you really want to review it. Since they (afaik) don't buy us anything apart from auto-assigning reviewers, I'd vote for deleting them.

LMKWYT!