### PR TITLE
fix: properly update unread messages. it was wrongly using simple query

### DIFF
--- a/frontend/src/views/RequestView/index.tsx
+++ b/frontend/src/views/RequestView/index.tsx
@@ -57,16 +57,16 @@ function useUpdateTopicLastSeenMessage(topic: TopicEntity | null) {
       const lastSeenMessageInfo = topic.lastSeenMessageByCurrentUserInfo;
       const lastMessage = topic.messages.last;
 
+      if (!lastMessage) {
+        console.warn(`Topic has no messages - skipping setting last seen message`);
+        return;
+      }
+
       const nowISO = new Date().toISOString();
 
       if (lastSeenMessageInfo) {
         lastSeenMessageInfo.update({ seen_at: nowISO, message_id: lastMessage?.id });
 
-        return;
-      }
-
-      if (!lastMessage) {
-        console.warn(`Topic has no messages - skipping setting last seen message`);
         return;
       }
 


### PR DESCRIPTION
Bug: it was not updating unread messages properly.

This surfaced some interesting use case we have (TLDR: lack of warning when incorrectly using simpleQuery)

Context:
Clientdb has simplequery (`.query({foo: bar})`) that is optimized for speed. It uses key value index.

Index is updated on `entityChanged` event (instead of creating computed values). This is super fast, but has limitation - it will only detect changes inside entity, but not inside other entities (aka relations). It seems to be reasonable limitation.

Thus we should simply warn about using `{key: value}` where computing `key` value needs reading from relations.

Simple solution would be to only allow fragment keys in simple query, but this is limiting, eg: entity has `closed_at` date and then computed `isClosed` field. In such case doing `.query({isClosed: true})` is safe (computing it is not using relations) and it is very handy.

Thus solving it properly would require spying during simple query (in dev mode) for access for other entities fields and warning then. It seems complex to do so I skipped it