### PR TITLE
feat(slack): more info on home tab

### DIFF
--- a/backend/src/slack/home-tab/RequestItem.ts
+++ b/backend/src/slack/home-tab/RequestItem.ts
@@ -2,49 +2,59 @@ import { Blocks, Elements, Md } from "slack-block-builder";
 
 import { REQUEST_TYPE_EMOJIS } from "~backend/src/slack/utils";
 import { backendGetTopicUrl } from "~backend/src/topics/url";
+import { User } from "~db";
+import { pluralize } from "~shared/text/pluralize";
 import { MENTION_TYPE_LABELS, RequestType } from "~shared/types/mention";
 
-import { createSlackLink, mdDate } from "../md/utils";
+import { mdDate } from "../md/utils";
 import { MessageWithOpenTask, TopicWithOpenTask } from "./types";
 import { getMostUrgentMessage } from "./utils";
 
-const TaskLabel = (userId: string, { task: tasks }: MessageWithOpenTask) => {
-  const task = tasks.find((t) => t.user_id == userId);
-  if (!task) {
-    return "";
-  }
-  const type = task.type as RequestType;
-  return Md.codeInline(REQUEST_TYPE_EMOJIS[type] + " " + MENTION_TYPE_LABELS[type] + " requested");
-};
+const TaskLabel = (type: RequestType) =>
+  Md.codeInline(REQUEST_TYPE_EMOJIS[type] + " " + MENTION_TYPE_LABELS[type] + " requested");
 
-const TaskInfoBlock = ({ user, task: tasks, message_task_due_date: dueDate }: MessageWithOpenTask) =>
-  Blocks.Context().elements(
-    user.avatar_url ? Elements.Img({ imageUrl: user.avatar_url ?? undefined, altText: user.name }) : undefined,
-    `${Md.bold(user.name)} to ${Md.bold("You")}${
-      tasks.length == 1 ? "" : ` and ${Md.bold(String(tasks.length - 1) + " others")}`
-    }`,
-    dueDate ? `🗓 Due ${Md.bold(mdDate(dueDate?.due_at))}` : ""
-  );
+const Avatar = (user: User) =>
+  user.avatar_url ? Elements.Img({ imageUrl: user.avatar_url ?? undefined, altText: user.name }) : undefined;
+
+const UserName = (currentUserId: string, user: User) => Md.bold(currentUserId == user.id ? "You" : user.name);
+
+const getOthersLabel = (othersCount: number) =>
+  othersCount == 0 ? "" : ` and ${Md.bold(othersCount + " " + pluralize(othersCount, "other", "others"))}`;
+
+const TaskInfo = (userId: string, { user, task: tasks, message_task_due_date: dueDate }: MessageWithOpenTask) => [
+  Avatar(user),
+  `${UserName(userId, user)} to ${Md.bold("You")}${getOthersLabel(tasks.length - 1)}`,
+  dueDate ? `🗓 Due ${Md.bold(mdDate(dueDate?.due_at))}` : undefined,
+];
+
+const TopicInfo = (userId: string, topic: TopicWithOpenTask) => [
+  Avatar(topic.user),
+  `${UserName(userId, topic.user)}${getOthersLabel(topic.topic_member.length - 1)}`,
+];
 
 const Spacer = Blocks.Section({ text: " " });
 
 export async function RequestItem(userId: string, topic: TopicWithOpenTask, unreadMessages: number) {
   const mostUrgentMessage = getMostUrgentMessage(topic);
-  const unreadText = unreadMessages ? ` *(${unreadMessages} unread)* ` : "";
-
+  const userTask = mostUrgentMessage?.task.find((t) => t.user_id == userId);
   return [
     Blocks.Section({
-      text:
-        createSlackLink(await backendGetTopicUrl(topic), topic.name) +
-        unreadText +
-        (mostUrgentMessage ? "\n" + TaskLabel(userId, mostUrgentMessage) : ""),
-    }).accessory(
+      text: Md.bold(topic.name) + (userTask ? "\n" + TaskLabel(userTask.type as RequestType) : ""),
+    }),
+    userTask && Spacer,
+    Blocks.Context().elements(
+      mostUrgentMessage ? TaskInfo(userId, mostUrgentMessage) : TopicInfo(userId, topic),
+      unreadMessages
+        ? `✉️ ${Md.bold(unreadMessages + " New " + pluralize(unreadMessages, "reply", "replies"))}`
+        : undefined
+    ),
+    Blocks.Actions().elements(
       Elements.Button({
         actionId: "open_view_request_modal",
         value: topic.id,
         text: "View Request",
-      })
+      }).primary(true),
+      Elements.Button({ text: "Open in Acapela", url: await backendGetTopicUrl(topic) })
     ),
-    ...(mostUrgentMessage ? [Spacer, TaskInfoBlock(mostUrgentMessage)] : []),
   ];
 }

