### PR TITLE
revert(slack): disable posting through bot

### DIFF
--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -126,9 +126,11 @@ async function checkHasTeamMemberAllSlackUserScopes(slackUserId: string) {
 
 async function checkHasChannelAccess(token: string, channelId: string, slackUserId: string) {
   try {
-    const { channel } = await slackClient.conversations.info({ token, channel: channelId });
-    const isPublic = channel?.is_channel && !channel.is_private;
-    return isPublic || checkHasTeamMemberAllSlackUserScopes(slackUserId);
+    // TODO: this is currently blocked on us not being able to change our prod manifest
+    /*const { channel } = */ await slackClient.conversations.info({ token, channel: channelId });
+    // const isPublic = channel?.is_channel && !channel.is_private;
+    // return isPublic || checkHasTeamMemberAllSlackUserScopes(slackUserId);
+    return checkHasTeamMemberAllSlackUserScopes(slackUserId);
   } catch (error) {
     if (isChannelNotFoundError(error)) {
       return false;

--- a/shared/slack/index.ts
+++ b/shared/slack/index.ts
@@ -4,9 +4,9 @@ import manifest from "./manifest.json";
 
 export const { bot: botScopes, user: userScopes } = manifest.oauth_config.scopes;
 
-const compareArrays = (a: unknown[], b: unknown[]) => _.intersection(a, b).length === b.length;
-export const checkHasAllSlackUserScopes = (scopes: string[]) => compareArrays(scopes, userScopes);
-export const checkHasAllSlackBotScopes = (scopes: string[]) => compareArrays(scopes, botScopes);
+const isSubsetOf = (a: unknown[], b: unknown[]) => _.intersection(a, b).length === a.length;
+export const checkHasAllSlackUserScopes = (scopes: string[]) => isSubsetOf(userScopes, scopes);
+export const checkHasAllSlackBotScopes = (scopes: string[]) => isSubsetOf(botScopes, scopes);
 
 export const SLACK_INSTALL_ERROR_KEY = "slack_install_error";
 export const SLACK_WORKSPACE_ALREADY_USED_ERROR = "slack_workspace_already_used";

--- a/shared/slack/manifest.json
+++ b/shared/slack/manifest.json
@@ -47,7 +47,6 @@
     "redirect_urls": ["https://app.acape.la/api/backend/slack/oauth_redirect", "https://app.acape.la"],
     "scopes": {
       "bot": [
-        "channels:join",
         "channels:read",
         "commands",
         "im:write",
@@ -58,7 +57,6 @@
       ],
       "user": [
         "channels:read",
-        "channels:write",
         "chat:write",
         "groups:read",
         "im:read",


### PR DESCRIPTION
This came with manifest changes we can't make while the app is in submission (as mentioned in Slack). I'll revert this revert, once we hear back from the support (with good news).