### PR TITLE
fix(logger): correctly pass in obj params

### DIFF
--- a/backend/src/actions/actions.ts
+++ b/backend/src/actions/actions.ts
@@ -16,9 +16,7 @@ router.post("/v1/actions", middlewareAuthenticateHasura, async (req: Request, re
   const hasuraAction = req.body as HasuraAction<string, unknown>;
   const userId = hasuraAction.session_variables["x-hasura-user-id"];
 
-  logger.info(`Handling action (${hasuraAction.action.name})`, {
-    userId,
-  });
+  logger.info({ userId }, `Handling action (${hasuraAction.action.name})`);
 
   const handler = actionHandlers.get(hasuraAction.action.name);
   if (!handler) {
@@ -28,9 +26,7 @@ router.post("/v1/actions", middlewareAuthenticateHasura, async (req: Request, re
   try {
     const response = await handler.handle(userId, hasuraAction.input);
     res.status(HttpStatus.OK).json(response);
-    logger.info(`Action handled (${hasuraAction.action.name})`, {
-      userId,
-    });
+    logger.info({ userId }, `Action handled (${hasuraAction.action.name})`);
   } catch (error) {
     isHttpError(error);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,12 +36,15 @@ router.post("/v1/actions", middlewareAuthenticateHasura, async (req: Request, re
       message: anyError.message || "Something went wrong",
       code: `${status}`,
     });
-    logger.info("Failed handling action", {
-      actionName: hasuraAction.action.name,
-      userId,
-      failureReason: anyError.message,
-      status: status,
-    });
+    logger.info(
+      {
+        actionName: hasuraAction.action.name,
+        userId,
+        failureReason: anyError.message,
+        status: status,
+      },
+      "Failed handling action"
+    );
   }
 });
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -50,14 +50,17 @@ function setupMiddleware(app: Application): void {
     const startTime = process.hrtime();
     res.once("finish", () => {
       const requestStatusDescription = `[${req.method}] ${req.url} (status: ${req.statusCode})`;
-      if (!IS_DEV) {
-        logger.info(`Request finished - ${requestStatusDescription}`, {
-          host: req.hostname,
-          userAgent: req.get("user-agent"),
-          timeInMilliseconds: process.hrtime(startTime)[1] / NANOSECONDS_IN_MILLISECOND,
-        });
-      } else {
+      if (IS_DEV) {
         logger.info(`Request finished - ${requestStatusDescription}`);
+      } else {
+        logger.info(
+          {
+            host: req.hostname,
+            userAgent: req.get("user-agent"),
+            timeInMilliseconds: process.hrtime(startTime)[1] / NANOSECONDS_IN_MILLISECOND,
+          },
+          `Request finished - ${requestStatusDescription}`
+        );
       }
     });
     next();

--- a/backend/src/hasura/eventHandlers.ts
+++ b/backend/src/hasura/eventHandlers.ts
@@ -55,7 +55,7 @@ export function createHasuraEventsHandler<T extends EntitiesEventsMapBase>() {
     const normalizedEvent = normalizeHasuraEvent(event);
 
     if (!normalizedEvent) {
-      logger.warn(`Failed to normalize hasura event`, { event });
+      logger.warn({ event }, `Failed to normalize hasura event`);
       return;
     }
 
@@ -75,11 +75,14 @@ export function createHasuraEventsHandler<T extends EntitiesEventsMapBase>() {
     if (IS_DEV) {
       logger.info(`Handling event (${hasuraEvent.trigger.name})`);
     } else {
-      logger.info("Handling event", {
-        eventId: hasuraEvent.id,
-        triggerName: hasuraEvent.trigger.name,
-        userId,
-      });
+      logger.info(
+        {
+          eventId: hasuraEvent.id,
+          triggerName: hasuraEvent.trigger.name,
+          userId,
+        },
+        "Handling event"
+      );
     }
 
     await handleHasuraEvent(hasuraEvent);

--- a/backend/src/messages/events.ts
+++ b/backend/src/messages/events.ts
@@ -24,7 +24,7 @@ async function prepareMessagePlainTextData(message: Message) {
 
     await db.message.update({ where: { id: message.id }, data: { content_text: plainText } });
   } catch (error) {
-    logger.warn("Failed to prepare message plain text content", message);
+    logger.warn({ message }, "Failed to prepare message plain text content");
   }
 }
 


### PR DESCRIPTION
In my previous logger refactoring I accidentally axed object logging. Pino flips those params, compared to what we're doing before, so I flipped our call-sites to adhere to pino's ways.