### PR TITLE
fix(slack-home): limit topics per category

### DIFF
--- a/backend/src/slack/home-tab/RequestList.ts
+++ b/backend/src/slack/home-tab/RequestList.ts
@@ -7,8 +7,6 @@ import { RequestItem } from "./RequestItem";
 import { TopicWithOpenTask } from "./types";
 import { Padding } from "./utils";
 
-const MAX_SHOWN_TOPICS = 10;
-
 export async function RequestsList({
   title,
   explainer,
@@ -17,6 +15,7 @@ export async function RequestsList({
   unreadMessagesByTopicId,
   emptyText = "No requests here",
   showHighlightContext = false,
+  maxShownTopics = 2,
 }: {
   title: string;
   explainer: string;
@@ -25,6 +24,7 @@ export async function RequestsList({
   unreadMessagesByTopicId: { [topicId: string]: number };
   emptyText?: string;
   showHighlightContext?: boolean;
+  maxShownTopics?: number;
 }) {
   const header = [Padding, Padding, Blocks.Header({ text: title }), Blocks.Context().elements(explainer), Padding];
 
@@ -32,11 +32,11 @@ export async function RequestsList({
     return [...header, Blocks.Section({ text: Md.italic(emptyText) })];
   }
 
-  const extraTopicsCount = Math.max(topics.length - MAX_SHOWN_TOPICS, 0);
+  const extraTopicsCount = Math.max(topics.length - maxShownTopics, 0);
 
   const nestedTopicsBlocks = await Promise.all(
     topics
-      .slice(0, MAX_SHOWN_TOPICS)
+      .slice(0, maxShownTopics)
       .map(async (topic, i) => [
         ...(await RequestItem(currentUserId, topic, unreadMessagesByTopicId[topic.id] || 0, showHighlightContext)),
         i < topics.length - 1 ? Blocks.Divider() : undefined,
@@ -45,6 +45,7 @@ export async function RequestsList({
 
   const topicBlocks = nestedTopicsBlocks.flat();
 
+  const extraCountLabel = Md.bold(String(extraTopicsCount));
   return [
     ...header,
     ...topicBlocks,
@@ -52,8 +53,8 @@ export async function RequestsList({
       ? Blocks.Context().elements(
           `There ${pluralize(
             extraTopicsCount,
-            "is another topic",
-            `are ${Md.bold(String(extraTopicsCount))} more topics`
+            `is ${extraCountLabel} other topic`,
+            `are ${extraCountLabel} more topics`
           )} in this category. ${createSlackLink(process.env.FRONTEND_URL, "Open the web app")} to see ${pluralize(
             extraTopicsCount,
             "it",

--- a/backend/src/slack/home-tab/index.ts
+++ b/backend/src/slack/home-tab/index.ts
@@ -164,6 +164,7 @@ export async function updateHomeView(botToken: string, slackUserId: string) {
               topics: highlights,
               unreadMessagesByTopicId,
               showHighlightContext: true,
+              maxShownTopics: 3,
             }),
         highlights.length > 0 && received.length == 0
           ? undefined
@@ -174,6 +175,7 @@ export async function updateHomeView(botToken: string, slackUserId: string) {
               topics: received,
               unreadMessagesByTopicId,
               emptyText: "You are all caught up 🎉",
+              maxShownTopics: 3,
             }),
         await RequestsList({
           title: "📤 Sent",


### PR DESCRIPTION
My previous PR was way too optimistic wrt how many topics we can display in Slack Home. Now it's 2 for sent/open/closed and 3 for highlights/received. Will talk with Riccardo to figure out something nicer, this is more of a temporary solution, candidates are:
- not showing some sections (open & closed come to mind)
- finding ways to minimize blocks
- pagination