### PR TITLE
fix(slack): slimmer home and decisions in view request modal

### DIFF
--- a/backend/src/slack/actions.ts
+++ b/backend/src/slack/actions.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { App, BlockButtonAction, ViewOutput } from "@slack/bolt";
+import { App, BlockButtonAction } from "@slack/bolt";
 import { Blocks, Modal } from "slack-block-builder";
 
 import { db } from "~db";
@@ -8,35 +8,14 @@ import { assertDefined } from "~shared/assert";
 import { trackBackendUserEvent } from "~shared/backendAnalytics";
 import { routes } from "~shared/routes";
 import { Sentry } from "~shared/sentry";
-import { Origin } from "~shared/types/analytics";
 import { RequestType } from "~shared/types/mention";
 
 import { slackClient } from "./app";
 import { openCreateRequestModal } from "./create-request-modal/openCreateRequestModal";
 import { updateHomeView } from "./home-tab";
 import { createSlackLink } from "./md/utils";
-import { SlackActionIds, assertToken, findUserBySlackId } from "./utils";
+import { SlackActionIds, assertToken, findUserBySlackId, getViewOrigin } from "./utils";
 import { ViewRequestModal } from "./view-request-modal/ViewRequestModal";
-
-type SlackViewOrigin = Extract<
-  Origin,
-  "slack-live-message" | "slack-home-tab" | "slack-view-request-modal" | "unknown"
->;
-
-function getViewOrigin(view?: ViewOutput): SlackViewOrigin {
-  if (!view) {
-    return "slack-live-message";
-  }
-
-  if (view.type === "home") {
-    return "slack-home-tab";
-  }
-  if (view.type === "modal" && view.callback_id === "view_request_modal") {
-    return "slack-view-request-modal";
-  }
-
-  return "unknown";
-}
 
 export function setupSlackActionHandlers(slackApp: App) {
   slackApp.action<BlockButtonAction>(SlackActionIds.CreateTopic, async ({ ack, context, body }) => {

--- a/backend/src/slack/decision.ts
+++ b/backend/src/slack/decision.ts
@@ -1,0 +1,132 @@
+import { App, BlockButtonAction } from "@slack/bolt";
+import { orderBy } from "lodash";
+import { Blocks, Elements, Md, Modal } from "slack-block-builder";
+
+import { slackClient } from "~backend/src/slack/app";
+import { ViewRequestModal } from "~backend/src/slack/view-request-modal/ViewRequestModal";
+import { DecisionOption, DecisionVote, User, db } from "~db";
+import { routes } from "~shared/routes";
+import { REQUEST_DECISION } from "~shared/types/mention";
+
+import { createSlackLink } from "./md/utils";
+import { assertToken, findUserBySlackId, getViewOrigin } from "./utils";
+
+const DECISION_VOTE_ACTION_ID = "decision_option-vote";
+
+export function setupDecision(app: App) {
+  app.action<BlockButtonAction>(DECISION_VOTE_ACTION_ID, async ({ ack, action, client, body, context }) => {
+    await ack();
+
+    const token = assertToken(context);
+    const user = await findUserBySlackId(token, body.user.id);
+
+    const decisionOption = user
+      ? await db.decision_option.findFirst({
+          where: { id: action.value, message: { task: { some: { user_id: user.id, type: REQUEST_DECISION } } } },
+          include: { message: { include: { topic: true } }, decision_vote: { where: { user_id: user.id } } },
+        })
+      : null;
+
+    if (!user || !decisionOption) {
+      await client.views.open({
+        trigger_id: body.trigger_id,
+        view: Modal({ title: "No Vote" })
+          .blocks(
+            user
+              ? Blocks.Section({
+                  text: "You were not asked to vote in this decision, so this button does not do anything.",
+                })
+              : Blocks.Section({
+                  text: `We could not find an Acapela user for you. Make sure ${createSlackLink(
+                    process.env.FRONTEND_URL + routes.settings,
+                    "to link your Slack account in your Acapela team settings"
+                  )} so that you can vote on decisions through Slack.`,
+                })
+          )
+          .buildToObject(),
+      });
+      return;
+    }
+
+    const { topic } = decisionOption.message;
+    await db.$transaction(async (db) => {
+      const votes = await db.decision_vote.findMany({
+        where: { user_id: user.id, decision_option: { message_id: decisionOption.message_id } },
+      });
+      await db.decision_vote.deleteMany({ where: { id: { in: votes.map((vote) => vote.id) } } });
+
+      // our deletion sync system can not automatically handle entities deleted through the backend at the moment
+      // so we have to manually create a sync request
+
+      await db.sync_request.createMany({
+        data: votes.map((vote) => ({
+          entity_name: "decision_vote",
+          entity_id: vote.id,
+          change_type: "delete",
+          team_id: topic.team_id,
+          user_id: user.id,
+          date: new Date().toISOString(),
+        })),
+      });
+      if (decisionOption.decision_vote.length == 0) {
+        await db.decision_vote.create({
+          data: {
+            user_id: user.id,
+            decision_option_id: decisionOption.id,
+          },
+        });
+      }
+    });
+    await db.task.updateMany({
+      where: { user_id: user.id, message_id: decisionOption.message_id },
+      data: {
+        done_at:
+          (await db.decision_vote.count({
+            where: { user_id: user.id, decision_option: { message_id: decisionOption.message_id } },
+          })) == 0
+            ? null
+            : new Date().toISOString(),
+      },
+    });
+
+    if (getViewOrigin(body.view) == "slack-view-request-modal") {
+      await slackClient.views.update({
+        token,
+        view_id: body.view?.id,
+        view: await ViewRequestModal(token, {
+          slackUserId: body.user.id,
+          topicId: topic.id,
+        }),
+      });
+    }
+  });
+}
+
+const EMOJI_NUMBERS = ["0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"];
+const emojifyNumber = (n: number) =>
+  n
+    .toString()
+    .split("")
+    .map((n) => EMOJI_NUMBERS[parseInt(n)])
+    .join("");
+
+export type DecisionOptionWithVotes = DecisionOption & { decision_vote: (DecisionVote & { user: User })[] };
+
+export const DecisionOptionVoting = (options: DecisionOptionWithVotes[], slackUsers: Record<string, string>) =>
+  orderBy(options, "index").map(({ id, option, index, decision_vote }) => {
+    const emojiNo = emojifyNumber(index + 1);
+    return Blocks.Section({
+      text:
+        emojiNo +
+        " " +
+        option +
+        (decision_vote.length == 0
+          ? ""
+          : " " +
+            Md.codeInline(String(decision_vote.length)) +
+            "\n" +
+            decision_vote
+              .map(({ user }) => (slackUsers[user.id] ? Md.user(slackUsers[user.id]) : Md.italic(user.name)))
+              .join(", ")),
+    }).accessory(Elements.Button({ text: emojiNo, actionId: DECISION_VOTE_ACTION_ID, value: id }));
+  });

--- a/backend/src/slack/live-messages/LiveTaskMessage.ts
+++ b/backend/src/slack/live-messages/LiveTaskMessage.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client";
-import { Blocks, Md, Message as SlackMessage } from "slack-block-builder";
+import { Blocks, Elements, Md, Message as SlackMessage } from "slack-block-builder";
 
 import { Message, MessageTaskDueDate, Task, Topic, db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
@@ -8,7 +8,7 @@ import { MENTION_TYPE_LABELS, MentionType, REQUEST_DECISION } from "~shared/type
 
 import { slackClient } from "../app";
 import { mdDate } from "../md/utils";
-import { fetchTeamBotToken } from "../utils";
+import { SlackActionIds, fetchTeamBotToken } from "../utils";
 import { ToggleTaskDoneAtButton, createTopicLink, generateMessageTextWithMentions } from "./utils";
 
 type TaskDetail = Task & {
@@ -42,7 +42,14 @@ export async function LiveTaskMessage(task: TaskDetail) {
         ? Blocks.Section({ text: "The topic has been closed ✅️" })
         : [
             dueAt ? Blocks.Section({ text: Md.italic(`Due ${mdDate(dueAt)}`) }) : undefined,
-            task.type === REQUEST_DECISION ? undefined : Blocks.Actions().elements(ToggleTaskDoneAtButton(task)),
+            Blocks.Actions().elements(
+              task.type === REQUEST_DECISION ? undefined : ToggleTaskDoneAtButton(task),
+              Elements.Button({
+                actionId: SlackActionIds.OpenViewRequestModal,
+                value: topic.id,
+                text: "View Request",
+              })
+            ),
           ]
     )
     .buildToObject();

--- a/backend/src/slack/live-messages/LiveTopicMessage.ts
+++ b/backend/src/slack/live-messages/LiveTopicMessage.ts
@@ -1,102 +1,16 @@
-import { App, BlockButtonAction } from "@slack/bolt";
-import { groupBy, orderBy } from "lodash";
-import { Blocks, Elements, Md, Modal, Message as SlackMessage } from "slack-block-builder";
+import { groupBy } from "lodash";
+import { Blocks, Elements, Md, Message as SlackMessage } from "slack-block-builder";
 
-import { DecisionOption, DecisionVote, Message, Task, Topic, TopicAccessToken, User, db } from "~db";
+import { Message, Task, Topic, TopicAccessToken, User, db } from "~db";
 import { assert, assertDefined } from "~shared/assert";
 import { logger } from "~shared/logger";
-import { routes } from "~shared/routes";
 import { REQUEST_DECISION, REQUEST_NOTIFICATION_LABELS, RequestType } from "~shared/types/mention";
 
 import { slackClient } from "../app";
-import { createSlackLink, mdDate } from "../md/utils";
-import {
-  SlackActionIds,
-  assertToken,
-  fetchTeamBotToken,
-  fetchTeamMemberToken,
-  findSlackUserId,
-  findUserBySlackId,
-} from "../utils";
+import { DecisionOptionVoting } from "../decision";
+import { mdDate } from "../md/utils";
+import { SlackActionIds, fetchTeamBotToken, fetchTeamMemberToken, findSlackUserId } from "../utils";
 import { ToggleTaskDoneAtButton, createTopicLink, generateMessageTextWithMentions } from "./utils";
-
-const DECISION_VOTE_ACTION_ID = "decision_option-vote";
-
-export function setupLiveTopicMessage(app: App) {
-  app.action<BlockButtonAction>(DECISION_VOTE_ACTION_ID, async ({ ack, action, client, body, context }) => {
-    await ack();
-
-    const token = assertToken(context);
-    const user = await findUserBySlackId(token, body.user.id);
-
-    const decisionOption = user
-      ? await db.decision_option.findFirst({
-          where: { id: action.value, message: { task: { some: { user_id: user.id, type: REQUEST_DECISION } } } },
-          include: { message: { include: { topic: true } }, decision_vote: { where: { user_id: user.id } } },
-        })
-      : null;
-
-    if (!user || !decisionOption) {
-      await client.views.open({
-        trigger_id: body.trigger_id,
-        view: Modal({ title: "No Vote" })
-          .blocks(
-            user
-              ? Blocks.Section({
-                  text: "You were not asked to vote in this decision, so this button does not do anything.",
-                })
-              : Blocks.Section({
-                  text: `We could not find an Acapela user for you. Make sure ${createSlackLink(
-                    process.env.FRONTEND_URL + routes.settings,
-                    "to link your Slack account in your Acapela team settings"
-                  )} so that you can vote on decisions through Slack.`,
-                })
-          )
-          .buildToObject(),
-      });
-      return;
-    }
-
-    await db.$transaction(async (db) => {
-      const votes = await db.decision_vote.findMany({
-        where: { user_id: user.id, decision_option: { message_id: decisionOption.message_id } },
-      });
-      await db.decision_vote.deleteMany({ where: { id: { in: votes.map((vote) => vote.id) } } });
-
-      // our deletion sync system can not automatically handle entities deleted through the backend at the moment
-      // so we have to manually create a sync request
-      await db.sync_request.createMany({
-        data: votes.map((vote) => ({
-          entity_name: "decision_vote",
-          entity_id: vote.id,
-          change_type: "delete",
-          team_id: decisionOption.message.topic.team_id,
-          user_id: user.id,
-          date: new Date().toISOString(),
-        })),
-      });
-      if (decisionOption.decision_vote.length == 0) {
-        await db.decision_vote.create({
-          data: {
-            user_id: user.id,
-            decision_option_id: decisionOption.id,
-          },
-        });
-      }
-    });
-    await db.task.updateMany({
-      where: { user_id: user.id, message_id: decisionOption.message_id },
-      data: {
-        done_at:
-          (await db.decision_vote.count({
-            where: { user_id: user.id, decision_option: { message_id: decisionOption.message_id } },
-          })) == 0
-            ? null
-            : new Date().toISOString(),
-      },
-    });
-  });
-}
 
 const makeSlackMessageTextWithContent = async (topic: Topic, message: Message, accessToken?: string) =>
   Md.bold(`[Acapela request] ${await createTopicLink(topic, accessToken)}`) +
@@ -118,36 +32,6 @@ const getTasksText = (tasks: (Task & { user: User })[], slackUsers: Record<strin
     .join("\n");
 
 type TopicWithToken = Topic & { topic_access_token?: TopicAccessToken[] };
-
-const EMOJI_NUMBERS = ["0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"];
-const emojifyNumber = (n: number) =>
-  n
-    .toString()
-    .split("")
-    .map((n) => EMOJI_NUMBERS[parseInt(n)])
-    .join("");
-
-const DecisionVotes = (
-  options: (DecisionOption & { decision_vote: (DecisionVote & { user: User })[] })[],
-  slackUsers: Record<string, string>
-) =>
-  orderBy(options, "index").map(({ id, option, index, decision_vote }) => {
-    const emojiNo = emojifyNumber(index + 1);
-    return Blocks.Section({
-      text:
-        emojiNo +
-        " " +
-        option +
-        (decision_vote.length == 0
-          ? ""
-          : " " +
-            Md.codeInline(String(decision_vote.length)) +
-            "\n" +
-            decision_vote
-              .map(({ user }) => (slackUsers[user.id] ? Md.user(slackUsers[user.id]) : Md.italic(user.name)))
-              .join(" ")),
-    }).accessory(Elements.Button({ text: emojiNo, actionId: DECISION_VOTE_ACTION_ID, value: id }));
-  });
 
 export async function LiveTopicMessage(topic: TopicWithToken, options?: { isMessageContentExcluded?: boolean }) {
   const [message, accessToken] = await Promise.all([
@@ -189,7 +73,7 @@ export async function LiveTopicMessage(topic: TopicWithToken, options?: { isMess
       Blocks.Divider(),
       message.decision_option.length == 0
         ? undefined
-        : [...DecisionVotes(message.decision_option, slackUsers), Blocks.Divider()],
+        : [...DecisionOptionVoting(message.decision_option, slackUsers), Blocks.Divider()],
       topic.closed_at || tasks.length == 0
         ? Blocks.Section({ text: "All tasks have been completed 🎉" })
         : [

--- a/backend/src/slack/setup.ts
+++ b/backend/src/slack/setup.ts
@@ -3,8 +3,8 @@ import { Express } from "express";
 import { setupSlackActionHandlers } from "./actions";
 import { slackApp, slackReceiver } from "./app";
 import { setupCreateRequestModal } from "./create-request-modal";
+import { setupDecision } from "./decision";
 import { setupHomeTab } from "./home-tab";
-import { setupLiveTopicMessage } from "./live-messages/LiveTopicMessage";
 import { setupViewRequestModal } from "./view-request-modal";
 
 export function setupSlack(app: Express) {
@@ -18,5 +18,5 @@ export function setupSlack(app: Express) {
 
   setupSlackActionHandlers(slackApp);
 
-  setupLiveTopicMessage(slackApp);
+  setupDecision(slackApp);
 }

--- a/backend/src/slack/utils.ts
+++ b/backend/src/slack/utils.ts
@@ -1,4 +1,4 @@
-import { App, Context, Middleware, SlackViewAction, SlackViewMiddlewareArgs } from "@slack/bolt";
+import { App, Context, Middleware, SlackViewAction, SlackViewMiddlewareArgs, ViewOutput } from "@slack/bolt";
 import { WebClient } from "@slack/web-api";
 import { zonedTimeToUtc } from "date-fns-tz";
 import { upperFirst } from "lodash";
@@ -9,7 +9,7 @@ import { assert, assertDefined } from "~shared/assert";
 import { getNextWorkDayEndOfDay } from "~shared/dates/times";
 import { checkHasAllSlackBotScopes } from "~shared/slack";
 import { Maybe } from "~shared/types";
-import { AnalyticsEventsMap } from "~shared/types/analytics";
+import { AnalyticsEventsMap, Origin } from "~shared/types/analytics";
 import { REQUEST_ACTION, REQUEST_DECISION, REQUEST_READ, REQUEST_RESPONSE, RequestType } from "~shared/types/mention";
 
 import { SlackInstallation, slackClient } from "./app";
@@ -186,3 +186,23 @@ export async function buildDateTimePerUserTimezone(
 
 export const PriorityLabel = (priority: null | string) =>
   priority ? `🚩 ${Md.bold("Priority")} ${upperFirst(priority)}` : undefined;
+
+type SlackViewOrigin = Extract<
+  Origin,
+  "slack-live-message" | "slack-home-tab" | "slack-view-request-modal" | "unknown"
+>;
+
+export function getViewOrigin(view?: ViewOutput): SlackViewOrigin {
+  if (!view) {
+    return "slack-live-message";
+  }
+
+  if (view.type === "home") {
+    return "slack-home-tab";
+  }
+  if (view.type === "modal" && view.callback_id === "view_request_modal") {
+    return "slack-view-request-modal";
+  }
+
+  return "unknown";
+}

--- a/backend/src/slack/view-request-modal/getTopicInfo.ts
+++ b/backend/src/slack/view-request-modal/getTopicInfo.ts
@@ -9,7 +9,7 @@ import { RequestType } from "~shared/types/mention";
 import { slackClient } from "../app";
 import { GenerateContext, generateMarkdownFromTipTapJson } from "../md/generator";
 import { createSlackLink } from "../md/utils";
-import { SlackMember, TopicInfo } from "./types";
+import { SlackMember } from "./types";
 
 export async function getViewRequestViewModel(token: string, topicId: string, slackUserId: string) {
   const team = await db.team.findFirst({
@@ -53,6 +53,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
         include: {
           message_task_due_date: true,
           task: true,
+          decision_option: { include: { decision_vote: { include: { user: true } } } },
           attachment: {
             select: {
               id: true,
@@ -124,7 +125,7 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
     : undefined;
 
   const topicUrl = await backendGetTopicUrl(topic);
-  const topicInfo: TopicInfo = {
+  return {
     ...topic,
     url: topicUrl,
     isClosed: !!topic.closed_at,
@@ -157,10 +158,11 @@ export async function getViewRequestViewModel(token: string, topicId: string, sl
               doneAt: t.done_at ? new Date(t.done_at) : undefined,
             }))
           ),
+          decisionOptions: message.decision_option,
         };
       })
     ),
   };
-
-  return topicInfo;
 }
+
+export type TopicInfo = Awaited<ReturnType<typeof getViewRequestViewModel>>;

--- a/backend/src/slack/view-request-modal/types.ts
+++ b/backend/src/slack/view-request-modal/types.ts
@@ -1,4 +1,4 @@
-import { Topic } from "~db";
+import { DecisionOptionWithVotes } from "~backend/src/slack/decision";
 import { RequestType } from "~shared/types/mention";
 
 export interface SlackMember {
@@ -18,12 +18,5 @@ export interface MessageInfo {
   message: { id: string; content: string; fromUser: SlackMember; createdAt: Date; fromUserImage?: string };
   dueDate?: Date;
   tasks?: TaskInfo[];
+  decisionOptions: DecisionOptionWithVotes[];
 }
-
-export type TopicInfo = Topic & {
-  url: string;
-  slackUserId: string;
-  isClosed: boolean;
-  messages: MessageInfo[];
-  slackMessagePermalink?: string;
-};


### PR DESCRIPTION
Two for one. Made Slack Home a bit slimmer, by moving actionability into the request modal again. And made that one a little more actionable, by also including decisions in it.

<img width="765" alt="Screenshot 2021-12-17 at 13 54 51" src="https://user-images.githubusercontent.com/4051932/146547766-dc64e965-df83-4e46-831e-2d3aa2ce92ba.png">
<img width="519" alt="Screenshot 2021-12-17 at 13 55 39" src="https://user-images.githubusercontent.com/4051932/146547774-22d624c5-866c-4157-9828-689933379545.png">
