### PR TITLE
feat(slack-home): highlights

### DIFF
--- a/backend/src/slack/home-tab/RequestList.ts
+++ b/backend/src/slack/home-tab/RequestList.ts
@@ -2,8 +2,7 @@ import { Blocks, Md } from "slack-block-builder";
 
 import { RequestItem } from "./RequestItem";
 import { TopicWithOpenTask } from "./types";
-
-const Padding = [Blocks.Section({ text: " " }), Blocks.Section({ text: " " })];
+import { Padding } from "./utils";
 
 export async function RequestsList({
   title,
@@ -12,6 +11,7 @@ export async function RequestsList({
   topics,
   unreadMessagesByTopicId,
   emptyText = "No requests here",
+  showHighlightContext = false,
 }: {
   title: string;
   explainer: string;
@@ -19,20 +19,19 @@ export async function RequestsList({
   topics: TopicWithOpenTask[];
   unreadMessagesByTopicId: { [topicId: string]: number };
   emptyText?: string;
+  showHighlightContext?: boolean;
 }) {
-  const header = [...Padding, Blocks.Header({ text: title }), Blocks.Context().elements(explainer)];
+  const header = [Padding, Padding, Blocks.Header({ text: title }), Blocks.Context().elements(explainer), Padding];
 
   if (topics.length === 0) {
     return [...header, Blocks.Section({ text: Md.italic(emptyText) })];
   }
 
   const nestedTopicsBlocks = await Promise.all(
-    topics.map(async (topic, i) => {
-      return [
-        ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0)),
-        i < topics.length - 1 ? Blocks.Divider() : undefined,
-      ];
-    })
+    topics.map(async (topic, i) => [
+      ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0, showHighlightContext)),
+      i < topics.length - 1 ? Blocks.Divider() : undefined,
+    ])
   );
 
   const topicBlocks = nestedTopicsBlocks.flat();

--- a/backend/src/slack/home-tab/types.ts
+++ b/backend/src/slack/home-tab/types.ts
@@ -15,4 +15,6 @@ export type TopicWithOpenTask = Topic & {
   user: User;
   message: MessageWithOpenTask[];
   topic_member: TopicMember[];
+  isDueSoon?: boolean;
+  isUnread?: boolean;
 };

--- a/backend/src/slack/home-tab/utils.ts
+++ b/backend/src/slack/home-tab/utils.ts
@@ -1,7 +1,10 @@
 import { minBy } from "lodash";
+import { Blocks } from "slack-block-builder";
 
 import { TopicWithOpenTask } from "./types";
 
 // TODO this will need to be updated in the year 3k
 export const getMostUrgentMessage = ({ message }: TopicWithOpenTask) =>
   minBy(message, (message) => message.message_task_due_date?.due_at ?? new Date(3000, 0));
+
+export const Padding = Blocks.Section({ text: " " });

--- a/backend/src/slack/view-request-modal/ViewRequestModal.ts
+++ b/backend/src/slack/view-request-modal/ViewRequestModal.ts
@@ -1,13 +1,23 @@
+import Sentry from "@sentry/node";
 import { sortBy } from "lodash";
 import { Blocks, Elements, Md, Modal } from "slack-block-builder";
 
+import { updateHomeView } from "~backend/src/slack/home-tab";
+import { db } from "~db";
 import { assert } from "~shared/assert";
 import { COMPLETED_REQUEST_LABEL, RequestType, UNCOMPLETED_REQUEST_LABEL } from "~shared/types/mention";
 
 import { mdDate } from "../md/utils";
-import { REQUEST_TYPE_EMOJIS, SlackActionIds, ViewMetadata, attachToViewWithMetadata } from "../utils";
+import {
+  REQUEST_TYPE_EMOJIS,
+  SlackActionIds,
+  ViewMetadata,
+  attachToViewWithMetadata,
+  fetchTeamBotToken,
+  findUserBySlackId,
+} from "../utils";
 import { getViewRequestViewModel } from "./getTopicInfo";
-import { MessageInfo, TaskInfo } from "./types";
+import { MessageInfo, TaskInfo, TopicInfo } from "./types";
 
 const Padding = (amountOfSpaces = 1) => [...new Array(amountOfSpaces)].map(() => Blocks.Section({ text: " " }));
 
@@ -130,9 +140,41 @@ const MessageBlock = (messageInfo: MessageInfo, topicURL: string) => {
   ];
 };
 
