### PR TITLE
fix(slack): do not try to join before posting

### DIFF
--- a/backend/src/slack/create-request-modal/index.ts
+++ b/backend/src/slack/create-request-modal/index.ts
@@ -4,7 +4,6 @@ import { format } from "date-fns";
 import { difference, find, get } from "lodash";
 import { Bits, Blocks, Elements, Md, Message, Modal } from "slack-block-builder";
 
-import { isWebAPIErrorType } from "~backend/src/slack/errors";
 import { backendGetTopicUrl } from "~backend/src/topics/url";
 import { db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
@@ -211,14 +210,6 @@ export function setupCreateRequestModal(app: App) {
       return;
     }
 
-    try {
-      // try to join the channel in case the bot/user is not in it already
-      await client.conversations.join({ token, channel: channelId });
-    } catch (error) {
-      if (!isWebAPIErrorType(error, "method_not_supported_for_channel_type")) {
-        throw error;
-      }
-    }
     const response = await client.chat.postMessage({
       ...(await LiveTopicMessage(topic, { isMessageContentExcluded: hasRequestOriginatedFromMessageAction })),
       token,


### PR DESCRIPTION
A leftover from un-authed command posting, which is blocked by manifest changes, which is blocked by slack support getting back to us.

For whatever cursed reason, when trying to first join a channel and then post into it, you'll need a different scope to do the latter. And because I still had the manifest changes locally, it was still working for me. Ay! I'll try to understand that deeper tomorrow.
