### PR TITLE
ui: basic electron styles

### DIFF
--- a/desktop/client/index.html
+++ b/desktop/client/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Acapela</title>
   </head>
-  <body>
+  <body class="desktop">
     <div id="root"></div>
     <script type="module" src="./index.tsx"></script>
   </body>

--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -10,6 +10,7 @@ import { TooltipsRenderer } from "@aca/ui/popovers/TooltipsRenderer";
 import { AppThemeProvider, theme } from "@aca/ui/theme";
 import { ToastsRenderer } from "@aca/ui/toasts/ToastsRenderer";
 
+import { GlobalDesktopStyles } from "../styles/GlobalDesktopStyles";
 import { RootView } from "../views/RootView";
 import { SidebarLayout } from "../views/sidebar";
 
@@ -22,6 +23,7 @@ const BuiltInStyles = createGlobalStyle`
 render(
   <>
     <BuiltInStyles />
+    <GlobalDesktopStyles />
     <MotionConfig transition={{ ...POP_ANIMATION_CONFIG }}>
       <AppThemeProvider theme={theme}>
         <PromiseUIRenderer />

--- a/desktop/electron/index.ts
+++ b/desktop/electron/index.ts
@@ -27,6 +27,8 @@ function initializeMainWindow() {
       contextIsolation: true,
       preload: path.resolve(__dirname, "preload.js"),
     },
+    titleBarStyle: "hidden",
+    fullscreenable: false,
   });
 
   mainWindow.loadURL(

--- a/desktop/styles/GlobalDesktopStyles.tsx
+++ b/desktop/styles/GlobalDesktopStyles.tsx
@@ -1,0 +1,8 @@
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalDesktopStyles = createGlobalStyle`
+  body.desktop {
+    --pointer: default;
+    -webkit-app-region: drag;
+  }
+`;

--- a/desktop/styles/titleBar.ts
+++ b/desktop/styles/titleBar.ts
@@ -1,0 +1,7 @@
+import { css } from "styled-components";
+
+export const DESKTOP_TITLE_BAR_HEIGHT = 28;
+
+export const avoidTitleBarPadding = css`
+  padding-top: ${DESKTOP_TITLE_BAR_HEIGHT}px;
+`;

--- a/desktop/views/sidebar/index.tsx
+++ b/desktop/views/sidebar/index.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 
+import { avoidTitleBarPadding } from "@aca/desktop/styles/titleBar";
 import { theme } from "@aca/ui/theme";
 
 import { SidebarContent } from "./content";
@@ -27,6 +28,7 @@ const UISidebar = styled.div<{}>`
   height: 100vh;
   max-height: 100vh;
   ${theme.colors.layout.backgroundAccent.asBg};
+  ${avoidTitleBarPadding}
 
   box-sizing: border-box;
   flex-shrink: 0;

--- a/frontend/styles/global.ts
+++ b/frontend/styles/global.ts
@@ -21,6 +21,10 @@ export const global = css`
     color: #232b35;
   }
 
+  body {
+    --pointer: pointer;
+  }
+
   body.css-debug {
     * {
       outline: 1px solid red;

--- a/ui/buttons/Button.tsx
+++ b/ui/buttons/Button.tsx
@@ -115,7 +115,7 @@ export const baseButtonStyles = css`
   align-items: center;
   justify-content: center;
   white-space: nowrap;
-  cursor: pointer;
+  cursor: var(--pointer);
 
   ${theme.typo.content.medium.resetLineHeight};
   ${theme.radius.secondaryItem};
@@ -123,7 +123,7 @@ export const baseButtonStyles = css`
 
   a & {
     /* It is possible that button is inside <a> tag without having onClick handler. It means it should also have cursor pointer. */
-    cursor: pointer;
+    cursor: var(--pointer);
   }
 
   ${theme.transitions.hover()}


### PR DESCRIPTION
<img width="478" alt="CleanShot 2022-01-14 at 16 02 23@2x" src="https://user-images.githubusercontent.com/7311462/149537018-9c81800b-f4b6-4a85-9761-9912b348905a.png">

- removed title bar
- made window draggable without title bar
- buttons use 'default' mouse pointer instead of 'pointing finger' (this is default on desktop apps comparing with web)