### PR TITLE
fix(layout): bring back page-layout to reduce flicker & re-renders

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -20,6 +20,7 @@ import { sentryFallbackErrorRenderer } from "~frontend/errors/sentryFallbackErro
 import initializeUserbackPlugin from "~frontend/scripts/userback";
 import { global } from "~frontend/styles/global";
 import { CurrentTeamProvider } from "~frontend/team/CurrentTeam";
+import { renderWithPageLayout } from "~frontend/utils/pageLayout";
 import { useConst } from "~shared/hooks/useConst";
 import { POP_ANIMATION_CONFIG } from "~ui/animations";
 import { PromiseUIRenderer } from "~ui/createPromiseUI";
@@ -98,7 +99,7 @@ export default function App({
             <PromiseUIRenderer />
             <TooltipsRenderer />
             <ToastsRenderer />
-            <Component {...{ appConfig, ...pageProps }} />
+            {renderWithPageLayout(Component, { appConfig, ...pageProps })}
           </AppThemeProvider>
         </RequiredSessionProvider>
       </>
@@ -120,7 +121,7 @@ export default function App({
                       <PromiseUIRenderer />
                       <TooltipsRenderer />
                       <ToastsRenderer />
-                      <Component {...{ appConfig, ...pageProps }} />
+                      {renderWithPageLayout(Component, { appConfig, ...pageProps })}
                     </AppStateStoreProvider>
                   </ClientDbProvider>
                 </CurrentTeamProvider>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,3 +1,9 @@
+import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
+import { assignPageLayout } from "~frontend/utils/pageLayout";
 import { InboxView } from "~frontend/views/InboxView";
 
-export default InboxView;
+export default function InboxPage() {
+  return <InboxView />;
+}
+
+assignPageLayout(InboxPage, SidebarLayout);

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
+import { assignPageLayout } from "~frontend/utils/pageLayout";
 import { PageMeta } from "~frontend/utils/PageMeta";
 import { SettingsView } from "~frontend/views/SettingsView";
 
@@ -11,14 +12,14 @@ export default function SettingsPage(props: { appConfig: AppConfig }) {
   return (
     <>
       <PageMeta title="Settings" />
-      <SidebarLayout>
-        <UIHolder>
-          <SettingsView version={props.appConfig.version} buildDate={props.appConfig.buildDate} />
-        </UIHolder>
-      </SidebarLayout>
+      <UIHolder>
+        <SettingsView version={props.appConfig.version} buildDate={props.appConfig.buildDate} />
+      </UIHolder>
     </>
   );
 }
+
+assignPageLayout(SettingsPage, SidebarLayout);
 
 const UIHolder = styled.div`
   max-width: 1200px;

--- a/frontend/src/utils/pageLayout.tsx
+++ b/frontend/src/utils/pageLayout.tsx
@@ -1,0 +1,32 @@
+import { ComponentType, ReactNode } from "react";
+
+const layoutSymbol = Symbol("page layout");
+const layoutPropsSymbol = Symbol("page layout props");
+
+export function assignPageLayout<PageProps, LayoutProps>(
+  PageComponent: ComponentType<PageProps>,
+  LayoutComponent: ComponentType<{ children: ReactNode } & LayoutProps>,
+  defaultLayoutProps?: Partial<LayoutProps>
+) {
+  if (Reflect.get(PageComponent, layoutSymbol)) {
+    console.warn(`PageComponent - ${PageComponent.displayName} already has LayoutComponent. Overwritting.`);
+  }
+
+  Reflect.set(PageComponent, layoutSymbol, LayoutComponent);
+  Reflect.set(PageComponent, layoutPropsSymbol, defaultLayoutProps);
+}
+
+export function renderWithPageLayout<P>(PageComponent: ComponentType<P>, props: P) {
+  const LayoutComponent = Reflect.get(PageComponent, layoutSymbol) as ComponentType | null;
+  const layoutProps = Reflect.get(PageComponent, layoutPropsSymbol) as Record<string, unknown> | undefined;
+
+  if (!LayoutComponent) {
+    return <PageComponent {...props} />;
+  }
+
+  return (
+    <LayoutComponent {...layoutProps}>
+      <PageComponent {...props} />
+    </LayoutComponent>
+  );
+}

--- a/frontend/src/views/InboxView/index.tsx
+++ b/frontend/src/views/InboxView/index.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 
 import { useDb } from "~frontend/clientdb";
 import { TopicEntity } from "~frontend/clientdb/topic";
-import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
 import { pluralize } from "~shared/text/pluralize";
 import { theme } from "~ui/theme";
 
@@ -37,24 +36,22 @@ export const InboxView = observer(() => {
     (topic) => topic.selfAssignedOpenTasks.query({ seen_at: null }).hasItems
   ).count;
   return (
-    <SidebarLayout>
-      <UILayout>
-        <div>
-          <UITitle>Inbox</UITitle>
-          <UIWelcome>
-            Hi there 👋
-            {unreadTasksCount > 0 && (
-              <>
-                {" "}
-                You have <UIUnreadIndicator>{unreadTasksCount} new unread</UIUnreadIndicator>{" "}
-                {pluralize(unreadTasksCount, "request", "requests")}.
-              </>
-            )}
-          </UIWelcome>
-        </div>
-        <RequestsStream topics={openTopics.all} />
-      </UILayout>
-    </SidebarLayout>
+    <UILayout>
+      <div>
+        <UITitle>Inbox</UITitle>
+        <UIWelcome>
+          Hi there 👋
+          {unreadTasksCount > 0 && (
+            <>
+              {" "}
+              You have <UIUnreadIndicator>{unreadTasksCount} new unread</UIUnreadIndicator>{" "}
+              {pluralize(unreadTasksCount, "request", "requests")}.
+            </>
+          )}
+        </UIWelcome>
+      </div>
+      <RequestsStream topics={openTopics.all} />
+    </UILayout>
   );
 });
 

--- a/frontend/src/views/TopicOrNewRequestPage.tsx
+++ b/frontend/src/views/TopicOrNewRequestPage.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useDb } from "~frontend/clientdb";
 import { useRouteParamsIfRouteActive } from "~frontend/hooks/useRouteParams";
 import { SidebarLayout } from "~frontend/layouts/SidebarLayout";
+import { assignPageLayout } from "~frontend/utils/pageLayout";
 import { NewRequestView } from "~frontend/views/NewRequestView";
 import { RequestView } from "~frontend/views/RequestView";
 import { routes } from "~shared/routes";
@@ -17,18 +18,12 @@ export const TopicOrNewRequestPage = observer(function TopicOrNewRequestPage(): 
   if (topicByHandleParams?.topicId) {
     const topic = db.topic.findById(topicByHandleParams.topicId);
 
-    return (
-      <SidebarLayout>
-        <RequestView topic={topic} />
-      </SidebarLayout>
-    );
+    return <RequestView topic={topic} />;
   }
 
   const topicToDuplicateId = duplicateRouteParams?.topicId;
   const topicToDuplicate = topicToDuplicateId ? db.topic.findById(topicToDuplicateId) : null;
-  return (
-    <SidebarLayout>
-      <NewRequestView _legacyHideIfCreatingInModal topicToDuplicate={topicToDuplicate ?? undefined} />
-    </SidebarLayout>
-  );
+  return <NewRequestView _legacyHideIfCreatingInModal topicToDuplicate={topicToDuplicate ?? undefined} />;
 });
+
+assignPageLayout(TopicOrNewRequestPage, SidebarLayout);


### PR DESCRIPTION
As anticipated by some, the pruning in #775 was a bit over-eager, this is the PR where we bring back page-layout to reduce flicker (and incidentally re-renders) for inbox/settings/topic-page switching.