### PR TITLE
Mentions are not correctly resolved

### DIFF
--- a/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
+++ b/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
@@ -1,11 +1,11 @@
-import { compact, uniq } from "lodash";
+import { compact, map, uniq } from "lodash";
 
 import { sendInviteNotification } from "~backend/src/inviteUser";
 import { Account, User, db } from "~db";
 import { convertMessageContentToPlainText } from "~richEditor/content/plainText";
 import { assertDefined } from "~shared/assert";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
-import { MENTION_TYPE_KEY, getUniqueRequestMentionDataFromContent } from "~shared/editor/mentions";
+import { MENTION_TYPE_KEY, getMentionNodesFromContent } from "~shared/editor/mentions";
 import { slugify } from "~shared/slugify";
 import { DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH, truncateTextWithEllipsis } from "~shared/text/ellipsis";
 import { Maybe } from "~shared/types";
@@ -141,11 +141,11 @@ function transformMessage(
     slackTeamId,
     mentionedUsersBySlackId,
   });
+
   const alreadyMentionedUsers = new Set(
-    getUniqueRequestMentionDataFromContent(messageContent)
-      .filter((d) => "userId" in d)
-      .map((mentionData) => mentionData.userId)
+    uniq(compact(map(getMentionNodesFromContent(messageContent), "attrs.data.userId")))
   );
+
   const extraMentionNodes = usersWithRequestType
     .filter(({ userId }) => !alreadyMentionedUsers.has(userId))
     .flatMap(({ userId, mentionType }) => {

--- a/backend/src/slack/create-request-modal/index.ts
+++ b/backend/src/slack/create-request-modal/index.ts
@@ -9,7 +9,7 @@ import { db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
 import { getNextWorkDayEndOfDay } from "~shared/dates/times";
-import { MentionType } from "~shared/types/mention";
+import { MENTION_OBSERVER, MentionType } from "~shared/types/mention";
 
 import { LiveTopicMessage } from "../live-messages/LiveTopicMessage";
 import {
@@ -173,11 +173,20 @@ export function setupCreateRequestModal(app: App) {
       mentionType: requestType.value as MentionType,
     }));
 
+    // add mentioned users from message as observers
+    difference(metadata.slackUserIdsFromMessage, members || []).forEach((id) => {
+      slackUserIdsWithMentionType.push({
+        slackUserId: id,
+        mentionType: MENTION_OBSERVER,
+      });
+    });
+
     // When a request is created from a message, add message author as observer
     const hasRequestOriginatedFromMessageAction = metadata.origin === "slack-message-action";
     if (hasRequestOriginatedFromMessageAction && metadata.fromMessageBelongingToSlackUserId) {
       slackUserIdsWithMentionType.push({
         slackUserId: metadata.fromMessageBelongingToSlackUserId,
+        mentionType: MENTION_OBSERVER,
       });
     }
 

--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -233,6 +233,7 @@ export async function openCreateRequestModal(
       origin,
       fromMessageBelongingToSlackUserId,
       requestToSlackUserIds,
+      slackUserIdsFromMessage,
     })
   );
 

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -104,6 +104,7 @@ export type ViewMetadata = {
     messageTs?: string;
     origin: CreateRequestOrigin;
     fromMessageBelongingToSlackUserId?: string;
+    slackUserIdsFromMessage?: string[];
   };
   open_view_request_modal: {
     slackUserId: string;


### PR DESCRIPTION
The problem was if a request was created from slack that contains a slack mention, but nothing from the mentioned user was requested. The fix is to add the mentioned user as an observer to the topic.