### PR TITLE
fix(prisma): increase connection_limit to 10

### DIFF
--- a/db/.env
+++ b/db/.env
@@ -1,6 +1,6 @@
 # This file doesnt have to be ignored as its only concentrating other env variabels and has no persistance on its own
 # It has to be added to git
-PRISMA_DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=public
+PRISMA_DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=public&connection_limit=10
 
 # WARNING
 # This file is added into git! Don't put secrets here

--- a/db/index.ts
+++ b/db/index.ts
@@ -33,7 +33,7 @@ assert(process.env.DB_NAME, "DB_NAME required");
 
 const prismaDatabaseUrl = `postgresql://${process.env.DB_USER}:${encodeURIComponent(process.env.DB_PASSWORD)}@${
   process.env.DB_HOST
-}:${process.env.DB_PORT}/${process.env.DB_NAME}?schema=public`;
+}:${process.env.DB_PORT}/${process.env.DB_NAME}?schema=public&connection_limit=10`;
 
 export const db = new PrismaClient({
   datasources: {


### PR DESCRIPTION
Looking at the new logs we added for health-errors it looks like our backend nodes are running out of connections. We could also increase the timeout, but since our db still has plenty memory and free connections to offer, I'd go down that route for now.