### PR TITLE
chore: reduce playwright retries

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { PlaywrightTestConfig } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
-  retries: 5, // We have some flakiness wrt topic creation
+  retries: 1, // We still have some flakiness, but hopefully this number will go to 0 at some point.
   use: {
     video: "retain-on-failure",
     trace: "retain-on-failure",


### PR DESCRIPTION
That's just wasting energy and money right now, looked through `master` a bit and usually only 1-2 tests fail ONCE, so let's try a more conservative retry setting