### PR TITLE
fix(decision): show task undo button

### DIFF
--- a/frontend/src/clientdb/message.ts
+++ b/frontend/src/clientdb/message.ts
@@ -4,6 +4,7 @@ import { memoize } from "lodash";
 import { observable } from "mobx";
 
 import { EntityByDefinition, cachedComputed, defineEntity } from "~clientdb";
+import { decisionOptionEntity } from "~frontend/clientdb/decisionOption";
 import { MessageFragment } from "~gql";
 import { convertMessageContentToPlainText } from "~richEditor/content/plainText";
 import { getUniqueRequestMentionDataFromContent } from "~shared/editor/mentions";
@@ -149,6 +150,10 @@ export const messageEntity = defineEntity<MessageFragment>({
 
     get dueDate() {
       return taskDueDate.first?.due_at ? new Date(taskDueDate.first.due_at) : null;
+    },
+
+    get decisionOptions() {
+      return getEntity(decisionOptionEntity).query({ message_id: message.id });
     },
   };
 

--- a/frontend/src/tasks/OwnTaskCompletionButton.tsx
+++ b/frontend/src/tasks/OwnTaskCompletionButton.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import styled from "styled-components";
 
+import { useAssertCurrentUser } from "~frontend/authentication/useCurrentUser";
 import { TaskEntity } from "~frontend/clientdb/task";
 import { getMentionColor } from "~frontend/message/extensions/mentions/TypedMention";
 import {
@@ -20,7 +21,8 @@ interface Props {
 }
 
 export const OwnTaskCompletionButton = observer(function OwnTaskCompletionButton({ task }: Props) {
-  if (task.type === REQUEST_DECISION) {
+  const currentUser = useAssertCurrentUser();
+  if (task.type === REQUEST_DECISION && !task.isDone) {
     return null;
   }
 
@@ -45,6 +47,10 @@ export const OwnTaskCompletionButton = observer(function OwnTaskCompletionButton
           label: "Undo",
           onSelect: () => {
             task.update({ done_at: null });
+            task.message?.decisionOptions.all
+              .flatMap((option) => option.votes.all)
+              .find((vote) => vote.user_id == currentUser.id)
+              ?.remove();
           },
           icon: <IconUndo />,
         },


### PR DESCRIPTION
I completely hid the task-complete button for decisions, but actually I like the redundancy of showing it for undo, as the other way of undoing voting (clicking the existing vote) might be a tad non-obvious