### PR TITLE
feat(slack): set due_at from request modal

### DIFF
--- a/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
+++ b/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
@@ -178,6 +178,7 @@ export async function createTopicForSlackUsers({
   ownerSlackUserId,
   slackTeamId,
   topicName,
+  dueAt,
   rawTopicMessage,
   slackUserIdsWithMentionType,
   requestedObservers,
@@ -188,6 +189,7 @@ export async function createTopicForSlackUsers({
   ownerSlackUserId: string;
   slackTeamId: string;
   topicName: Maybe<string>;
+  dueAt: Maybe<Date>;
   rawTopicMessage: string;
   slackUserIdsWithMentionType: SlackUserIdWithRequestType[];
   requestedObservers: string[];
@@ -234,6 +236,7 @@ export async function createTopicForSlackUsers({
           user_id: ownerId,
           content: messageContent,
           content_text: messageContentText,
+          message_task_due_date: dueAt ? { create: { due_at: dueAt } } : undefined,
           task: {
             createMany: {
               data: usersWithMentionType

--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -93,6 +93,12 @@ const CreateRequestModal = (metadata: ViewMetadata["create_request"]) => {
         : Blocks.Input({ label: "Your Message", blockId: "message_block" }).element(
             Elements.TextInput({ actionId: "message_text" }).multiline(true)
           ),
+      Blocks.Input({ blockId: "due_at_date_block", label: "Due Date" })
+        .element(Elements.DatePicker({ actionId: "due_at_date" }))
+        .optional(true),
+      Blocks.Input({ blockId: "due_at_hour_block", label: "Time" })
+        .element(Elements.TimePicker({ actionId: "due_at_hour" }))
+        .optional(true),
       Blocks.Input({ blockId: "topic_block", label: "Request Title" })
         .element(Elements.TextInput({ actionId: "topic_name", placeholder: "Eg feedback for Figma v12" }))
         .optional(true),

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -73,7 +73,6 @@ export const SlackActionIds = {
   ReOpenTopic: "reopen-topic",
   CloseTopic: "close-topic",
   ArchiveTopic: "archive-topic",
-  UpdateMessageTaskDueAt: "update-task-due-at",
   TrackEvent: "track-event",
 } as const;
 


### PR DESCRIPTION
<img width="503" alt="Screenshot 2021-12-01 at 14 29 54" src="https://user-images.githubusercontent.com/4051932/144242972-33831503-8018-428f-8ce7-9918b719abd5.png">

As you can see that moves the topic title beneath the fold, but since we're de-prioritizing the title anyway, it seemed more sensible to put the due date before it.

Since there's not a combined date-time selector a due date is set when EITHER a date or a time is given (defaulting to "next workday" and "12 PM" respectively).