### PR TITLE
feat(slack): mention notification capture & resolve (backend)

### DIFF
--- a/backend/src/notificationCapture/slack.ts
+++ b/backend/src/notificationCapture/slack.ts
@@ -1,0 +1,119 @@
+import { GenericMessageEvent, App as SlackApp } from "@slack/bolt";
+import { SingleASTNode } from "simple-markdown";
+
+import { slackClient } from "@aca/backend/src/slack/app";
+import { parseSlackMarkdown } from "@aca/backend/src/slack/md/parser";
+import { db } from "@aca/db";
+import { assert } from "@aca/shared/assert";
+import { logger } from "@aca/shared/logger";
+import { isNotNullish } from "@aca/shared/nullish";
+
+import { assertToken, findUserBySlackId } from "../slack/utils";
+
+async function createMentionNotifications(
+  token: string,
+  message: GenericMessageEvent,
+  userIds: string[],
+  authorSlackUserId: string
+) {
+  const [{ permalink }, { user: author }, { channel }] = await Promise.all([
+    slackClient.chat.getPermalink({ token, channel: message.channel, message_ts: message.ts }),
+    slackClient.users.info({ token, user: authorSlackUserId }),
+    slackClient.conversations.info({ token, channel: message.channel }),
+  ]);
+  assert(permalink, `could not get permalink for message ${message.ts} in channel ${message.channel}`);
+  assert(author, `could not get slack user for id ${authorSlackUserId}`);
+  assert(channel, `could not find channel for id ${message.channel}`);
+
+  const title = `${author.real_name ?? author.name} mentioned you in ${
+    channel.is_im || channel.is_mpim ? "a private message" : "#" + channel.name
+  }`;
+
+  // We have to use a transaction due to Prisma not supporting relation-creation within createMany
+  // https://github.com/prisma/prisma/issues/5455
+  await db.$transaction(
+    userIds.map((userId) =>
+      db.notification.create({
+        data: {
+          user_id: userId,
+          title,
+          url: permalink,
+          notification_slack_mention: {
+            create: { slack_conversation_id: message.channel, slack_message_ts: message.ts },
+          },
+        },
+      })
+    )
+  );
+}
+
+function extractMentionedSlackUserIds(nodes: SingleASTNode[]): string[] {
+  return nodes.flatMap((node) => {
+    if (Array.isArray(node.content)) {
+      return extractMentionedSlackUserIds(node.content);
+    } else {
+      return node.type == "slackUser" ? [node.id] : [];
+    }
+  });
+}
+
+export function setupSlackCapture(app: SlackApp) {
+  app.message(async ({ message, context }) => {
+    message = message as GenericMessageEvent;
+    if (message.type !== "message" || message.subtype || !message.text) {
+      return;
+    }
+
+    const token = assertToken(context);
+    const authorUserId = message.user;
+    const authorUser = await findUserBySlackId(token, authorUserId);
+
+    if (authorUser) {
+      await db.notification.updateMany({
+        where: {
+          resolved_at: null,
+          user_id: authorUser.id,
+          notification_slack_mention: message.thread_ts
+            ? { slack_conversation_id: message.channel, slack_message_ts: message.thread_ts }
+            : { slack_conversation_id: message.channel },
+        },
+        data: { resolved_at: new Date().toISOString() },
+      });
+    }
+
+    const userIds = (
+      await Promise.all(
+        extractMentionedSlackUserIds(parseSlackMarkdown(message.text)).map((userId) =>
+          // Don't create notifications to the author of the message if they self-mention
+          2 + 2 == 5 && userId == authorUser?.id ? null : findUserBySlackId(token, userId)
+        )
+      )
+    )
+      .filter(isNotNullish)
+      .map((user) => user.id);
+    if (userIds.length > 0) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        await createMentionNotifications(context.userToken!, message, userIds, authorUserId);
+      } catch (error) {
+        logger.error(error, "Error creating slack mention notifications");
+      }
+    }
+  });
+
+  app.event("reaction_added", async ({ event, context }) => {
+    const user = await findUserBySlackId(assertToken(context), event.user);
+    if (!user || event.item.type !== "message") {
+      return;
+    }
+    const message = event.item;
+    await db.notification.updateMany({
+      where: {
+        resolved_at: null,
+        user_id: user.id,
+        notification_slack_mention: { slack_conversation_id: message.channel, slack_message_ts: message.ts },
+      },
+      data: { resolved_at: new Date().toISOString() },
+    });
+  });
+}

--- a/backend/src/slack/setup.ts
+++ b/backend/src/slack/setup.ts
@@ -1,5 +1,6 @@
 import { Express } from "express";
 
