### PR TITLE
feat(slack): use conversation select defaulting to current

### DIFF
--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -100,8 +100,10 @@ const CreateRequestModal = (metadata: ViewMetadata["create_request"]) => {
         .optional(true),
       metadata.channelId
         ? undefined
-        : Blocks.Input({ label: "Post in channel", blockId: "channel_block" })
-            .element(Elements.ChannelSelect({ actionId: "channel_select" }))
+        : Blocks.Input({ label: "Post in channel", blockId: "conversation_block" })
+            .element(
+              Elements.ConversationSelect({ actionId: "conversation_select" }).defaultToCurrentConversation(true)
+            )
             .optional(true)
     )
     .submit("Create")


### PR DESCRIPTION
© by Heiki (who discovered this API)

@heikir as you can see in the screenshot below, it defaults to the current conversation, which can be different from the currently active thread. But I guess a lot of the times the current thread comes from the current conversation, so I'd still go with it.

<img width="1168" alt="Screenshot 2021-12-02 at 17 40 14" src="https://user-images.githubusercontent.com/4051932/144465207-160aa35a-36df-462e-b020-124ddf061e5a.png">

