### PR TITLE
feat(desktop): notification entity

### DIFF
--- a/desktop/clientdb/createNewClientDb.tsx
+++ b/desktop/clientdb/createNewClientDb.tsx
@@ -8,6 +8,7 @@ import { clientdbForceRefreshCount, increaseClientDBForceRefreshCount } from "@a
 import { IS_DEV, devAssignWindowVariable } from "@aca/shared/dev";
 import { isClient } from "@aca/shared/document";
 
+import { notificationEntity } from "./notification/notification";
 import { userEntity } from "./user";
 
 interface CreateNewClientDbInput {
@@ -24,6 +25,7 @@ devAssignWindowVariable("reloadClientDb", () => {
 
 export const appClientDbEntities = {
   user: userEntity,
+  notification: notificationEntity,
 };
 
 export function createNewClientDb({ userId, teamId, apolloClient, onDestroyRequest }: CreateNewClientDbInput) {

--- a/desktop/clientdb/notification/notification.ts
+++ b/desktop/clientdb/notification/notification.ts
@@ -1,0 +1,45 @@
+import gql from "graphql-tag";
+
+import { defineEntity } from "@aca/clientdb";
+import { EntityByDefinition } from "@aca/clientdb";
+import { createHasuraSyncSetupFromFragment } from "@aca/clientdb/sync";
+import { getFragmentKeys } from "@aca/clientdb/utils/analyzeFragment";
+import { getGenericDefaultData } from "@aca/clientdb/utils/getGenericDefaultData";
+import { DesktopNotificationFragment } from "@aca/gql";
+import { findAndMap } from "@aca/shared/array";
+
+import { notificationSlackMentionEntity } from "./slack/mention";
+
+const notificationFragment = gql`
+  fragment DesktopNotification on notification {
+    id
+    title
+    url
+    resolved_at
+    updated_at
+    created_at
+  }
+`;
+
+const notificationEntities = [notificationSlackMentionEntity];
+
+export const notificationEntity = defineEntity<DesktopNotificationFragment>({
+  name: "notification",
+  updatedAtField: "updated_at",
+  keyField: "id",
+  keys: getFragmentKeys<DesktopNotificationFragment>(notificationFragment),
+  getDefaultValues: () => ({
+    __typename: "notification",
+    ...getGenericDefaultData(),
+  }),
+  sync: createHasuraSyncSetupFromFragment<DesktopNotificationFragment>(notificationFragment),
+}).addConnections((notification, { getEntity }) => ({
+  get inner() {
+    return findAndMap(
+      notificationEntities,
+      (entity) => getEntity(entity).query({ notification_id: notification.id }).first
+    );
+  },
+}));
+
+export type NotificationEntity = EntityByDefinition<typeof notificationEntity>;

--- a/desktop/clientdb/notification/slack/mention.ts
+++ b/desktop/clientdb/notification/slack/mention.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+
+import { defineEntity } from "@aca/clientdb";
+import { EntityByDefinition } from "@aca/clientdb";
+import { createHasuraSyncSetupFromFragment } from "@aca/clientdb/sync";
+import { getFragmentKeys } from "@aca/clientdb/utils/analyzeFragment";
+import { getGenericDefaultData } from "@aca/clientdb/utils/getGenericDefaultData";
+import { NotificationSlackMentionFragment } from "@aca/gql";
+
+const notificationSlackMentionFragment = gql`
+  fragment NotificationSlackMention on notification_slack_mention {
+    id
+    notification_id
+    created_at
+    updated_at
+    slack_conversation_id
+    slack_message_ts
+  }
+`;
+
+export const notificationSlackMentionEntity = defineEntity<NotificationSlackMentionFragment>({
+  name: "notification_slack_mention",
+  updatedAtField: "updated_at",
+  keyField: "id",
+  keys: getFragmentKeys<NotificationSlackMentionFragment>(notificationSlackMentionFragment),
+  getDefaultValues: () => ({
+    __typename: "notification_slack_mention",
+    ...getGenericDefaultData(),
+  }),
+  sync: createHasuraSyncSetupFromFragment<NotificationSlackMentionFragment>(notificationSlackMentionFragment),
+});
+
+export type NotificationSlackMentionEntity = EntityByDefinition<typeof notificationSlackMentionEntity>;

--- a/infrastructure/hasura/metadata/databases/default/tables/public_notification.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_notification.yaml
@@ -11,3 +11,17 @@ object_relationships:
       remote_table:
         name: notification_slack_mention
         schema: public
+select_permissions:
+- permission:
+    columns:
+    - title
+    - url
+    - created_at
+    - resolved_at
+    - updated_at
+    - id
+    - user_id
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: user

--- a/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_mention.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_mention.yaml
@@ -1,3 +1,21 @@
 table:
   name: notification_slack_mention
   schema: public
+object_relationships:
+- name: notification
+  using:
+    foreign_key_constraint_on: notification_id
+select_permissions:
+- permission:
+    columns:
+    - id
+    - slack_conversation_id
+    - slack_message_ts
+    - created_at
+    - updated_at
+    - notification_id
+    filter:
+      notification:
+        user_id:
+          _eq: X-Hasura-User-Id
+  role: user


### PR DESCRIPTION
Omar and I talked a bit about what we'll need for Notion and Slack, this is part of the shared code which when merged will allow us both to continue working in our corners.

The `notification` entity has a connection called `inner` which is a union of all the possible notification entities (e.g. `-SlackMention`, `-SlackDM`, `-NotionMention` etc.). Then we can switch on that in the UI to build the appropriate views, e.g.

```tsx
function getNotificationTitle(notification: NotificationEntity) {
  const inner = notification.inner!;
  switch (inner.__typename) {
    case "notification_slack_mention":
      return `You were mentioned in ${inner.slackConversation.name}`;

    case "notification_notion_mention":
      return `You were mentioned you in ${inner.notionPage.title}`;
  }
}
```
(just an example, reality will likely be more complex with bucketing and aggregating etc.)