### PR TITLE
fix(slack): use plain message content for self-request title

### DIFF
--- a/backend/src/slack/create-request-modal/messageSelfRequest.ts
+++ b/backend/src/slack/create-request-modal/messageSelfRequest.ts
@@ -4,7 +4,6 @@ import { assertToken } from "../utils";
 import { createAndTrackRequestInSlack } from "./createRequestInSlack";
 import { requestSlackAuthorizedOrOpenAuthModalForMessageShortcut } from "./requestSlackAuthorized";
 import { MessageShortcutRequest } from "./types";
-import { createRequestTitleFromMessageText } from "./utils";
 
 export async function handleMessageSelfRequestShortcut(request: MessageShortcutRequest) {
   const {
@@ -42,9 +41,6 @@ export async function handleMessageSelfRequestShortcut(request: MessageShortcutR
 
   const messageBodyWithMessageLink = message.text + `\n\n> from <${messageUrl.permalink}|slack message>`;
 
-  // We dont want to include 'from message' in title
-  const requestTitle = createRequestTitleFromMessageText(messageBody);
-
   await createAndTrackRequestInSlack({
     messageText: messageBodyWithMessageLink,
     slackTeamId: slackTeamId,
@@ -61,7 +57,6 @@ export async function handleMessageSelfRequestShortcut(request: MessageShortcutR
     client,
     triggerId,
     botToken: context.botToken,
-    topicName: requestTitle,
   });
 
   trackBackendUserEvent(authInfo.user.id, "Used Slack Self Request Message Action", { slackUserName });


### PR DESCRIPTION
The fix was to remove a piece of code that did not do much, which re-enables getting the request title from the plain message content (as that's what `createRequestYadaYada` does when no `topicName` is passed in). The deleted code in question only stripped "from slack message" from the original slack message, to which it was not even added. So it basically no-op'd and returned the slack message text. Probably some refactory confusion 🤷🏼 