### PR TITLE
fix(slack-home): limit topics shown to 10

### DIFF
--- a/backend/src/slack/home-tab/RequestList.ts
+++ b/backend/src/slack/home-tab/RequestList.ts
@@ -1,8 +1,13 @@
 import { Blocks, Md } from "slack-block-builder";
 
+import { createSlackLink } from "~backend/src/slack/md/utils";
+import { pluralize } from "~shared/text/pluralize";
+
 import { RequestItem } from "./RequestItem";
 import { TopicWithOpenTask } from "./types";
 import { Padding } from "./utils";
+
+const MAX_SHOWN_TOPICS = 10;
 
 export async function RequestsList({
   title,
@@ -27,14 +32,34 @@ export async function RequestsList({
     return [...header, Blocks.Section({ text: Md.italic(emptyText) })];
   }
 
+  const extraTopicsCount = Math.max(topics.length - MAX_SHOWN_TOPICS, 0);
+
   const nestedTopicsBlocks = await Promise.all(
-    topics.map(async (topic, i) => [
-      ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0, showHighlightContext)),
-      i < topics.length - 1 ? Blocks.Divider() : undefined,
-    ])
+    topics
+      .slice(0, MAX_SHOWN_TOPICS)
+      .map(async (topic, i) => [
+        ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0, showHighlightContext)),
+        i < topics.length - 1 ? Blocks.Divider() : undefined,
+      ])
   );
 
   const topicBlocks = nestedTopicsBlocks.flat();
 
-  return [...header, ...topicBlocks];
+  return [
+    ...header,
+    ...topicBlocks,
+    extraTopicsCount > 0
+      ? Blocks.Context().elements(
+          `There ${pluralize(
+            extraTopicsCount,
+            "is another topic",
+            `are ${Md.bold(String(extraTopicsCount))} more topics`
+          )} in this category. ${createSlackLink(process.env.FRONTEND_URL, "Open the web app")} to see ${pluralize(
+            extraTopicsCount,
+            "it",
+            "them"
+          )}.`
+        )
+      : undefined,
+  ];
 }

--- a/backend/src/slack/view-request-modal/ViewRequestModal.ts
+++ b/backend/src/slack/view-request-modal/ViewRequestModal.ts
@@ -1,4 +1,4 @@
-import Sentry from "@sentry/node";
+import * as Sentry from "@sentry/node";
 import { sortBy } from "lodash";
 import { Blocks, Elements, Md, Modal } from "slack-block-builder";
 


### PR DESCRIPTION
I might add a commit later which does this a little bit more sensibly, i.e. we probably want different limits for different categories (e.g. highlights 20, received 15, sent 10, open 5, closed 5) but since this is breaking slack home for Heiki (and other power users) in prod, I want to get this out quick.

Note that we had a limit before as well but someone took it out. Please leave it in this time, if we want to show more topics, we need to add pagination.