### PR TITLE
fix(slack-home): make open/sent request items renderable

### DIFF
--- a/backend/src/slack/home-tab/RequestItem.ts
+++ b/backend/src/slack/home-tab/RequestItem.ts
@@ -54,29 +54,14 @@ const RequestFooter = (userId: string, topic: TopicWithOpenTask) => {
 };
 
 export async function RequestItemHeader(topic: TopicWithOpenTask, unreadMessages: number) {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const mostUrgentMessage = getMostUrgentMessage(topic)!;
+  const mostUrgentMessage = getMostUrgentMessage(topic);
 
-  const messageSnippet = await convertDbMessageToSlackMessageSnippet(mostUrgentMessage);
+  const messageSnippet = mostUrgentMessage && (await convertDbMessageToSlackMessageSnippet(mostUrgentMessage));
 
-  function getNameNode() {
-    const topicName = Md.bold(topic.name);
-    const parts: Array<string | null> = [topicName];
+  const topicName = Md.bold(topic.name);
+  const nameLine = unreadMessages ? `${topicName} ✉️ ${Md.bold(unreadMessages.toString())}` : topicName;
 
-    if (unreadMessages) {
-      parts.push(`✉️ ${Md.bold(unreadMessages.toString())}`);
-    }
-
-    return parts.filter(isNotNullish).join(" ");
-  }
-
-  function getTaskLines() {
-    const name = getNameNode();
-
-    return [name, messageSnippet];
-  }
-
-  return getTaskLines().join("\n");
+  return messageSnippet ? [nameLine, messageSnippet].join("\n") : nameLine;
 }
 
 export async function RequestItem(userId: string, topic: TopicWithOpenTask, unreadMessages: number) {

--- a/backend/src/slack/home-tab/content.ts
+++ b/backend/src/slack/home-tab/content.ts
@@ -65,12 +65,12 @@ export const MissingAuthHomeTab = HomeTab()
 
 /*
  This arbitrary number is estimated based on Slack's 100 max block limit, minus the 4 header blocks, so 96 left.
- RequestList needs up to 5 blocks and then 3 blocks per RequestItem in it.
- So if we show all our 5 categories that gives us: 96 - 5 * 3 = 81 blocks left
- For a total number of 81 / 5 = 16 topics
- And then to make sure it renders and there's some slack (pardon the pun) in the system 16 - 2 = 14
+ RequestList needs up to 7 blocks and then 2 (+ 1 Divider) blocks per RequestItem in it.
+ So if we show all our 5 categories that gives us: 96 - 5 * 7 = 61 blocks left
+ For a total number of 61 / 3 = 20 topics
+ And then to make sure it renders and there's some slack (pardon the pun) in the system 20 * 90% = 18
 */
-const MAX_TOTAL_TOPICS = 14;
+const MAX_TOTAL_TOPICS = 18;
 
 interface SummaryBuilderInput {
   includeWelcome?: boolean;


### PR DESCRIPTION
I started with writing tests, but it became tricky and I felt like I already spent many hours for tests for sth that amounts to a small fix (for now). So no tests for this fix, sorry!

Now talking about the bug: the problem was that the latest refactor/visual-refresh added an asserted-assumption for there always to be a message in `TopicWithOpenTask`, where that only contains non-done messages for the current user, which by definition is not the case for open/sent. I've just turned the line empty for now to make it work, but maybe @pie6k will want to revisit it.