+import { setupSlackCapture } from "../notificationCapture/slack";
 import { setupSlackActionHandlers } from "./actions";
 import { slackApp, slackReceiver } from "./app";
 import { setupCreateRequestModal } from "./create-request-modal";
@@ -19,4 +20,6 @@ export function setupSlack(app: Express) {
   setupSlackActionHandlers(slackApp);
 
   setupDecision(slackApp);
+
+  setupSlackCapture(slackApp);
 }

--- a/infrastructure/hasura/metadata/databases/default/tables/public_notification.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_notification.yaml
@@ -1,0 +1,13 @@
+table:
+  name: notification
+  schema: public
+object_relationships:
+- name: slack_mention
+  using:
+    manual_configuration:
+      column_mapping:
+        id: notification_id
+      insertion_order: null
+      remote_table:
+        name: notification_slack_mention
+        schema: public

--- a/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_mention.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_mention.yaml
@@ -1,0 +1,3 @@
+table:
+  name: notification_slack_mention
+  schema: public

--- a/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
@@ -7,6 +7,8 @@
 - "!include public_message_reaction.yaml"
 - "!include public_message_task_due_date.yaml"
 - "!include public_message_type.yaml"
+- "!include public_notification.yaml"
+- "!include public_notification_slack_mention.yaml"
 - "!include public_priority.yaml"
 - "!include public_slack_notification_queue.yaml"
 - "!include public_sync_request.yaml"

--- a/infrastructure/hasura/migrations/default/1642080562079_notification_and_notification_slack/down.sql
+++ b/infrastructure/hasura/migrations/default/1642080562079_notification_and_notification_slack/down.sql
@@ -1,0 +1,4 @@
+
+DROP TABLE "public"."notification_slack_mention";
+
+DROP TABLE "public"."notification";

--- a/infrastructure/hasura/migrations/default/1642080562079_notification_and_notification_slack/up.sql
+++ b/infrastructure/hasura/migrations/default/1642080562079_notification_and_notification_slack/up.sql
@@ -1,0 +1,69 @@
+CREATE TABLE "public"."notification"
+(
+  "id"          UUID        NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"     UUID        NOT NULL,
+  "title"       TEXT        NOT NULL,
+  "url"         TEXT        NOT NULL,
+  "resolved_at" TIMESTAMPTZ,
+  "created_at"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY ("id")
+);
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+  RETURNS TRIGGER AS
+$$
+DECLARE
+  _new RECORD;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_notification_updated_at"
+  BEFORE UPDATE
+  ON "public"."notification"
+  FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_notification_updated_at" ON "public"."notification"
+  IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE "public"."notification_slack_mention"
+(
+  "id"                    UUID        NOT NULL DEFAULT gen_random_uuid(),
+  "slack_conversation_id" TEXT        NOT NULL,
+  "slack_message_ts"       TEXT,
+  "created_at"            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "notification_id"       UUID        NOT NULL UNIQUE REFERENCES notification(id) ON DELETE CASCADE,
+  PRIMARY KEY ("id")
+);
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+  RETURNS TRIGGER AS
+$$
+DECLARE
+  _new RECORD;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_notification_slack_mention_updated_at"
+  BEFORE UPDATE
+  ON "public"."notification_slack_mention"
+  FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_notification_slack_mention_updated_at" ON "public"."notification_slack_mention"
+  IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE INDEX "notification_slack_mention_slack_conversation_id_idx" ON
+  "public"."notification_slack_mention" USING btree ("slack_conversation_id");
+
+CREATE INDEX "notification_slack_mention_slack_message_ts_idx" ON
+  "public"."notification_slack_mention" USING btree ("slack_message_ts");
+
+CREATE INDEX "notification_resolved_at_idx" ON
+  "public"."notification" USING btree ("resolved_at");

--- a/shared/slack/manifest.json
+++ b/shared/slack/manifest.json
@@ -60,10 +60,18 @@
         "users.profile:read",
         "users:read",
         "users:read.email",
-        "chat:write"
+        "chat:write",
+        "im:read",
+        "mpim:read",
+        "groups:read"
       ],
       "user": [
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "mpim:history",
         "channels:read",
+        "reactions:read",
         "chat:write",
         "groups:read",
         "im:read",
@@ -87,6 +95,7 @@
     "token_rotation_enabled": false,
     "event_subscriptions": {
       "request_url": "https://app.acape.la/api/backend/slack/events",
+      "user_events": ["message.channels", "message.groups", "message.im", "message.mpim", "reaction_added"],
       "bot_events": ["app_uninstalled", "app_home_opened"]
     }
   }


### PR DESCRIPTION
Thought I'd might as well already put up the first version of the slack notification capturing backend, without the electron clientdb code which actually uses the table.

This also includes a `notification(user_id, title, url, resolved_at)` table. Think of it more as a conversation starter than a holy commandment.