### PR TITLE
feat(desktop): auth token flow finished and value persisted

### DIFF
--- a/desktop/bridge/auth.ts
+++ b/desktop/bridge/auth.ts
@@ -1,0 +1,3 @@
+import { createElectronPersistedValue } from "./base/persistance";
+
+export const authTokenBridgeValue = createElectronPersistedValue<string | null>("auth-token", () => null);

--- a/desktop/bridge/base/persistance.ts
+++ b/desktop/bridge/base/persistance.ts
@@ -1,0 +1,47 @@
+import { createChannel } from "@aca/shared/channel";
+
+import { createChannelBridge, createInvokeBridge } from "./channels";
+
+export const requestPersistValue = createInvokeBridge<boolean, { key: string; data: unknown }>("requestPersistValue");
+export const requestGetPersistedValue = createInvokeBridge<unknown, string>("requestGetPersistedValue");
+
+export const persistedValueChangeRequestChannel = createChannelBridge<{ key: string; data: unknown }>(
+  "persistedValueChangeRequestChannel"
+);
+
+export function createElectronPersistedValue<T>(valueKey: string, getDefault: () => T) {
+  const localChannel = createChannel<T>();
+
+  setTimeout(() => {
+    requestGetPersistedValue(valueKey).then((value) => {
+      if (value !== null) {
+        localChannel.publish(value as T);
+      }
+    });
+  }, 1);
+
+  persistedValueChangeRequestChannel.subscribe(({ key, data }) => {
+    if (key !== valueKey) return;
+    localChannel.publish(data as T);
+  });
+
+  function set(value: T) {
+    localChannel.publish(value);
+    requestPersistValue({ key: valueKey, data: value });
+    persistedValueChangeRequestChannel.send({ key: valueKey, data: value });
+  }
+
+  function get() {
+    return localChannel.getLastValue() ?? getDefault();
+  }
+
+  function use() {
+    return localChannel.useLastValue() ?? getDefault();
+  }
+
+  return {
+    get,
+    set,
+    use,
+  };
+}

