### PR TITLE
feat(slack): interactive request decision modal

### DIFF
--- a/backend/src/slack/create-request-modal/createRequestInSlack.ts
+++ b/backend/src/slack/create-request-modal/createRequestInSlack.ts
@@ -33,6 +33,7 @@ interface CreateRequestInSlackInput {
   messageTs?: Maybe<string>;
   topicName?: Maybe<string>;
   priority?: Maybe<string>;
+  decisionOptions: string[];
 }
 
 // TODO: Split this function to require prepared data and only handle creating and tracking slack message instead of doing all request preparation
@@ -54,6 +55,7 @@ export async function createAndTrackRequestInSlack({
   botToken,
   topicName,
   priority,
+  decisionOptions = [],
 }: CreateRequestInSlackInput) {
   assert(messageText, "create_request called with wrong arguments");
 
@@ -101,6 +103,7 @@ export async function createAndTrackRequestInSlack({
     dueAt,
     slackUserIdsWithMentionType,
     priority,
+    decisionOptions,
   });
 
   if (!channelId) {

--- a/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
+++ b/backend/src/slack/create-request-modal/createTopicForSlackUsers.ts
@@ -182,6 +182,7 @@ export async function createTopicForSlackUsers({
   rawTopicMessage,
   slackUserIdsWithMentionType,
   priority,
+  decisionOptions,
 }: {
   token: string;
   teamId: string;
@@ -193,6 +194,7 @@ export async function createTopicForSlackUsers({
   rawTopicMessage: string;
   slackUserIdsWithMentionType: SlackUserIdWithRequestType[];
   priority: Maybe<string>;
+  decisionOptions: string[];
 }) {
   const usersWithMentionType = await findOrInviteUsers({
     slackToken: token,
@@ -239,6 +241,7 @@ export async function createTopicForSlackUsers({
                 })),
             },
           },
+          decision_option: { createMany: { data: decisionOptions.map((option, index) => ({ option, index })) } },
         },
       },
     },

--- a/backend/src/slack/create-request-modal/openCreateRequestModal.ts
+++ b/backend/src/slack/create-request-modal/openCreateRequestModal.ts
@@ -1,4 +1,4 @@
-import type { View } from "@slack/types";
+import { ViewStateValue } from "@slack/bolt";
 import { without } from "lodash";
 import { Bits, Blocks, Elements, Md, Modal } from "slack-block-builder";
 
@@ -13,37 +13,79 @@ import {
 
 import { slackClient } from "../app";
 import { ChannelInfo, ViewMetadata, attachToViewWithMetadata } from "../utils";
-import { excludeBotUsers, pickRealUsersFromMessageText } from "./utils";
+import { DECISION_BLOCK_ID_PRE, excludeBotUsers, getDecisionBlockCount, pickRealUsersFromMessageText } from "./utils";
 
 const buildOptionFromRequestType = (value: RequestType) =>
   Bits.Option({ value, text: MENTION_TYPE_PICKER_LABELS[value] });
 
-const CreateRequestModal = (metadata: ViewMetadata["create_request"]) => {
-  const { messageText, requestToSlackUserIds } = metadata;
+export const CreateRequestModal = async (
+  token: string,
+  metadata: ViewMetadata["open_create_request_modal"],
+  stateValues?: {
+    [blockId: string]: {
+      [actionId: string]: ViewStateValue;
+    };
+  }
+) => {
+  const { channelId, slackUserId, messageText } = metadata;
+
+  let requestToSlackUserIds: string[] = [];
+  if (!stateValues) {
+    // we only need to do the following for setting initial values, where stateValues is not set yet
+    const slackUserIdsFromMessage = await pickRealUsersFromMessageText(token, messageText);
+    const slackUserIdsFromMessageWithoutSelf = without(slackUserIdsFromMessage, slackUserId);
+
+    const channelInfo = await getChannelInfo(token, channelId);
+    if (channelInfo) channelInfo.members = without(channelInfo.members, slackUserId);
+
+    requestToSlackUserIds = slackUserIdsFromMessageWithoutSelf;
+
+    // if there is no real user mentioned prefill all channel members
+    if (requestToSlackUserIds.length === 0 && channelInfo && channelInfo.isPrivate) {
+      requestToSlackUserIds = channelInfo.members;
+    }
+  }
+
+  const isDecision = stateValues?.request_type_block?.request_type_select?.selected_option?.value == REQUEST_DECISION;
 
   return Modal({ title: "Create a new request", ...attachToViewWithMetadata("create_request", metadata) })
     .blocks(
-      Blocks.Input({ blockId: "request_type_block", label: "Request Type" }).element(
-        Elements.StaticSelect({ actionId: "request_type_select" })
-          .initialOption(buildOptionFromRequestType(REQUEST_ACTION))
-          .options(
-            Object.keys(MENTION_TYPE_PICKER_LABELS)
-              //TODO: Decisions are still not supported in slack
-              .filter((value) => value !== MENTION_OBSERVER && value !== REQUEST_DECISION)
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .map(buildOptionFromRequestType as any)
-          )
-      ),
+      Blocks.Input({ blockId: "request_type_block", label: "Request Type" })
+        .dispatchAction(true)
+        .element(
+          Elements.StaticSelect({ actionId: "request_type_select" })
+            .initialOption(buildOptionFromRequestType(REQUEST_ACTION))
+            .options(
+              Object.keys(MENTION_TYPE_PICKER_LABELS)
+                .filter((value) => value !== MENTION_OBSERVER)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .map(buildOptionFromRequestType as any)
+            )
+        ),
+
       Blocks.Input({ blockId: "members_block", label: "Request to" }).element(
         Elements.UserMultiSelect({ actionId: "members_select" }).initialUsers(requestToSlackUserIds ?? [])
       ),
       messageText
         ? Blocks.Section({
-            text: Md.bold("Your Message") + "\n" + Md.blockquote(messageText),
+            text: Md.bold(isDecision ? "Decision to be made" : "Your Message") + "\n" + Md.blockquote(messageText),
           })
-        : Blocks.Input({ label: "Your Message", blockId: "message_block" }).element(
-            Elements.TextInput({ actionId: "message_text" }).multiline(true)
-          ),
+        : Blocks.Input({
+            label: isDecision ? "Decision to be made" : "Your Message",
+            blockId: "message_block",
+          }).element(Elements.TextInput({ actionId: "message_text" }).multiline(true)),
+      isDecision
+        ? [
+            ...Array.from({ length: getDecisionBlockCount(stateValues) }, (_, i) =>
+              Blocks.Input({ blockId: DECISION_BLOCK_ID_PRE + i, label: "Option " + (i + 1) })
+                .element(Elements.TextInput({ actionId: "decision_input_" + i }).initialValue(["Yes", "No"][i]))
+                .optional(i > 1)
+            ),
+            Blocks.Actions().elements(
+              Elements.Button({ actionId: "request-modal-add-option", text: "Add another option" })
+            ),
+          ]
+        : undefined,
       Blocks.Input({ blockId: "priority_block", label: "Priority" })
         .element(
           Elements.StaticSelect({ actionId: "priority", placeholder: "No priority" }).options(
@@ -98,32 +140,5 @@ export async function openCreateRequestModal(
   triggerId: string,
   data: ViewMetadata["open_create_request_modal"]
 ) {
-  const { channelId, messageTs, slackUserId, messageText, origin, fromMessageBelongingToSlackUserId } = data;
-  const openView = (view: View) => slackClient.views.open({ token, trigger_id: triggerId, view });
-
-  const slackUserIdsFromMessage = await pickRealUsersFromMessageText(token, messageText);
-  const slackUserIdsFromMessageWithoutSelf = without(slackUserIdsFromMessage, slackUserId);
-
-  const channelInfo = await getChannelInfo(token, channelId);
-  if (channelInfo) channelInfo.members = without(channelInfo.members, slackUserId);
-
-  let requestToSlackUserIds = slackUserIdsFromMessageWithoutSelf;
-
-  // if there is no real user mentioned prefill all channel members
-  if (requestToSlackUserIds.length === 0 && channelInfo && channelInfo.isPrivate) {
-    requestToSlackUserIds = channelInfo.members;
-  }
-
-  await openView(
-    CreateRequestModal({
-      messageText,
-      channelId,
-      channelInfo,
-      messageTs,
-      origin,
-      fromMessageBelongingToSlackUserId,
-      requestToSlackUserIds,
-      slackUserIdsFromMessage: slackUserIdsFromMessageWithoutSelf,
-    })
-  );
+  await slackClient.views.open({ token, trigger_id: triggerId, view: await CreateRequestModal(token, data) });
 }

--- a/backend/src/slack/create-request-modal/utils.ts
+++ b/backend/src/slack/create-request-modal/utils.ts
@@ -32,6 +32,11 @@ export async function pickRealUsersFromMessageText(token: string, messageText?: 
   return slackUserIdsFromMessage;
 }
 
+export const DECISION_BLOCK_ID_PRE = "decision_block_";
+
+export const getDecisionBlockCount = (values: object) =>
+  Math.max(Object.keys(values).filter((key) => key.startsWith(DECISION_BLOCK_ID_PRE)).length, 2);
+
 export function createRequestTitleFromMessageText(messageText: string) {
   return truncateTextWithEllipsis(messageText, DEFAULT_TOPIC_TITLE_TRUNCATE_LENGTH).replaceAll("\n", "");
 }


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/146047778-2e59fe73-8203-41d1-be8b-e6a612fcb929.mov

This is Part 1 of bringing the decision flow into Slack. This here dynamically updates the modal, depending on which request type is chosen.

The sequel will be about bringing the decision into the LiveTopicMessage