### PR TITLE
fix: make request-action the default type

### DIFF
--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -7,7 +7,7 @@ import { db } from "~db";
 import { routes } from "~shared/routes";
 import { checkHasAllSlackUserScopes } from "~shared/slack";
 import { Maybe } from "~shared/types";
-import { MENTION_OBSERVER, MENTION_TYPE_PICKER_LABELS, REQUEST_READ } from "~shared/types/mention";
+import { MENTION_OBSERVER, MENTION_TYPE_PICKER_LABELS, REQUEST_ACTION, RequestType } from "~shared/types/mention";
 
 import { SlackInstallation, slackClient } from "../app";
 import { isChannelNotFoundError } from "../errors";
@@ -63,6 +63,9 @@ const AuthForCreateRequestModal = async (
     .buildToObject();
 };
 
+const buildOptionFromRequestType = (value: RequestType) =>
+  Bits.Option({ value, text: MENTION_TYPE_PICKER_LABELS[value] });
+
 const CreateRequestModal = (metadata: ViewMetadata["create_request"]) => {
   const { messageText, requestToSlackUserIds } = metadata;
 
@@ -70,13 +73,12 @@ const CreateRequestModal = (metadata: ViewMetadata["create_request"]) => {
     .blocks(
       Blocks.Input({ blockId: "request_type_block", label: "Request Type" }).element(
         Elements.StaticSelect({ actionId: "request_type_select" })
-          .initialOption(Bits.Option({ value: REQUEST_READ, text: MENTION_TYPE_PICKER_LABELS[REQUEST_READ] }))
-          .optionGroups(
-            Bits.OptionGroup({ label: "Request types" }).options(
-              Object.entries(MENTION_TYPE_PICKER_LABELS)
-                .filter(([value]) => value !== MENTION_OBSERVER)
-                .map(([value, text]) => Bits.Option({ value, text }))
-            )
+          .initialOption(buildOptionFromRequestType(REQUEST_ACTION))
+          .options(
+            Object.keys(MENTION_TYPE_PICKER_LABELS)
+              .filter((value) => value !== MENTION_OBSERVER)
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .map(buildOptionFromRequestType as any)
           )
       ),
       Blocks.Input({ blockId: "members_block", label: "Request to" }).element(

--- a/shared/types/mention.ts
+++ b/shared/types/mention.ts
@@ -22,9 +22,9 @@ export const MENTION_TYPE_LABELS: Record<MentionType, string> = {
 };
 
 export const MENTION_TYPE_PICKER_LABELS: Record<MentionType, string> = {
+  [REQUEST_ACTION]: "Request action",
   [REQUEST_RESPONSE]: "Request response",
   [REQUEST_READ]: "Request read confirmation",
-  [REQUEST_ACTION]: "Request action",
   [MENTION_OBSERVER]: "Add as observer",
 };
 


### PR DESCRIPTION
Would've been a one-liner (single source of truth 🥳 :yay:) but then I did some minor refactoring too and also ungrouped the request picker in Slack. In the past there were two groups, request types and observer, since the latter is gone, the grouping didn't make sense no more.