+async function markAsSeenAndUpdateHomeView(token: string, slackUserId: string, topic: TopicInfo) {
+  try {
+    const user = await findUserBySlackId(token, slackUserId, topic.teamId);
+    const [{ message: lastMessage }] = topic.messages.slice(-1);
+
+    if (user && lastMessage) {
+      await db.$transaction([
+        db.last_seen_message.upsert({
+          where: { user_id_topic_id: { user_id: user.id, topic_id: topic.id } },
+          create: { user_id: user.id, topic_id: topic.id, message_id: lastMessage.id },
+          update: { message_id: lastMessage.id },
+        }),
+        db.task.updateMany({
+          where: { message: { topic_id: topic.id }, user_id: user.id },
+          data: { seen_at: new Date().toISOString() },
+        }),
+      ]);
+      const botToken = await fetchTeamBotToken(topic.teamId);
+      if (botToken) {
+        await updateHomeView(botToken, slackUserId);
+      }
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+}
+
 export const ViewRequestModal = async (token: string, metadata: ViewMetadata["view_request_modal"]) => {
-  const topic = await getViewRequestViewModel(token, metadata.topicId, metadata.slackUserId);
+  const slackUserId = metadata.slackUserId;
+  const topic = await getViewRequestViewModel(token, metadata.topicId, slackUserId);
   const [mainRequest, ...otherMessages] = topic.messages;
+
+  // This does need to be awaited as its side effects are not needed for rendering the request modal, and it does its
+  // own error handling
+  markAsSeenAndUpdateHomeView(token, slackUserId, topic);
 
   const RequestOrMessageBlock = (message: MessageInfo) =>
     message.tasks?.length ? RequestBlock(message, topic.slackUserId, topic.url) : MessageBlock(message, topic.url);

--- a/backend/src/slack/view-request-modal/getTopicInfo.ts
+++ b/backend/src/slack/view-request-modal/getTopicInfo.ts
@@ -131,6 +131,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
     isClosed: !!topic.closed_at,
     slackUserId,
     slackMessagePermalink,
+    teamId: team.id,
     messages: await Promise.all(
       topic.message.map(async (message) => {
         const content =

--- a/backend/src/slack/view-request-modal/types.ts
+++ b/backend/src/slack/view-request-modal/types.ts
@@ -27,4 +27,5 @@ export interface TopicInfo {
   isClosed: boolean;
   messages: MessageInfo[];
   slackMessagePermalink?: string;
+  teamId: string;
 }


### PR DESCRIPTION
<img width="499" alt="Screenshot 2021-12-08 at 15 49 59" src="https://user-images.githubusercontent.com/4051932/145236390-6c9ca1c9-8d78-4d6c-a959-8a9deb2ede8b.png">

https://user-images.githubusercontent.com/4051932/145236361-87b7c747-a6cb-4ac4-899b-d173f1f1d307.mov

Riccardo and I decided to do new thing which is to build sth for Slack-1st before we drop it into the webapp. A highlights section, which atm shows requests you received that are either due soon (in the next 24h) or unread. We'll add it to the webapp next week.

Included in this PR is also marking tasks and messages as seen when the request-view-modal is opened in Slack. As an aside, when looking at that code I found [sth I think is objectively off](https://github.com/weareacapela/monorepo/pull/791/files#r764953135) but I also found that I subjectively don't like the indrection MVVM brings too much, but I guess the latter we'll have to duke out longer term through some back-and-forths in more review-y PRs (this is feature week and in feature week we 🚢 ).