### PR TITLE
chore: drop node extra memory options

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=4096' next dev -p 3030",
+    "dev": "next dev -p 3030",
     "dev:inspect": "NODE_OPTIONS='--inspect' next dev -p 3030",
-    "next:build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
+    "next:build": "next build",
     "next:start": "dotenv -e ../.env -- next start -p 3030",
     "next:build:analyze": "ANALYZE=true next build",
     "server:start": "dotenv -e ../.env -- next start -p 3030",

--- a/frontend/start-ci.sh
+++ b/frontend/start-ci.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 export NODE_ENV=production
-export NODE_OPTIONS="--max-old-space-size=4096"
 
 echo "starting frontend..."
 nohup yarn next:start > frontend.log 2>&1 & echo $! > frontend.pid

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "frontend:dev": "yarn frontend dev",
     "frontend:test": "yarn frontend test",
     "frontend:test:watch": "yarn frontend test:watch",
-    "frontend:build": "NODE_OPTIONS='--max-old-space-size=4096' yarn frontend next:build",
+    "frontend:build": "yarn frontend next:build",
     "backend:dev": "yarn backend dev",
     "backend:test": "yarn backend test",
     "backend:test:watch": "yarn backend test:watch",


### PR DESCRIPTION
Thanks to Omar our savior we should not OOM no more, so we don't need to bloat up the memory needs anymore.