### PR TITLE
feat(slack): set due date in request modal

### DIFF
--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -1,8 +1,12 @@
 import { App, Context, Middleware, SlackViewAction, SlackViewMiddlewareArgs } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
+import { zonedTimeToUtc } from "date-fns-tz";
 
 import { User, db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
+import { getNextWorkDayEndOfDay } from "~shared/dates/times";
 import { checkHasAllSlackBotScopes } from "~shared/slack";
+import { Maybe } from "~shared/types";
 import { AnalyticsEventsMap } from "~shared/types/analytics";
 import { REQUEST_ACTION, REQUEST_DECISION, REQUEST_READ, REQUEST_RESPONSE, RequestType } from "~shared/types/mention";
 
@@ -163,3 +167,16 @@ export async function createTeamMemberUserFromSlack(token: string, slackUserId: 
 
 export const checkHasSlackInstallationAllBotScopes = (data: unknown) =>
   checkHasAllSlackBotScopes((data as SlackInstallation)?.bot?.scopes ?? []);
+
+export async function buildDateTimePerUserTimezone(
+  client: WebClient,
+  slackUserId: string,
+  maybeDate: Maybe<string>,
+  maybeHour: Maybe<string>
+) {
+  const { user: slackUser } = await client.users.info({ user: slackUserId });
+  const date = maybeDate ?? getNextWorkDayEndOfDay().toISOString().split("T")[0];
+  const hour = maybeHour ?? "12";
+  const timeZone = slackUser?.tz ?? "Europe/Berlin";
+  return zonedTimeToUtc(`${date} ${hour}:00`, timeZone);
+}

--- a/backend/src/slack/view-request-modal/index.ts
+++ b/backend/src/slack/view-request-modal/index.ts
@@ -6,7 +6,7 @@ import { Sentry } from "~shared/sentry";
 
 import { slackClient } from "../app";
 import { assertToken } from "../utils";
-import { ViewRequestModal } from "./ViewRequestModal";
+import { ViewRequestModal, setupViewRequestModalActions } from "./ViewRequestModal";
 
 export function setupViewRequestModal(slackApp: App) {
   slackApp.action<BlockButtonAction>("open_view_request_modal", async ({ ack, context, body, action }) => {
@@ -30,4 +30,6 @@ export function setupViewRequestModal(slackApp: App) {
       Sentry.captureException(e);
     }
   });
+
+  setupViewRequestModalActions(slackApp);
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/4051932/145426991-06c23537-a86d-49eb-923c-491a476b3266.mov

Also establishes a bit of a different pattern when it comes to slack actions, namely here I've decided to co-locate it with the actual view using it. Imo with the ones we already have the distance between the handler and the caller is already quite large and only the action_id is type-checked, which makes it more likely to break in some ways.
(that said for handlers with global side effects, like updating the home view, it's also not quite clear to me yet what the cleanest thing to do would be).