### PR TITLE
fix(ui): avoid tasks being hidden by scrollable container

### DIFF
--- a/frontend/src/message/feed/tasks/MessageTask.tsx
+++ b/frontend/src/message/feed/tasks/MessageTask.tsx
@@ -50,7 +50,6 @@ export const MessageTask = styledObserver(({ task, className }: Props) => {
 })``;
 
 const UISingleTask = styled.div<{}>`
-  overflow-y: hidden;
   display: flex;
   align-items: center;
   ${theme.spacing.actions.asGap};

--- a/frontend/src/message/feed/tasks/MessageTasks.tsx
+++ b/frontend/src/message/feed/tasks/MessageTasks.tsx
@@ -61,8 +61,7 @@ const UIHolder = styled.div<{}>`
   display: flex;
   flex-direction: row;
   align-items: center;
-  ${theme.spacing.actions.asGap}
-  overflow-y: hidden;
+  ${theme.spacing.actions.asGap};
 `;
 
 const UIDivider = styled.div<{}>`

--- a/frontend/src/message/feed/tasks/MessageTasksPeople.tsx
+++ b/frontend/src/message/feed/tasks/MessageTasksPeople.tsx
@@ -74,7 +74,6 @@ const UICollapsedTasks = styled(UIDropdownPanelBody)<{}>`
   flex-direction: column;
 
   max-height: 400px;
-  overflow-y: auto;
 
   ${MessageTask} {
     ${theme.transitions.hover("all")};


### PR DESCRIPTION
<img width="457" alt="CleanShot 2021-12-13 at 15 22 50@2x" src="https://user-images.githubusercontent.com/7311462/145829420-2089cfb8-55df-4768-beec-02eb2155773a.png">

I was not able to reproduce it (screenshot from Omar), but it is clearly related to 'scroll' overflow.

We had this before in previous UI when we were showing all task labels next to each other and they were X-axis scrollable.

We did not fully remove overflow styles related to this, even tho it is not needed anymore.

Thus I'm semi-confident it will resolve the issue fully, but I bet it is, if it still happens I'll give it another shot.