### PR TITLE
fix(slack): respect post in channel choice

### DIFF
--- a/backend/src/slack/create-request-modal/index.ts
+++ b/backend/src/slack/create-request-modal/index.ts
@@ -221,7 +221,9 @@ export function setupCreateRequestModal(app: App) {
       observersSlackUserIds,
       origin: metadata.origin,
       token,
-      channelId: metadata.channelId,
+      originalChannelId: metadata.channelId,
+      conversationId:
+        metadata.channelId ?? view.state.values.conversation_block.conversation_select.selected_conversation,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore WebClient has different version of typings and is not directly exported from slack-bolt
       client,

--- a/backend/src/slack/create-request-modal/messageSelfRequest.ts
+++ b/backend/src/slack/create-request-modal/messageSelfRequest.ts
@@ -53,7 +53,8 @@ export async function handleMessageSelfRequestShortcut(request: MessageShortcutR
     requestForSlackUserIds: requestForSlackUserIds,
     origin: "slack-command",
     token,
-    channelId,
+    originalChannelId: channelId,
+    conversationId: channelId,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore WebClient has different version of typings and is not directly exported from slack-bolt
     client,

--- a/backend/src/slack/create-request-modal/quickEntry.ts
+++ b/backend/src/slack/create-request-modal/quickEntry.ts
@@ -87,7 +87,8 @@ export async function handleSlackCommandAsQuickEntry(request: SlashCommandReques
     requestForSlackUserIds: mentionedPeopleSlackIds,
     origin: "slack-command",
     token,
-    channelId,
+    originalChannelId: channelId,
+    conversationId: channelId,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore WebClient has different version of typings and is not directly exported from slack-bolt
     client,


### PR DESCRIPTION
Fixes https://weareacapela.slack.com/archives/C027RS14F0T/p1639499256001300

One of the last larger refactors dropped the part of the code that reads out the "post in channel" selector, which is used in the global shortcut. Longer term we probably want to give this whole code a good old refactor, as it looks like feature-rush, but I feel like it's time to add more test coverage first to make it less risky.