### PR TITLE
fix(slack): correctly thread requests

### DIFF
--- a/backend/src/slack/live-messages/utils.ts
+++ b/backend/src/slack/live-messages/utils.ts
@@ -10,7 +10,7 @@ import { createSlackLink } from "../md/utils";
 import { REQUEST_TYPE_EMOJIS } from "../utils";
 
 export const createTopicLink = (topic: Topic) =>
-  createSlackLink(process.env.FRONTEND_URL + routes.topic({ topicSlug: topic.slug }), topic.name);
+  createSlackLink(process.env.FRONTEND_URL + routes.topic({ topicSlug: topic.slug }), topic.name.replaceAll("\n", " "));
 
 export const ToggleTaskDoneAtButton = (task: Task, user?: User) => {
   const type = task.type as RequestType;

--- a/backend/src/slack/request-modal/index.tsx
+++ b/backend/src/slack/request-modal/index.tsx
@@ -92,7 +92,7 @@ export function setupRequestModal(app: App) {
 
     const { user } = await tryOpenRequestModal(assertToken(context), trigger_id, {
       channelId: channel.id,
-      messageTs: message.ts,
+      messageTs: message.thread_ts ?? message.ts,
       slackUserId: body.user.id,
       slackTeamId: assertDefined(body.team?.id, "must have slack team"),
       messageText: messageBody,


### PR DESCRIPTION
I think we saw a bit of a slack bug here. When you'd try to thread a message into an already-threaded message, the targeted messages gets visually unthreaded, so that the new message can be put into its thread. But without it being shown as thread. Anyway...

This just changes it so that we never try to deep-thread, as Slack does not support that. So when using the message action for a message within a thread, it just re-uses that thread.

Also fixes an issue where link formatting broke because of newlines in a topic title. We should probably kill new lines in the topic title at the source, but I didn't know where the source was, will look at that now.