--- a/backend/src/slack/home-tab/RequestList.ts
+++ b/backend/src/slack/home-tab/RequestList.ts
@@ -5,22 +5,31 @@ import { TopicWithOpenTask } from "./types";
 
 const Padding = [Blocks.Section({ text: " " }), Blocks.Section({ text: " " })];
 
-export async function RequestsList(
-  title: string,
-  userId: string,
-  topics: TopicWithOpenTask[],
-  unreadMessagesByTopicId: { [topicId: string]: number }
-) {
-  const header = [...Padding, Blocks.Header({ text: title })];
+export async function RequestsList({
+  title,
+  explainer,
+  currentUserId,
+  topics,
+  unreadMessagesByTopicId,
+  emptyText = "No requests here",
+}: {
+  title: string;
+  explainer: string;
+  currentUserId: string;
+  topics: TopicWithOpenTask[];
+  unreadMessagesByTopicId: { [topicId: string]: number };
+  emptyText?: string;
+}) {
+  const header = [...Padding, Blocks.Header({ text: title }), Blocks.Context().elements(explainer)];
 
   if (topics.length === 0) {
-    return [...header, Blocks.Section({ text: Md.italic("No requests here") })];
+    return [...header, Blocks.Section({ text: Md.italic(emptyText) })];
   }
 
   const nestedTopicsBlocks = await Promise.all(
     topics.map(async (topic, i) => {
       return [
-        ...(await RequestItem(userId, topic, unreadMessagesByTopicId[topic.id] || 0)),
+        ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0)),
         i < topics.length - 1 ? Blocks.Divider() : undefined,
       ];
     })

--- a/backend/src/slack/home-tab/index.ts
+++ b/backend/src/slack/home-tab/index.ts
@@ -142,10 +142,38 @@ export async function updateHomeView(botToken: string, slackUserId: string) {
             .actionId(SlackActionIds.TrackEvent)
             .value(backendUserEventToJSON(teamMember.user_id, "Opened Webapp From Slack Home Tab"))
         ),
-        await RequestsList("🔥 Received", currentUserId, received, unreadMessagesByTopicId),
-        await RequestsList("📤 Sent", currentUserId, sent, unreadMessagesByTopicId),
-        await RequestsList("⏳ Open", currentUserId, open, unreadMessagesByTopicId),
-        await RequestsList("✅ Closed", currentUserId, closed, unreadMessagesByTopicId)
+        await RequestsList({
+          title: "🔥 Received",
+          explainer: "Requests assigned to you",
+          currentUserId,
+          topics: received,
+          unreadMessagesByTopicId,
+          emptyText: "You are all caught up 🎉",
+        }),
+        await RequestsList({
+          title: "📤 Sent",
+          explainer: "Requests you have sent to other people",
+          currentUserId,
+          topics: sent,
+          unreadMessagesByTopicId,
+        }),
+        await RequestsList({
+          title: "⏳ Open",
+          explainer: "Open topics without outstanding requests",
+          currentUserId,
+          topics: open,
+          unreadMessagesByTopicId,
+        }),
+        await RequestsList({
+          title: "✅ Closed",
+          explainer: `Closed topics will be archived after a day. You can still find them ${createSlackLink(
+            process.env.FRONTEND_URL,
+            "in the web app"
+          )}.`,
+          currentUserId,
+          topics: closed,
+          unreadMessagesByTopicId,
+        })
       )
       .buildToObject()
   );

--- a/backend/src/slack/home-tab/utils.ts
+++ b/backend/src/slack/home-tab/utils.ts
@@ -4,4 +4,4 @@ import { TopicWithOpenTask } from "./types";
 
 // TODO this will need to be updated in the year 3k
 export const getMostUrgentMessage = ({ message }: TopicWithOpenTask) =>
-  minBy(message, (message) => (message.task[0] && message.message_task_due_date?.due_at) ?? new Date(3000, 0));
+  minBy(message, (message) => message.message_task_due_date?.due_at ?? new Date(3000, 0));

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -131,7 +131,7 @@ export function listenToViewWithMetadata<
 
 export const REQUEST_TYPE_EMOJIS: Record<RequestType, string> = {
   [REQUEST_ACTION]: "🎬",
-  [REQUEST_RESPONSE]: "✍️",
+  [REQUEST_RESPONSE]: "📝",
   [REQUEST_READ]: "👀",
 };
 


### PR DESCRIPTION
Another small iteration, giving the non-received sections also the do-over treatment. Also adds explainer texts to all sections, a button row and a more celbratory "received-inbox zero" message.

Again, more to come!

<img width="491" alt="Screenshot 2021-12-07 at 18 20 23" src="https://user-images.githubusercontent.com/4051932/145076448-0a33222f-dd9c-44a3-8947-2170b409312a.png">

Fixes ACA-1007