### PR TITLE
feat: editor can now include links between requests

### DIFF
--- a/frontend/src/layouts/SidebarLayout/RequestFeed/RequestContentSnippet.tsx
+++ b/frontend/src/layouts/SidebarLayout/RequestFeed/RequestContentSnippet.tsx
@@ -104,4 +104,5 @@ export const RequestContentSnippet = styledObserver(({ topic, className }: Props
 
 const UIHolder = styled.div`
   ${theme.typo.label};
+  pointer-events: none;
 `;

--- a/frontend/src/message/extensions/index.ts
+++ b/frontend/src/message/extensions/index.ts
@@ -1,7 +1,8 @@
 import { emojiAutocompleteExtension } from "./emoji";
 import { userMentionExtension } from "./mentions";
+import { requestLinkExtension } from "./requestLink";
 
 /**
  * List of frontend related rich editor extensions used both to edit and display messages.
  */
-export const messageComposerExtensions = [userMentionExtension, emojiAutocompleteExtension];
+export const messageComposerExtensions = [userMentionExtension, emojiAutocompleteExtension, requestLinkExtension];

--- a/frontend/src/message/extensions/requestLink/MentionTypePicker.tsx
+++ b/frontend/src/message/extensions/requestLink/MentionTypePicker.tsx
@@ -1,0 +1,26 @@
+import { toPairs } from "lodash";
+import React from "react";
+
+import { MENTION_TYPE_PICKER_LABELS, MentionType } from "~shared/types/mention";
+import { ItemsDropdown } from "~ui/forms/OptionsDropdown/ItemsDropdown";
+
+interface Props {
+  selected?: MentionType;
+  onSelect: (mention: MentionType) => void;
+}
+
+export function MentionTypePicker({ selected, onSelect }: Props) {
+  const mentionLabelPairs = toPairs(MENTION_TYPE_PICKER_LABELS) as [MentionType, string][];
+  const selectedPair = selected ? [selected, MENTION_TYPE_PICKER_LABELS[selected]] : [];
+
+  return (
+    <ItemsDropdown
+      items={mentionLabelPairs}
+      keyGetter={([mentionType]) => mentionType}
+      onItemSelected={([mentionType]) => onSelect(mentionType)}
+      labelGetter={([, mentionLabel]) => mentionLabel}
+      selectedItems={[selectedPair as [MentionType, string]]}
+      dividerIndexes={[mentionLabelPairs.length - 1]}
+    />
+  );
+}

--- a/frontend/src/message/extensions/requestLink/RequestLinkNode.tsx
+++ b/frontend/src/message/extensions/requestLink/RequestLinkNode.tsx
@@ -1,0 +1,37 @@
+import { observer } from "mobx-react";
+import Link from "next/link";
+import React, { PropsWithChildren } from "react";
+import styled from "styled-components";
+
+import { useDb } from "~frontend/clientdb";
+import { AutocompleteNodeProps } from "~richEditor/autocomplete/component";
+import { EditorRequestLinkData } from "~shared/types/editor";
+import { IconComments } from "~ui/icons";
+import { theme } from "~ui/theme";
+
+export const RequestLinkNode = observer((props: PropsWithChildren<AutocompleteNodeProps<EditorRequestLinkData>>) => {
+  const { data } = props;
+  const { requestId } = data;
+  const db = useDb();
+  const request = db.topic.findById(requestId);
+
+  return (
+    <Link href={request?.href ?? "/"} passHref>
+      <UIRequestLink>
+        <IconComments /> {request?.name ?? "Unknown request"}
+      </UIRequestLink>
+    </Link>
+  );
+});
+
+const UIRequestLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  ${theme.colors.primary.asColor};
+  ${theme.typo.content.semibold};
+  font-size: inherit;
+
+  svg {
+    margin-right: 0.5ch;
+  }
+`;

--- a/frontend/src/message/extensions/requestLink/RequestPicker.tsx
+++ b/frontend/src/message/extensions/requestLink/RequestPicker.tsx
@@ -1,0 +1,41 @@
+import { observer } from "mobx-react";
+import React from "react";
+import styled from "styled-components";
+
+import { useDb } from "~frontend/clientdb";
+import { TopicEntity } from "~frontend/clientdb/topic";
+import { UserAvatar } from "~frontend/ui/users/UserAvatar";
+import { AutocompletePickerProps } from "~richEditor/autocomplete/component";
+import { EditorRequestLinkData } from "~shared/types/editor";
+import { EmptyStatePlaceholder } from "~ui/empty/EmptyStatePlaceholder";
+import { IconComments } from "~ui/icons";
+import { SelectList } from "~ui/SelectList";
+import { theme } from "~ui/theme";
+
+export const RequestPicker = observer(({ keyword, onSelect }: AutocompletePickerProps<EditorRequestLinkData>) => {
+  const db = useDb();
+
+  const foundTopics = db.topic.search(keyword);
+
+  return (
+    <SelectList<TopicEntity>
+      items={foundTopics}
+      noItemsPlaceholder={<EmptyStatePlaceholder description="No requests found" noSpacing icon={<IconComments />} />}
+      keyGetter={(topic) => topic.id}
+      onItemSelected={(topic) => {
+        onSelect([{ requestId: topic.id }]);
+      }}
+      renderItem={(item) => <UISelectItem>{item.name}</UISelectItem>}
+    />
+  );
+});
+
+const UISelectItem = styled.div<{}>`
+  display: flex;
+  align-items: center;
+  ${theme.spacing.actions.asGap};
+
+  ${UserAvatar} {
+    font-size: 1.5rem;
+  }
+`;

--- a/frontend/src/message/extensions/requestLink/index.tsx
+++ b/frontend/src/message/extensions/requestLink/index.tsx
@@ -1,0 +1,12 @@
+import { createAutocompletePlugin } from "~richEditor/autocomplete";
+import { EditorRequestLinkData } from "~shared/types/editor";
+
+import { RequestLinkNode } from "./RequestLinkNode";
+import { RequestPicker } from "./RequestPicker";
+
+export const requestLinkExtension = createAutocompletePlugin<EditorRequestLinkData>({
+  type: "request-link",
+  triggerChar: "#",
+  nodeComponent: RequestLinkNode,
+  pickerComponent: RequestPicker,
+});

--- a/shared/types/editor.ts
+++ b/shared/types/editor.ts
@@ -4,3 +4,7 @@ export interface EditorMentionData<T = MentionType> {
   userId: string;
   type: T;
 }
+
+export interface EditorRequestLinkData {
+  requestId: string;
+}


### PR DESCRIPTION
Added new mention-like feature, but for links between requests.

It is groundwork for 'convert message into new topic' (https://linear.app/acapela/issue/ACA-1047/convert-message-in-web-app-to-request)

It works nearly identical as mentions, but:
- trigger char for suggestions is `#`
- no 'type' picker obviously as it is not needed for request link

![CleanShot 2021-12-07 at 14 26 59](https://user-images.githubusercontent.com/7311462/145037624-b2f0adeb-3748-42f1-adbe-ce4433314087.gif)

