### PR TITLE
fix(modals): fix modals to use overlay z-index to not be covered by z-indexed elements of ui

### DIFF
--- a/frontend/src/message/attachment/MessageImageAttachment.tsx
+++ b/frontend/src/message/attachment/MessageImageAttachment.tsx
@@ -50,7 +50,7 @@ export const MessageImageAttachment = styled<AttachmentProps>(({ attachmentUrl, 
 })``;
 
 const UIFullscreenBackground = styled(ScreenCover)`
-  z-index: ${theme.zIndex.fullScreenPreview};
+  z-index: ${theme.zIndex.overlay};
 `;
 
 const UIInlineAttachmentHolder = styled.div<{}>`

--- a/frontend/src/ui/Modal/ScreenCover.tsx
+++ b/frontend/src/ui/Modal/ScreenCover.tsx
@@ -5,6 +5,7 @@ import { useUnmountPresence } from "~frontend/ui/presence";
 import { handleWithStopPropagation } from "~shared/events";
 import { BodyPortal } from "~ui/BodyPortal";
 import { theme } from "~ui/theme";
+import { zIndexValues } from "~ui/theme/zIndex";
 
 interface Props {
   children: ReactNode;
@@ -56,4 +57,5 @@ const UIBodyCover = styled.div<{ enableBlur: boolean; isCovering: boolean }>`
   backdrop-filter: blur(${(props) => (props.isCovering ? BACKGROUND_BLUR_SIZE_PX : 0)}px);
   background-color: ${(props) => (props.isCovering ? background.opacity(0.5) : background.opacity(0))};
   transition: 0.1s all;
+  z-index: ${zIndexValues.overlay};
 `;

--- a/ui/popovers/Popover.tsx
+++ b/ui/popovers/Popover.tsx
@@ -85,12 +85,12 @@ export const Popover = styled<PopoverProps>(
       </UIHolder>
     );
 
-    return (
-      <BodyPortal>
-        {!enableScreenCover && popoverNode}
-        {enableScreenCover && <ScreenCover>{popoverNode}</ScreenCover>}
-      </BodyPortal>
-    );
+    if (!enableScreenCover) {
+      return <BodyPortal>{popoverNode}</BodyPortal>;
+    }
+
+    // Screen cover is already body portal by itself
+    return <ScreenCover>{popoverNode}</ScreenCover>;
   }
 )``;
 

--- a/ui/popovers/PopoverMenu.tsx
+++ b/ui/popovers/PopoverMenu.tsx
@@ -4,7 +4,6 @@ import React, { ReactNode, RefObject, useRef } from "react";
 import { useClickAway } from "react-use";
 import styled, { css } from "styled-components";
 
-import { ScreenCover } from "~frontend/src/ui/Modal/ScreenCover";
 import { openInNewTab } from "~frontend/src/utils/openInNewTab";
 import { theme } from "~ui/theme";
 
@@ -35,51 +34,55 @@ export const PopoverMenu = styled<Props>(
     useClickAway(popoverRef, () => onCloseRequest?.());
 
     return (
-      <ScreenCover onCloseRequest={onCloseRequest}>
-        <Popover anchorRef={anchorRef} placement={placement} isDisabled={isDisabled}>
-          <UIPopoverMenuModal ref={popoverRef} className={className} onClick={(event) => event.stopPropagation()}>
-            {options.map((option) => {
-              const labelInnerNode = (
-                <>
-                  {option.icon && <UIItemIcon>{option.icon}</UIItemIcon>}
-                  {option.label}
-                </>
+      <Popover
+        anchorRef={anchorRef}
+        placement={placement}
+        isDisabled={isDisabled}
+        enableScreenCover
+        onClickOutside={onCloseRequest}
+      >
+        <UIPopoverMenuModal ref={popoverRef} className={className} onClick={(event) => event.stopPropagation()}>
+          {options.map((option) => {
+            const labelInnerNode = (
+              <>
+                {option.icon && <UIItemIcon>{option.icon}</UIItemIcon>}
+                {option.label}
+              </>
+            );
+
+            const labelNode = (
+              <UIMenuItem
+                data-test-id="popover-menu-item"
+                isDestructive={option.isDestructive ?? false}
+                isDisabled={option.isDisabled ?? false}
+                key={option.key ?? option.label}
+                onClick={() => {
+                  if ("externalURL" in option) {
+                    openInNewTab(option.externalURL);
+                  }
+                  onItemSelected?.(option);
+                  onCloseRequest?.();
+                  runInAction(() => {
+                    "onSelect" in option && option.onSelect();
+                  });
+                }}
+              >
+                {labelInnerNode}
+              </UIMenuItem>
+            );
+
+            if ("href" in option) {
+              return (
+                <Link href={option.href} passHref>
+                  <a>{labelNode}</a>
+                </Link>
               );
+            }
 
-              const labelNode = (
-                <UIMenuItem
-                  data-test-id="popover-menu-item"
-                  isDestructive={option.isDestructive ?? false}
-                  isDisabled={option.isDisabled ?? false}
-                  key={option.key ?? option.label}
-                  onClick={() => {
-                    if ("externalURL" in option) {
-                      openInNewTab(option.externalURL);
-                    }
-                    onItemSelected?.(option);
-                    onCloseRequest?.();
-                    runInAction(() => {
-                      "onSelect" in option && option.onSelect();
-                    });
-                  }}
-                >
-                  {labelInnerNode}
-                </UIMenuItem>
-              );
-
-              if ("href" in option) {
-                return (
-                  <Link href={option.href} passHref>
-                    <a>{labelNode}</a>
-                  </Link>
-                );
-              }
-
-              return labelNode;
-            })}
-          </UIPopoverMenuModal>
-        </Popover>
-      </ScreenCover>
+            return labelNode;
+          })}
+        </UIPopoverMenuModal>
+      </Popover>
     );
   }
 )``;

--- a/ui/theme/zIndex.ts
+++ b/ui/theme/zIndex.ts
@@ -1,5 +1,5 @@
 export enum zIndexValues {
   popover = 1000,
-  fullScreenPreview,
+  overlay,
   toast,
 }


### PR DESCRIPTION
Fixed issue:
<img width="1496" alt="CleanShot-Google Chrome-2021-11-25 at 15 54 56" src="https://user-images.githubusercontent.com/7311462/143463046-f0b16fd5-b498-4ee8-8b1d-62e24e0fff71.png">

overlay z index was not used for modals