### PR TITLE
fix: more informative assertion messages

### DIFF
--- a/backend/src/inviteUser/index.ts
+++ b/backend/src/inviteUser/index.ts
@@ -62,7 +62,7 @@ export const inviteUser: ActionHandler<{ input: { email: string; team_id: string
     });
 
     const firstInvite = !teamMember;
-    if (firstInvite) {
+    if (!teamMember) {
       teamMember = await db.team_member.create({
         data: {
           user: {
@@ -82,8 +82,6 @@ export const inviteUser: ActionHandler<{ input: { email: string; team_id: string
         },
       });
     }
-
-    assert(teamMember, "teamMember must have been created");
 
     if (firstInvite) {
       trackBackendUserEvent(invitingUserId, "Invite Sent", { teamId: team_id, email, origin: "webapp" });

--- a/backend/src/messages/events.ts
+++ b/backend/src/messages/events.ts
@@ -47,20 +47,20 @@ async function maybeUpdateSlackMessage(message: Message) {
     return;
   }
   const topic = await db.topic.findFirst({ where: { id: message.topic_id } });
-  assert(topic, "must have topic");
+  assert(topic, `must have topic ${message.topic_id}`);
   await tryUpdateTopicSlackMessage(topic);
 }
 
 export async function handleMessageChanges(event: HasuraEvent<Message>) {
   const userId = event.userId || event.item?.user_id || event.itemBefore?.user_id;
-  assert(userId, "cannot find user_id for message");
+  assert(userId, `cannot find user_id for message ${event.item.id}`);
   if (event.type === "create") {
     // this is required for fetching the attachments
     const message = await db.message.findUnique({
       where: { id: event.item.id },
       include: { attachment: true },
     });
-    assert(message, "message must exist");
+    assert(message, `message ${event.item.id} must exist`);
     trackBackendUserEvent(userId, "Sent Message", {
       messageType: event.item.type as Message_Type_Enum,
       hasAttachments: message.attachment.length !== 0,
@@ -90,7 +90,7 @@ export async function handleMessageChanges(event: HasuraEvent<Message>) {
 export async function handleMessageReactionChanges(event: HasuraEvent<MessageReaction>) {
   if (event.type === "create") {
     const userId = event.userId || event.item.user_id;
-    assert(userId, "cannot find user_id for message reaction");
+    assert(userId, `cannot find user_id for message reaction ${event.item.id}`);
     trackBackendUserEvent(userId, "Reacted To Message", {
       messageId: event.item.message_id,
       reactionEmoji: event.item.emoji,

--- a/backend/src/notifications/sendNotification.ts
+++ b/backend/src/notifications/sendNotification.ts
@@ -57,7 +57,7 @@ export async function sendNotificationIgnoringPreference(
 export async function sendNotificationPerPreference(user: User, teamId: string, message: Partial<NotificationMessage>) {
   const teamMember = assertDefined(
     await db.team_member.findFirst({ where: { user_id: user.id, team_id: teamId } }),
-    "missing team_member"
+    `missing team_member for user ${user.id} in team ${teamId}`
   );
   const notificationChannels: (keyof NotificationMessage)[] = [];
   if (teamMember.notify_email) {

--- a/backend/src/slack/actions.ts
+++ b/backend/src/slack/actions.ts
@@ -66,7 +66,7 @@ export function setupSlackActionHandlers(slackApp: App) {
     const user = await findUserBySlackId(assertToken(context), body.user.id);
     const topic = await db.topic.findFirst({ where: { id: topicId } });
 
-    assert(user, "Unable to find user(slack-id=${body.user.id}");
+    assert(user, `Unable to find user(slack-id=${body.user.id}`);
 
     if (!topic) {
       await ack();
@@ -123,7 +123,7 @@ export function setupSlackActionHandlers(slackApp: App) {
     const user = await findUserBySlackId(assertToken(context), body.user.id);
     const topic = await db.topic.findFirst({ where: { id: topicId } });
 
-    assert(user, "Unable to find user(slack-id=${body.user.id}");
+    assert(user, `Unable to find user(slack-id=${body.user.id}`);
 
     if (!topic) {
       await say(`Whoops! Seems that this request doesn't exist anymore.`);
@@ -154,7 +154,7 @@ export function setupSlackActionHandlers(slackApp: App) {
     const user = await findUserBySlackId(assertToken(context), body.user.id);
     const topic = await db.topic.findFirst({ where: { id: topicId } });
 
-    assert(user, "Unable to find user(slack-id=${body.user.id}");
+    assert(user, `Unable to find user(slack-id=${body.user.id}`);
 
     if (!topic) {
       await say(`Whoops! Seems that this request doesn't exist anymore.`);
@@ -251,7 +251,7 @@ export function setupSlackActionHandlers(slackApp: App) {
         },
       });
 
-      assert(message, "updating due date for inexistent message");
+      assert(message, `updating due date for inexistent message ${messageId}`);
 
       trackBackendUserEvent(message.user_id, "Added Due Date", {
         topicId: message.topic_id,
@@ -272,7 +272,7 @@ export function setupSlackActionHandlers(slackApp: App) {
       findUserBySlackId(token, body.user.id),
       db.task.findUnique({ where: { id: taskId }, include: { message: { include: { topic: true } }, user: true } }),
     ]);
-    assert(task, "missing task");
+    assert(task, `missing task ${taskId}`);
 
     if (user?.id !== task.user_id) {
       await slackClient.views.open({

--- a/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
+++ b/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
@@ -250,7 +250,7 @@ export async function createTopicForSlackUsers({
     include: { message: true },
   });
 
-  const botToken = assertDefined(await fetchTeamBotToken(teamId), "must have bot token");
+  const botToken = assertDefined(await fetchTeamBotToken(teamId), `must have bot token for team ${teamId}`);
   await updateHomeView(botToken, ownerSlackUserId);
 
   return topic;

--- a/backend/src/slack/create-request-modal/index.ts
+++ b/backend/src/slack/create-request-modal/index.ts
@@ -163,7 +163,7 @@ export function setupCreateRequestModal(app: App) {
     const ownerSlackUserId = body.user.id;
 
     const team = await db.team.findFirst({ where: { team_slack_installation: { slack_team_id: slackTeamId } } });
-    assert(team, "must have a team");
+    assert(team, `must have a team for slack team ${slackTeamId}`);
 
     const owner =
       (await findUserBySlackId(token, ownerSlackUserId, team.id)) ??

--- a/backend/src/slack/hasuraEvents.ts
+++ b/backend/src/slack/hasuraEvents.ts
@@ -9,8 +9,9 @@ export async function handleTaskSlackMessageChanges(event: HasuraEvent<TaskSlack
   if (event.type == "delete") {
     const { topic_id, slack_channel_id: channel, slack_message_ts: ts } = event.item;
     const topic = await db.topic.findUnique({ where: { id: topic_id } });
-    assert(topic, "missing topic");
-    const token = assertDefined(await fetchTeamBotToken(topic.team_id), "missing token");
+    assert(topic, `missing topic ${topic_id}`);
+    const teamId = topic.team_id;
+    const token = assertDefined(await fetchTeamBotToken(teamId), `missing token for team ${teamId}`);
     await slackClient.chat.delete({ token, channel, ts });
   }
 }

--- a/backend/src/slack/live-messages/LiveTaskMessage.ts
+++ b/backend/src/slack/live-messages/LiveTaskMessage.ts
@@ -26,7 +26,7 @@ export async function LiveTaskMessage(task: TaskDetail) {
     }),
     generateMessageTextWithMentions(topic, message),
   ]);
-  assert(author, "missing message author");
+  assert(author, `missing author for message ${message.id}`);
   const authorLabel = author.team_member_slack ? Md.user(author.team_member_slack.slack_user_id) : author.user.name;
   const requestType = Md.bold(MENTION_TYPE_LABELS[task.type as MentionType]);
   const text =
@@ -62,7 +62,8 @@ export async function tryUpdateTaskSlackMessages(where: {
   if (!firstMessage) {
     return;
   }
-  const botToken = assertDefined(await fetchTeamBotToken(firstMessage.topic.team_id), "must have a token");
+  const teamId = firstMessage.topic.team_id;
+  const botToken = assertDefined(await fetchTeamBotToken(teamId), `must have a token for team ${teamId}`);
 
   const messagesById = Object.fromEntries(messages.map((message) => [message.id, message]));
 

--- a/backend/src/slack/live-messages/LiveTopicMessage.ts
+++ b/backend/src/slack/live-messages/LiveTopicMessage.ts
@@ -37,7 +37,7 @@ export async function LiveTopicMessage(topic: Topic, options?: { isMessageConten
     include: { task: { include: { user: true } }, message_task_due_date: true },
   });
 
-  assert(message, "must have a first message");
+  assert(message, `must have a first message for topic ${topic.id}`);
 
   const text = options?.isMessageContentExcluded
     ? Md.italic("New Acapela Request Created:") + `\n> "${Md.bold(topic.name)}"`
@@ -80,7 +80,10 @@ export async function tryUpdateTopicSlackMessage(topic: Topic) {
     fetchTeamMemberToken(topic.owner_id, topic.team_id),
     fetchTeamBotToken(topic.team_id),
   ]);
-  const token = assertDefined(topicSlackMessage.was_sent_by_bot ? teamToken : teamMemberToken, "must have token");
+  const token = assertDefined(
+    topicSlackMessage.was_sent_by_bot ? teamToken : teamMemberToken,
+    `must have token for topic slack message ${topicSlackMessage.id}`
+  );
   try {
     await slackClient.chat.update({
       ...(await LiveTopicMessage(topic, {

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -139,8 +139,8 @@ export const REQUEST_TYPE_EMOJIS: Record<RequestType, string> = {
 
 export async function createTeamMemberUserFromSlack(token: string, slackUserId: string, teamId: string) {
   const { profile } = await slackClient.users.profile.get({ token, user: slackUserId });
-  assert(profile, "missing profile");
-  const email = assertDefined(profile.email, "must have email");
+  assert(profile, `missing profile for slack user ${slackUserId}`);
+  const email = assertDefined(profile.email, `missing email for slack user ${slackUserId}`);
   return db.team_member.create({
     data: {
       user: {
@@ -148,7 +148,7 @@ export async function createTeamMemberUserFromSlack(token: string, slackUserId: 
           where: { email },
           create: {
             email,
-            name: assertDefined(profile.display_name, "must have display name"),
+            name: assertDefined(profile.display_name, `missing display name for slack user ${slackUserId}`),
             avatar_url: profile.image_original,
             current_team_id: teamId,
           },

--- a/backend/src/slack/view-request-modal/getTopicInfo.ts
+++ b/backend/src/slack/view-request-modal/getTopicInfo.ts
@@ -25,7 +25,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
     },
   });
 
-  assert(team, "not team exists");
+  assert(team, `missing team for topic ${topicId}`);
 
   const topic = await db.topic.findFirst({
     where: { id: topicId },
@@ -64,7 +64,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
     },
   });
 
-  assert(topic, "topic not found");
+  assert(topic, `topic ${topicId} not found`);
 
   async function toSlackTeamMember(userId: string): Promise<SlackMember> {
     let userWithTeamAndSlackMember = topic?.topic_member.find((tm) => tm.user_id === userId)?.user;
@@ -90,7 +90,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
         })) ?? undefined;
     }
 
-    assert(userWithTeamAndSlackMember, "user not found");
+    assert(userWithTeamAndSlackMember, `user ${userId} not found`);
 
     return {
       name: userWithTeamAndSlackMember.name,

--- a/backend/src/tasks/messageTaskDueDateHandler.ts
+++ b/backend/src/tasks/messageTaskDueDateHandler.ts
@@ -10,7 +10,7 @@ export async function handleTaskDueDateChanges(event: HasuraEvent<MessageTaskDue
   const messageId = event.item.message_id;
   const topic = await db.topic.findFirst({ where: { message: { some: { id: messageId } } } });
 
-  assert(topic, "must have topic");
+  assert(topic, `must have topic for message ${messageId}`);
 
   // Most likely created by slack command. The analytics event should be triggered where the slack command is captured
   if (!event.userId) {

--- a/backend/src/tasks/taskHandlers.ts
+++ b/backend/src/tasks/taskHandlers.ts
@@ -92,7 +92,7 @@ async function onTaskCreation(task: Task) {
 async function onTaskUpdate({ item: task, itemBefore: taskBefore, userId }: UpdateHasuraEvent<Task>) {
   const topic = await db.topic.findFirst({ where: { message: { some: { id: task.message_id } } } });
 
-  assert(topic, "must have topic");
+  assert(topic, `must have topic for message ${task.message_id}`);
 
   if (!isEqualForPick(task, taskBefore, ["done_at"])) {
     await tryUpdateTaskSlackMessages({

--- a/backend/src/teams/events.ts
+++ b/backend/src/teams/events.ts
@@ -1,5 +1,4 @@
 import { Team, db } from "~db";
-import { assert } from "~shared/assert";
 import { identifyBackendUserTeam, trackBackendUserEvent } from "~shared/backendAnalytics";
 import { logger } from "~shared/logger";
 
@@ -17,7 +16,6 @@ export async function handleTeamUpdates(event: HasuraEvent<Team>) {
     });
     throw new UnprocessableEntityError(`User id of action caller: ${userId} does not match room creator: ${ownerId}`);
   }
-  assert(ownerId, "team must have owner id");
 
   if (event.type === "create") {
     trackBackendUserEvent(ownerId, "Account Created", { teamName: team.name });

--- a/backend/src/topics/events.ts
+++ b/backend/src/topics/events.ts
@@ -79,7 +79,7 @@ async function updateTopicEvents(event: HasuraEvent<Topic>) {
   const topicBefore = event.itemBefore;
 
   // Should never be null on event updates
-  assert(topicBefore, "Updated topic didn't contain previous topic data");
+  assert(topicBefore, `Updated topic ${event.item.id} didn't contain previous topic data`);
 
   const isOpenStatusChanged = topicNow.closed_at !== topicBefore.closed_at;
   if (isOpenStatusChanged) {
@@ -112,7 +112,7 @@ async function notifyTopicUpdates(event: HasuraEvent<Topic>) {
   const isClosedByOwner = ownerId === userIdThatClosedTopic;
   const wasJustClosed = topic.closed_at && event?.itemBefore?.closed_at === null;
 
-  assert(event.itemBefore, "Updated topic didn't contain previous topic data");
+  assert(event.itemBefore, `Updated topic ${topic.id} didn't contain previous topic data`);
 
   if (!isEqualForPick(topic, event.itemBefore, ["name", "closed_at"])) {
     await Promise.all([

--- a/backend/src/transcriptions/transcriptionService.ts
+++ b/backend/src/transcriptions/transcriptionService.ts
@@ -36,8 +36,8 @@ export async function handleAttachementTranscriptionStatusUpdate(mediaResponse: 
 
   const attachment = await db.attachment.findUnique({ where: { id: attachmentId } });
 
-  assert(attachment, "No attachment for given id");
-  assert(attachment.transcription_id, "Provided attachment has no transcript");
+  assert(attachment, `No attachment for given id ${attachmentId}`);
+  assert(attachment.transcription_id, `Provided attachment ${attachmentId} has no transcript`);
 
   await db.transcription.update({
     where: { id: attachment.transcription_id },

--- a/backend/src/users/events.ts
+++ b/backend/src/users/events.ts
@@ -9,12 +9,13 @@ export async function handleUserUpdates(event: HasuraEvent<User>) {
   const userNow = event.item;
 
   const hadTeamBeforeUpdate = !!(userBefore && userBefore.current_team_id);
-  const hasChangedTeam = userNow.current_team_id !== userBefore?.current_team_id;
+  const teamId = userNow.current_team_id;
+  const hasChangedTeam = teamId !== userBefore?.current_team_id;
 
   // check whether user has changed teams or was invited to their first team
-  if (userNow.current_team_id && (hasChangedTeam || !hadTeamBeforeUpdate)) {
-    const team = await db.team.findFirst({ where: { id: userNow.current_team_id } });
-    assert(team, "Team does not exist at user update");
+  if (teamId && (hasChangedTeam || !hadTeamBeforeUpdate)) {
+    const team = await db.team.findFirst({ where: { id: teamId } });
+    assert(team, `Team ${teamId} does not exist at user update`);
 
     await db.team_member.updateMany({
       where: { user_id: userNow.id, team_id: team.id },

--- a/frontend/src/team/TeamMembersManager/index.tsx
+++ b/frontend/src/team/TeamMembersManager/index.tsx
@@ -22,7 +22,7 @@ export const TeamMembersManager = observer(({ team }: Props) => {
 
   const handleRemoveTeamMember = (userId: string) => {
     const teamMember = team.members.query((teamMember) => teamMember.user_id === userId).all[0];
-    assert(teamMember, "did not find teamMember");
+    assert(teamMember, `did not find teamMember for user ${userId}`);
     teamMember.remove();
   };
 


### PR DESCRIPTION
I (re)learned to appreciate how context helps when reading logs, thus I added context wherever feasible.