--- a/desktop/bridge/foo.ts
+++ b/desktop/bridge/foo.ts
@@ -1,4 +1,4 @@
-import { createChannelBridge, createInvokeBridge } from "./base";
+import { createChannelBridge, createInvokeBridge } from "./base/channels";
 
 /**
  * This is an example how bridges are defined

--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -6,13 +6,20 @@ import { TestView } from "@aca/desktop/views/TestView";
 import { createInterval } from "@aca/shared/time";
 import { Button } from "@aca/ui/buttons/Button";
 
+import { authTokenBridgeValue } from "../bridge/auth";
+
 const rootElement = document.getElementById("root");
 
 function App() {
+  const token = authTokenBridgeValue.use();
   async function handleInvoke() {
     getFoo("foo").then((result) => {
       alert(result);
     });
+  }
+
+  function handleLogOut() {
+    authTokenBridgeValue.set(null);
   }
 
   useEffect(() => {
@@ -39,6 +46,12 @@ function App() {
       </Button>
       <Button kind="primary">Button test</Button>
       Hello from react <TestView />
+      <div>Token: {JSON.stringify(token)}</div>
+      {!!token && (
+        <Button kind="primary" onClick={handleLogOut}>
+          Log out
+        </Button>
+      )}
     </div>
   );
 }

--- a/desktop/electron/bridgeHandlers/index.ts
+++ b/desktop/electron/bridgeHandlers/index.ts
@@ -1,5 +1,7 @@
 import { initializeFooBridge } from "./foo";
+import { initializePersistance } from "./persistance";
 
 export function initializeBridgeHandlers() {
+  initializePersistance();
   initializeFooBridge();
 }

--- a/desktop/electron/bridgeHandlers/persistance.ts
+++ b/desktop/electron/bridgeHandlers/persistance.ts
@@ -1,0 +1,36 @@
+import os from "os";
+
+import storage from "electron-json-storage";
+
+import { requestGetPersistedValue, requestPersistValue } from "@aca/desktop/bridge/base/persistance";
+
+export function initializePersistance() {
+  storage.setDataPath(os.tmpdir());
+
+  requestPersistValue.handle(async ({ key, data }) => {
+    console.info(`Persisting value ${key}`);
+    await persistValue(key, data);
+    return true;
+  });
+
+  requestGetPersistedValue.handle(async (key) => {
+    console.info(`Get persisted value ${key}`);
+    return getPersistedValue(key);
+  });
+}
+
+function persistValue<T>(key: string, value: T) {
+  return new Promise<void>((resolve) => {
+    storage.set(key, value as unknown as object, () => {
+      resolve();
+    });
+  });
+}
+
+function getPersistedValue<T>(key: string) {
+  return new Promise<T>((resolve) => {
+    storage.get(key, (error, value) => {
+      resolve(value as unknown as T);
+    });
+  });
+}

--- a/desktop/electron/globals.ts
+++ b/desktop/electron/globals.ts
@@ -1,6 +1,6 @@
-import { IpcMainEvent, ipcMain } from "electron";
+import { BrowserWindow, IpcMainEvent, app, ipcMain } from "electron";
 
-import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base";
+import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base/channels";
 
 /**
  * Important note.
@@ -13,6 +13,8 @@ import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base";
  */
 const electronGlobal = {
   ipcMain: ipcMain,
+  BrowserWindow: BrowserWindow,
+  appReadyPromise: app.whenReady(),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   subscribe: (channel: string, subscriber: ElectronChannelSubscriber<any>) => {
     function handler(event: IpcMainEvent, data: unknown) {

--- a/desktop/electron/index.ts
+++ b/desktop/electron/index.ts
@@ -1,5 +1,4 @@
 import "./globals";
-import "./bridgeHandlers";
 
 import path from "path";
 
@@ -43,9 +42,9 @@ function initializeMainWindow() {
 }
 
 function initializeApp() {
+  initializeBridgeHandlers();
   initializeMainWindow();
   initializeProtocolHandlers();
-  initializeBridgeHandlers();
 }
 
 app.on("ready", initializeApp);

--- a/desktop/electron/preload.ts
+++ b/desktop/electron/preload.ts
@@ -1,6 +1,6 @@
 import { IpcRendererEvent, contextBridge, ipcRenderer } from "electron";
 
-import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base";
+import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base/channels";
 
 /**
  * This is what is published from electron api to browser.

--- a/desktop/electron/protocol/index.ts
+++ b/desktop/electron/protocol/index.ts
@@ -1,4 +1,6 @@
-import { app, dialog } from "electron";
+import { app } from "electron";
+
+import { authTokenBridgeValue } from "@aca/desktop/bridge/auth";
 
 import { handleUrlWithPattern } from "./urlPattern";
 
@@ -14,7 +16,7 @@ function handleAppReceivedUrl(url: string) {
 
   // Handle auth token received
   handleUrlWithPattern("authorize/:token", path, ({ token }) => {
-    dialog.showErrorBox("Auth", `Auth token received: ${token}`);
+    authTokenBridgeValue.set(token);
   });
 }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,10 +16,12 @@
     "@types/node-cleanup": "^2.1.2",
     "electron": "^16.0.6",
     "electron-is-dev": "^2.0.0",
+    "electron-json-storage": "^4.5.0",
     "node-cleanup": "^2.1.2",
     "url-pattern": "^1.0.3"
   },
   "devDependencies": {
+    "@types/electron-json-storage": "^4.5.0",
     "parcel": "^2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,9 +87,11 @@ __metadata:
   dependencies:
     "@parcel/config-default": ^2.1.1
     "@parcel/core": ^2.1.1
+    "@types/electron-json-storage": ^4.5.0
     "@types/node-cleanup": ^2.1.2
     electron: ^16.0.6
     electron-is-dev: ^2.0.0
+    electron-json-storage: ^4.5.0
     node-cleanup: ^2.1.2
     parcel: ^2.1.1
     url-pattern: ^1.0.3
@@ -5585,6 +5587,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/electron-json-storage@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@types/electron-json-storage@npm:4.5.0"
+  checksum: 0ce33c9fe756588f59e1ed24919f91ceb89dd78d5abf2e191d6a68b07800aadb0302feda87900d4f1c8df2142d189db99f5cd5f00b377be4d67022996c9ec8eb
+  languageName: node
+  linkType: hard
+
 "@types/emoji-mart@npm:^3.0.9":
   version: 3.0.9
   resolution: "@types/emoji-mart@npm:3.0.9"
@@ -7141,6 +7150,15 @@ __metadata:
   version: 0.9.2
   resolution: "async@npm:0.9.2"
   checksum: 87dbf129292b8a6c32a4e07f43f462498162aa86f404a7e11f978dbfdf75cfb163c26833684bb07b9d436083cd604cbbf730a57bfcbe436c6ae1ed266cdc56bb
+  languageName: node
+  linkType: hard
+
+"async@npm:^2.0.0":
+  version: 2.6.3
+  resolution: "async@npm:2.6.3"
+  dependencies:
+    lodash: ^4.17.14
+  checksum: 5e5561ff8fca807e88738533d620488ac03a5c43fce6c937451f7e35f943d33ad06c24af3f681a48cca3d2b0002b3118faff0a128dc89438a9bf0226f712c499
   languageName: node
   linkType: hard
 
@@ -10367,6 +10385,20 @@ __metadata:
   version: 2.0.0
   resolution: "electron-is-dev@npm:2.0.0"
   checksum: 7393f46f06153d70a427ea904c60a092e50fbf1015c26c342cebb8324ada8c9e0c0f1f02867af56d9cc76f47be17da8cb311ea6bdc83343e7ebd2323ec4014c8
+  languageName: node
+  linkType: hard
+
+"electron-json-storage@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "electron-json-storage@npm:4.5.0"
+  dependencies:
+    async: ^2.0.0
+    lockfile: ^1.0.4
+    lodash: ^4.0.1
+    mkdirp: ^0.5.1
+    rimraf: ^2.5.1
+    write-file-atomic: ^2.4.2
+  checksum: 25b0cbfed7c0020b4ce0e9422933ea717441efbfb5918751b6acd115b4a375bdcdca2cb5564b7c1aa16ef56aa0d845b89e83d69f2e9bdccdc3e8c71cc354f858
   languageName: node
   linkType: hard
 
@@ -15811,6 +15843,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lockfile@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "lockfile@npm:1.0.4"
+  dependencies:
+    signal-exit: ^3.0.2
+  checksum: 8de35aace8acbe883cbca3cc3959e88904d57c79dccd4afffc64aea8f9cf7b4c63598d08b8add66fbf381f8fb3ce4fd4c518cd231c797c266b6c790eb7b33abc
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -15923,7 +15964,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0, lodash@npm:~4.17.0":
+"lodash@npm:4.17.21, lodash@npm:^4.0.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0, lodash@npm:~4.17.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -20785,7 +20826,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.1":
+"rimraf@npm:^2.5.1, rimraf@npm:^2.6.1":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:
@@ -23968,6 +24009,17 @@ fsevents@^1.2.7:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  languageName: node
+  linkType: hard
+
+"write-file-atomic@npm:^2.4.2":
+  version: 2.4.3
+  resolution: "write-file-atomic@npm:2.4.3"
+  dependencies:
+    graceful-fs: ^4.1.11
+    imurmurhash: ^0.1.4
+    signal-exit: ^3.0.2
+  checksum: 2db81f92ae974fd87ab4a5e7932feacaca626679a7c98fcc73ad8fcea5a1950eab32fa831f79e9391ac99b562ca091ad49be37a79045bd65f595efbb8f4596ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Auth token is shared between electron and client
- is persisted
- UI is reacting to token changes
- even if app is fully closed - token is still persisted

Note: I'm not fully happy with persisted values API, but we can polish it later
Note2: Token is initially null, and then 'fetched' from electron in client. This can be avoided by passing tokens in sync way during electron init somehow, but did skip it now, as it'd require a bit of additional setup work


![CleanShot 2022-01-14 at 10 47 41](https://user-images.githubusercontent.com/7311462/149495097-99482962-a494-4b30-a553-8da17a3de174.gif)

