### PR TITLE
fix(Slack-Command): preselect users from command mentions

### DIFF
--- a/backend/src/slack/home-tab/RequestList.ts
+++ b/backend/src/slack/home-tab/RequestList.ts
@@ -1,0 +1,40 @@
+import { Blocks, Md } from "slack-block-builder";
+
+import { pluralize } from "~shared/text/pluralize";
+
+import { GenerateContext } from "../md/generator";
+import { createSlackLink } from "../md/utils";
+import { RequestItem } from "./RequestItem";
+import { TopicRowsWithCount } from "./types";
+
+const Padding = [Blocks.Section({ text: " " }), Blocks.Section({ text: " " })];
+
+export function RequestsList(title: string, topics: TopicRowsWithCount, context: GenerateContext) {
+  const extraRequestsCount = topics.count - topics.rows.length;
+  return [
+    ...Padding,
+    Blocks.Header({ text: title }),
+    ...(topics.count === 0
+      ? [Blocks.Section({ text: Md.italic("No requests here") })]
+      : topics.rows.flatMap((topic, i) => [
+          ...RequestItem(topic, context),
+          i < topics.rows.length - 1 ? Blocks.Divider() : undefined,
+        ])),
+    ...(extraRequestsCount > 0
+      ? [
+          Blocks.Divider(),
+          Blocks.Section({
+            text: Md.italic(
+              `There ${pluralize(extraRequestsCount, "is another topic", "are more topics")} ${Md.bold(
+                extraRequestsCount.toString()
+              )} in this category. ${createSlackLink(process.env.FRONTEND_URL, "Open the web app")} to see ${pluralize(
+                extraRequestsCount,
+                "it",
+                "them"
+              )}.`
+            ),
+          }),
+        ]
+      : []),
+  ];
+}


### PR DESCRIPTION
I accidentally removed auto-filling the Slack New Request Modal `Request to` field with the mentions included in the slack command.

I.e.,

## `/acapela @Omar here is a mention`  will now prefill with this:
<img width="523" alt="Screenshot 2021-11-24 at 12 04 22" src="https://user-images.githubusercontent.com/4765697/143217486-617a63a5-a3a5-49cb-aa0f-56c36215c4bd.png">

