### PR TITLE
fix(healthz): log messages and errors

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -86,6 +86,13 @@ function setupGracefulShutdown(server: Server) {
         setTimeout(resolve, 5000);
       });
     },
+    logger(msg, error) {
+      if (error) {
+        console.error("error thrown in /healthz", msg, error);
+      } else {
+        console.info("/healthz", msg);
+      }
+    },
     healthChecks: {
       verbatim: true,
       "/healthz": async function () {


### PR DESCRIPTION
We did not have enough information to find out what the 10 AM incident yesterday was about, this aims to address it by informing us why the health endpoint could have returned a faulty response.

I want to take some time to redo our backend logger (likely next week), it does not seem to be possible to call it in such a way that it logs a full error, with stack etc. So for now I just used `console`. Wdyt @christophwitzko , would that make it correctly into our GCP logs?

Fixes ACA-988