### PR TITLE
e2e: throw on CI if using .only flag for tests

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,5 +6,6 @@ const config: PlaywrightTestConfig = {
     video: "retain-on-failure",
     trace: "retain-on-failure",
   },
+  forbidOnly: Boolean(process.env.CI) && process.env.CI !== "false",
 };
 export default config;


### PR DESCRIPTION
We often by accident leave `.only` flags on e2e tests. It is useful in dev, but might be very risky if left like that