### PR TITLE
fix(slack): working install url for new creator

### DIFF
--- a/backend/src/slack/hasuraActions.ts
+++ b/backend/src/slack/hasuraActions.ts
@@ -26,7 +26,14 @@ export const getTeamSlackInstallationURLHandler: ActionHandler<
   async handle(userId, { input: { team_id, redirectURL } }) {
     assert(userId, "userId is required");
     const team = await db.team.findFirst({
-      where: { id: team_id, team_member: { some: { user_id: userId } } },
+      where: {
+        id: team_id,
+        OR: [
+          // During the initial setup flow the owner might not have been added as a team_member yet
+          { owner_id: userId },
+          { team_member: { some: { user_id: userId } } },
+        ],
+      },
       include: { team_member: true, team_slack_installation: true },
     });
     assert(team, new UnprocessableEntityError(`Team ${team_id} for member ${userId} not found`));


### PR DESCRIPTION
Fixes an issue where the slack install button would sometimes not work in th e onboarding flow. It does not repro in dev as frontend takes a bit longer here, thus giving the backend enough time to add the `team.owner` as a `team_member` (which happens in an hasura event).