### PR TITLE
feat: compose multiple blocks of content for slug if first is too short

### DIFF
--- a/shared/routes/topicSlug.ts
+++ b/shared/routes/topicSlug.ts
@@ -1,18 +1,15 @@
-/**
- * Topic handle has format of:
- *
- * any-human-familiar-part-<UUID-WITHOUT-DASHES>
- *
- */
-
 import { convertMessageContentToPlainText } from "~richEditor/content/plainText";
 import { RichEditorNode } from "~richEditor/content/types";
 import { slugifySync } from "~shared/slugify";
 
+function removeDoubleSpaces(input: string) {
+  return input.replace(/ +/g, " ");
+}
+
 /**
  * If topic has no title - we prepare slug from text snippet. To do that we'll try to take content from it.
  */
-function getTextSnippetFromMessageContent(content: RichEditorNode): string | null {
+function getTextSnippetFromMessageContent(content: RichEditorNode, targetLength = 30): string | null {
   if (content.text) {
     return content.text;
   }
@@ -22,44 +19,54 @@ function getTextSnippetFromMessageContent(content: RichEditorNode): string | nul
   }
 
   if (content.content) {
-    for (const node of content.content) {
-      const childText = getTextSnippetFromMessageContent(node);
+    let allContent = "";
 
-      if (childText) {
-        return childText;
-      }
+    for (const node of content.content) {
+      const childText = getTextSnippetFromMessageContent(node, targetLength - allContent.length);
+
+      allContent += ` ${childText}`;
+
+      if (allContent.length >= targetLength) return allContent;
     }
+
+    if (!allContent.length) return null;
+
+    return removeDoubleSpaces(allContent);
   }
 
   return null;
 }
 
-function pickFirstSentenceOrWords(content: string, maxWordsCount = 10) {
-  const [firstSentence] = content.split(".");
-
-  return firstSentence.split(" ").slice(0, maxWordsCount).join(" ").replace(/ +/, " ");
+/**
+ * Shorten a string to less than maxLength characters without truncating words.
+ */
+function trimLengthWithoutBreakingWords(input: string, maxLength: number) {
+  if (input.length <= maxLength) return input;
+  return input.substr(0, input.lastIndexOf(" ", maxLength));
 }
 
-export function getTopicNameFromContent(firstMessageContent: RichEditorNode, wordsCount?: number) {
+export function getTopicNameFromContent(firstMessageContent: RichEditorNode) {
   const snippet = getTextSnippetFromMessageContent(firstMessageContent);
 
   if (!snippet) return null;
 
-  const shortSnippet = pickFirstSentenceOrWords(snippet, wordsCount);
+  const shortSnippet = trimLengthWithoutBreakingWords(snippet, 50);
 
   return shortSnippet;
 }
 
+const DEFAULT_TOPIC_SLUG = "untitled-request";
+
 export function getTopicSlug(firstMessageContent: RichEditorNode, topicName?: string): string {
   if (topicName) {
-    return slugifySync(pickFirstSentenceOrWords(topicName), "topic");
+    return slugifySync(trimLengthWithoutBreakingWords(topicName, 50), DEFAULT_TOPIC_SLUG);
   }
 
   const topicNameFromContent = getTopicNameFromContent(firstMessageContent);
 
   if (!topicNameFromContent) {
-    return "topic";
+    return DEFAULT_TOPIC_SLUG;
   }
 
-  return slugifySync(topicNameFromContent, "topic");
+  return slugifySync(topicNameFromContent, DEFAULT_TOPIC_SLUG);
 }


### PR DESCRIPTION
It is followup to https://github.com/weareacapela/monorepo/pull/778 (@omarduarte fyi)

- better default topic slug
- slug from content generator now picks content until happy with slug length

eg having content like
```
Hi
Can you try to
- do this
- and that
```
before slug would be just `hi`, now it'll traverse content until having long enough slug
![CleanShot 2021-11-30 at 11 00 50](https://user-images.githubusercontent.com/7311462/144026342-95f907ee-cbf9-4a5e-9d60-065052928e92.gif)


