### PR TITLE
feat(desktop): bridge for client<>electron communication

### DIFF
--- a/desktop/bridge/base.ts
+++ b/desktop/bridge/base.ts
@@ -1,0 +1,104 @@
+import type { BrowserWindow, IpcMainInvokeEvent } from "electron";
+
+/**
+ * Important note!
+ *
+ * TLDR: Don't import any runtime thing from electron in this file. This file is imported both by electron and client
+ *
+ * Utils here allows creating type-safe bridge between electron and client.
+ * Those are only bridges - meaning they're not implementing any handling of given bridge events.
+ *
+ *
+ */
+
+/**
+ * Will create 'request' bridge - promise style requests from client to electron.
+ *
+ * Each invoke bridge needs to have handler added somewhere in electron to be able to be invoked.
+ */
+export function createInvokeBridge<Result, Input = void>(key: string) {
+  async function invoke(input: Input): Promise<Result> {
+    if (process.env.ELECTRON_CONTEXT !== "client") {
+      throw new Error(`Invoke can only be called on client side`);
+    }
+
+    return window.electronBridge.invoke(key, input);
+  }
+
+  /**
+   * Function needed to add electron side implementation that can handle given request
+   */
+  invoke.handle = (handler: (input: Input, event: IpcMainInvokeEvent) => Promise<Result>) => {
+    if (process.env.ELECTRON_CONTEXT === "client") {
+      throw new Error(`Cannot handle client side`);
+    }
+    /**
+     * Important note - we're not importing `ipcMain` in this file. This file is imported both by client and electron,
+     * thus we cannot import any runtime code from electron here.
+     *
+     * ipcMain is set in global context for electron and is available this way.
+     */
+    global.electronGlobal.ipcMain.handle(key, async (event, arg: Input) => {
+      const result = await handler(arg, event);
+
+      return result;
+    });
+  };
+
+  return invoke;
+}
+
+export type ElectronChannelSubscriber<T> = (data: T, event: ElectronChannelEventUnified<T>) => void;
+export type ElectronSubscribeCleanup = () => void;
+
+interface ElectronChannelEventUnified<T> {
+  reply: (data: T) => void;
+}
+
+/**
+ * Creates bridge channel that can be subscribed on from both sides.
+ */
+export function createChannelBridge<Data>(key: string) {
+  function subscribe(subscriber: ElectronChannelSubscriber<Data>) {
+    if (process.env.ELECTRON_CONTEXT === "client") {
+      return window.electronBridge.subscribe(key, subscriber);
+    } else {
+      return global.electronGlobal.subscribe(key, subscriber);
+    }
+  }
+
+  /**
+   * Allows sending messages from client to electron.
+   *
+   * Important note!
+   * There is one 'electron' process, but there can be multiple client processes. (multiple BrowserWindow's)
+   *
+   * Thus sending client > electron is obvious - there is only one electron, we know where to send it to
+   * but sending electron > client also requires specifying to which window we're sending, thus is handled in `sendFromElectron`
+   */
+  function send(data: Data) {
+    if (process.env.ELECTRON_CONTEXT === "client") {
+      return window.electronBridge.send(key, data);
+    } else {
+      throw new Error(
+        `If sending messages from electron to client - you need to specify to which window you're sending - use sendFromElectron instead.`
+      );
+    }
+  }
+
+  /**
+   * Allows sending data to specified window from electron
+   */
+  function sendFromElectron(targetWindow: BrowserWindow, data: Data) {
+    if (process.env.ELECTRON_CONTEXT === "client") {
+      throw new Error(`Cannot use sendFromElectron on client side`);
+    }
+    targetWindow.webContents.send(key, data);
+  }
+
+  return {
+    subscribe,
+    send,
+    sendFromElectron,
+  };
+}

--- a/desktop/bridge/foo.ts
+++ b/desktop/bridge/foo.ts
@@ -1,0 +1,16 @@
+import { createChannelBridge, createInvokeBridge } from "./base";
+
+/**
+ * This is an example how bridges are defined
+ */
+
+/**
+ * This is invoke bridge - it is imported by client to be able te send requests.
+ * It is imported by electron to add handler that is able to handle requests.
+ */
+export const getFoo = createInvokeBridge<string, string>("foo");
+
+/**
+ * This is channel bridge - can be imported by both electron and client, allowing both to subscribe or send messages
+ */
+export const pingPongChannel = createChannelBridge<string>("ping-pong");

