### PR TITLE
feat: close archived tab if no more archived items are left

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestFeedGroups/RequestFeedGroups.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestFeedGroups/RequestFeedGroups.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { computed } from "mobx";
 import { observer } from "mobx-react";
-import React, { memo, useMemo, useRef } from "react";
+import React, { memo, useEffect, useMemo, useRef } from "react";
 import { VariableSizeList as List, ListChildComponentProps, areEqual } from "react-window";
 import styled, { css } from "styled-components";
 
@@ -151,6 +151,12 @@ export const RequestFeedGroups = observer(({ topics, showArchived = false }: Pro
   const [archivedRows, archiveHeights] = useVirtualRowConverter(archivedGroups, (i) =>
     archivedListRef.current?.resetAfterIndex(i, true)
   );
+
+  useEffect(() => {
+    if (archivedRows.length === 0) {
+      setShowArchivedTimeline(false);
+    }
+  }, [archivedRows.length, setShowArchivedTimeline]);
 
   const [isFirstToggleRender, { unset: setFirstToggleRenderAsComplete }] = useBoolean(true);
 


### PR DESCRIPTION
- will automatically close archived tab if no more items are left there

This avoid resulting in empty sidebar
![CleanShot 2021-11-30 at 12 42 40](https://user-images.githubusercontent.com/7311462/144041306-c28208d2-accf-4430-88ec-5411ce2e8cea.gif)

