### PR TITLE
fix: tooltips are not covered by popovers

### DIFF
--- a/ui/popovers/TooltipLabel.tsx
+++ b/ui/popovers/TooltipLabel.tsx
@@ -6,6 +6,7 @@ import { Shortcut } from "~ui/keyboard/Shortcut";
 import { ShortcutDefinition } from "~ui/keyboard/shortcutBase";
 import { PresenceAnimator } from "~ui/PresenceAnimator";
 import { theme } from "~ui/theme";
+import { zIndexValues } from "~ui/theme/zIndex";
 
 import { Popover, PopoverPlacement } from "./Popover";
 
@@ -20,15 +21,20 @@ export interface TooltipLabelProps {
 export const TooltipLabel = styled<TooltipLabelProps>(
   ({ anchorRef, label, isDisabled, shortcut, placement = "top" }) => {
     return (
-      <Popover anchorRef={anchorRef} isDisabled={isDisabled} placement={placement}>
+      <TooltipFlyer anchorRef={anchorRef} isDisabled={isDisabled} placement={placement}>
         <UITooltip presenceStyles={POP_PRESENCE_STYLES}>
           {label}
           {shortcut && <Shortcut shortcut={shortcut} />}
         </UITooltip>
-      </Popover>
+      </TooltipFlyer>
     );
   }
 )``;
+
+const TooltipFlyer = styled(Popover)`
+  z-index: ${zIndexValues.tooltip};
+  pointer-events: none;
+`;
 
 const UITooltip = styled(PresenceAnimator)<{}>`
   ${theme.typo.functional.tooltip};

--- a/ui/theme/zIndex.ts
+++ b/ui/theme/zIndex.ts
@@ -2,4 +2,5 @@ export enum zIndexValues {
   popover = 1000,
   overlay,
   toast,
+  tooltip,
 }


### PR DESCRIPTION
Previously tooltips were wrapped inside popover with default z-index not being able to have higher z-index than it

![CleanShot 2021-12-01 at 14 04 45](https://user-images.githubusercontent.com/7311462/144239530-1758c044-d826-4505-8183-87f4f85fb880.gif)