--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -1,15 +1,46 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { render } from "react-dom";
 
+import { getFoo, pingPongChannel } from "@aca/desktop/bridge/foo";
 import { TestView } from "@aca/desktop/views/TestView";
+import { createInterval } from "@aca/shared/time";
 import { Button } from "@aca/ui/buttons/Button";
 
 const rootElement = document.getElementById("root");
 
-render(
-  <div>
-    <Button kind="primary">Button test</Button>
-    Hello from react <TestView />
-  </div>,
-  rootElement
-);
+function App() {
+  async function handleInvoke() {
+    getFoo("foo").then((result) => {
+      alert(result);
+    });
+  }
+
+  useEffect(() => {
+    const cleanSending = createInterval(() => {
+      const message = `ping - ${Math.random()}`;
+
+      console.info("sending", message);
+      pingPongChannel.send(message);
+    }, 1000);
+
+    const cleanListening = pingPongChannel.subscribe((response) => {
+      console.info(`Got response - ${response}`);
+    });
+
+    return () => {
+      cleanSending();
+      cleanListening();
+    };
+  });
+  return (
+    <div>
+      <Button kind="primary" onClick={handleInvoke}>
+        Invoke test3
+      </Button>
+      <Button kind="primary">Button test</Button>
+      Hello from react <TestView />
+    </div>
+  );
+}
+
+render(<App />, rootElement);

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -51,7 +51,21 @@ const electronBundler = new Parcel({
       includeNodeModules: ["@aca/shared", "@aca/ui", "@aca/config", "@aca/db", "@aca/gql", "@aca/desktop"],
     },
   },
+  env: {
+    ELECTRON_CONTEXT: "electron",
+  } as NodeJS.ProcessEnv,
 });
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    // Let's extend ProcessEnv to provide process.env autocompletion
+    export interface ProcessEnv {
+      // It is possible to narrow down types of some env variables here.
+      ELECTRON_CONTEXT: "client" | "electron";
+    }
+  }
+}
 
 // Client code bundler
 const clientBundler = new Parcel({
@@ -75,8 +89,12 @@ const clientBundler = new Parcel({
       context: "browser",
       scopeHoist: true,
       outputFormat: "commonjs",
+      optimize: true,
     },
   },
+  env: {
+    ELECTRON_CONTEXT: "client",
+  } as NodeJS.ProcessEnv,
 });
 
 async function start() {

--- a/desktop/electron/bridgeHandlers/foo.ts
+++ b/desktop/electron/bridgeHandlers/foo.ts
@@ -1,0 +1,12 @@
+import { getFoo, pingPongChannel } from "@aca/desktop/bridge/foo";
+
+export function initializeFooBridge() {
+  getFoo.handle(async (input) => {
+    return `super ${input}`;
+  });
+
+  pingPongChannel.subscribe((message, event) => {
+    console.info("got message", message);
+    event.reply(`pong (${message})`);
+  });
+}

--- a/desktop/electron/bridgeHandlers/index.ts
+++ b/desktop/electron/bridgeHandlers/index.ts
@@ -1,0 +1,5 @@
+import { initializeFooBridge } from "./foo";
+
+export function initializeBridgeHandlers() {
+  initializeFooBridge();
+}

--- a/desktop/electron/globals.ts
+++ b/desktop/electron/globals.ts
@@ -1,0 +1,42 @@
+import { IpcMainEvent, ipcMain } from "electron";
+
+import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base";
+
+/**
+ * Important note.
+ *
+ * We pass ipcMain to global on electron side to be able use it in files that are imported both by electron and client.
+ * This is used in `bridge/base`, under proper abstraction.
+ *
+ * This should not be used directly in other places. If some file is imported only by electron side -
+ * simply `import { ipcMain } from 'electron'`
+ */
+const electronGlobal = {
+  ipcMain: ipcMain,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subscribe: (channel: string, subscriber: ElectronChannelSubscriber<any>) => {
+    function handler(event: IpcMainEvent, data: unknown) {
+      subscriber(data, {
+        reply(data: unknown) {
+          event.reply(channel, data);
+        },
+      });
+    }
+    ipcMain.on(channel, handler);
+
+    return function cancel() {
+      ipcMain.off(channel, handler);
+    };
+  },
+};
+
+type ElectronGlobal = typeof electronGlobal;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var electronGlobal: ElectronGlobal;
+}
+
+export {};
+
+global.electronGlobal = electronGlobal;

