### PR TITLE
fix: only-reuse local storage manager when default matches

### DIFF
--- a/shared/localStorage.ts
+++ b/shared/localStorage.ts
@@ -101,7 +101,7 @@ export function getLocalStorageValueManager<T>(name: string | null, defaultValue
     return createLocalStorageValueManager<T>(name, defaultValue);
   }
 
-  const newOrExistingValueManager = mapGetOrCreate(localStorageValueManagers, name, () =>
+  const newOrExistingValueManager = mapGetOrCreate(localStorageValueManagers, name + JSON.stringify(defaultValue), () =>
     createLocalStorageValueManager<unknown>(name, defaultValue)
   );
 


### PR DESCRIPTION
Not quite my part of the swamp and I got a bit lost in the abstraction jungle, so I'm going to label this `ask` for @pie6k 

The bug was that editing a message would re-use it's previous value after saving, which seemed to have been related to those localStorage managers being saved based on their name, which breaks when their default value changes (which is the case when a message gets updated).

Here's the bug in video form:

https://user-images.githubusercontent.com/4051932/146193746-8ba86d65-4d54-4955-a4f7-c74b302d8070.mov