--- a/desktop/electron/index.ts
+++ b/desktop/electron/index.ts
@@ -1,8 +1,12 @@
+import "./globals";
+import "./bridgeHandlers";
+
 import path from "path";
 
 import { BrowserWindow, app } from "electron";
 import IS_DEV from "electron-is-dev";
 
+import { initializeBridgeHandlers } from "./bridgeHandlers";
 import { initializeProtocolHandlers } from "./protocol";
 
 // Note - please always use 'path' module for paths (especially with slashes) instead of eg `${pathA}/${pathB}` to avoid breaking it on windows.
@@ -19,6 +23,7 @@ function initializeMainWindow() {
     width: 900,
     height: 680,
     webPreferences: {
+      contextIsolation: true,
       preload: path.resolve(__dirname, "preload.js"),
     },
   });
@@ -40,6 +45,7 @@ function initializeMainWindow() {
 function initializeApp() {
   initializeMainWindow();
   initializeProtocolHandlers();
+  initializeBridgeHandlers();
 }
 
 app.on("ready", initializeApp);

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1,25 +1,54 @@
-import { contextBridge } from "electron";
+import { IpcRendererEvent, contextBridge, ipcRenderer } from "electron";
 
-import { IS_DEV } from "@aca/shared/dev";
+import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base";
 
 /**
  * This is what is published from electron api to browser.
  *
- * It is not possible to import anything from 'electron' directly in browser - it has to be published here.
+ * TLDR (aka. why?): Electron API is powerful and we don't want all of it to be directly available in the browser.
+ *
+ * Read: https://www.electronjs.org/docs/latest/tutorial/context-isolation
+ *
+ * Note: It is not possible to import anything from 'electron' directly in browser - it has to be published here.
+ *
+ * Note2: This file can grow large, we can be splitted.
+ * It can be a good place to publish specific APIS like 'Clipboard' access, requesting (and checking) system calendar permissions, etc.
+ *
+ * We should be careful here, tho, especially if we're loading some arbitral javascript in the browser we do not control.
+ * eg. if we publish filesystem API here without careful checks - it might potentially lead to serious security issues.
  */
 const publishedApi = {
-  loadPreferences: async () => {
-    //
-    console.info(IS_DEV);
+  invoke: async (key: string, data: unknown) => {
+    // TODO (security): reject other channels than registered bridges
+    return ipcRenderer.invoke(key, data);
   },
-  foo: () => 42,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subscribe: (channel: string, subscriber: ElectronChannelSubscriber<any>) => {
+    // TODO (security): reject other channels than registered bridges
+    function handler(event: IpcRendererEvent, data: unknown) {
+      subscriber(data, {
+        reply(data: unknown) {
+          ipcRenderer.send(channel, data);
+        },
+      });
+    }
+    ipcRenderer.on(channel, handler);
+
+    return function cancel() {
+      ipcRenderer.off(channel, handler);
+    };
+  },
+  send: (channel: string, data: unknown) => {
+    // TODO (security): reject other channels than registered bridges
+    ipcRenderer.send(channel, data);
+  },
 };
 
 export type ElectronPublishedAPI = typeof publishedApi;
 
 declare global {
   interface Window {
-    electronAPI: ElectronPublishedAPI;
+    electronBridge: ElectronPublishedAPI;
   }
 }
 


### PR DESCRIPTION
Introduced bridge for communicating between client<>electron in type safe way, also creating a thin abstraction layer that strongly couples definition and calling given 'thing' across the bridge

Gif: console from electron and browser ping-ponging each other (channel), clicking button and showing response from electron in the browser (invoke)
![CleanShot 2022-01-13 at 15 06 28](https://user-images.githubusercontent.com/7311462/149345040-1f0b9233-f1a9-4983-8ba3-71e275624748.gif)

