### PR TITLE
desktop: slack and google auth flow working with acapela auth

### DIFF
--- a/desktop/bridge/auth.ts
+++ b/desktop/bridge/auth.ts
@@ -2,10 +2,16 @@ import { createInvokeBridge } from "./base/channels";
 import { createElectronPersistedValue } from "./base/persistance";
 
 export const authTokenBridgeValue = createElectronPersistedValue<string | null>("auth-token", () => null);
-export const notionAuthTokenBridgeValue = createElectronPersistedValue<string | null>("notion-auth-token", () => null);
-
 export const loginBridge = createInvokeBridge("login");
+
+export const notionAuthTokenBridgeValue = createElectronPersistedValue<string | null>("notion-auth-token", () => null);
 export const loginNotionBridge = createInvokeBridge("login-notion");
+
+export const googleAuthTokenBridgeValue = createElectronPersistedValue<boolean>("google-auth-token", () => false);
+export const loginGoogleBridge = createInvokeBridge("login-google");
+
+export const slackAuthTokenBridgeValue = createElectronPersistedValue<string | null>("slack-auth-token", () => null);
+export const loginSlackBridge = createInvokeBridge("login-slack");
 
 export async function logout() {
   authTokenBridgeValue.set(null);

--- a/desktop/electron/auth/acapela.ts
+++ b/desktop/electron/auth/acapela.ts
@@ -2,6 +2,8 @@ import { BrowserWindow, session } from "electron";
 
 import { authTokenBridgeValue, loginBridge } from "@aca/desktop/bridge/auth";
 
+import { syncGoogleAuthState } from "./google";
+import { syncSlackAuthState } from "./slack";
 import { authWindowDefaultOptions } from "./utils";
 
 async function getAcapelaAuthToken() {
@@ -36,6 +38,19 @@ export async function loginAcapela() {
     window.close();
 
     authTokenBridgeValue.set(token);
+
+    /**
+     * We don't know what kind of auth method user has chosen.
+     *
+     * But a side-effect is that user is already logged in in one of those.
+     *
+     * eg. if you sign to acapela with Google, you'll already by logged in Google when it's done.
+     *
+     * Thus lets re-check auth status so it is up-to-date and synced with frontend
+     *
+     * TODO: Maybe there is some 'cookie change' listener so we could avoid such imperative code.
+     */
+    await Promise.all([syncGoogleAuthState(), syncSlackAuthState()]);
   });
 }
 

--- a/desktop/electron/auth/google.ts
+++ b/desktop/electron/auth/google.ts
@@ -1,0 +1,55 @@
+import { BrowserWindow, session } from "electron";
+
+import { googleAuthTokenBridgeValue, loginGoogleBridge } from "@aca/desktop/bridge/auth";
+
+import { authWindowDefaultOptions } from "./utils";
+
+const googleURL = "https://www.google.com";
+
+export async function getGoogleAuthToken() {
+  const cookiesRequiredForBeingAuthorized = ["SSID"];
+  const cookies = await session.defaultSession.cookies.get({ url: googleURL });
+
+  const authorizedCookies = cookies.filter((cookie) => cookiesRequiredForBeingAuthorized.includes(cookie.name));
+
+  return authorizedCookies.length === cookiesRequiredForBeingAuthorized.length;
+}
+
+export async function loginGoogle() {
+  const currentToken = await getGoogleAuthToken();
+  if (currentToken) {
+    googleAuthTokenBridgeValue.set(true);
+    console.info("Already logged in");
+    return;
+  }
+
+  const window = new BrowserWindow({ ...authWindowDefaultOptions });
+
+  window.webContents.loadURL("https://accounts.google.com/servicelogin");
+
+  window.webContents.on("did-navigate-in-page", async () => {
+    const token = await getGoogleAuthToken();
+
+    if (!token) {
+      return;
+    }
+
+    window.close();
+
+    googleAuthTokenBridgeValue.set(token);
+  });
+}
+
+export function initializeGoogleAuthHandler() {
+  loginGoogleBridge.handle(async () => {
+    await loginGoogle();
+  });
+
+  syncGoogleAuthState();
+}
+
+export function syncGoogleAuthState() {
+  getGoogleAuthToken().then((token) => {
+    googleAuthTokenBridgeValue.set(token);
+  });
+}

--- a/desktop/electron/auth/index.ts
+++ b/desktop/electron/auth/index.ts
@@ -1,7 +1,11 @@
 import { initializeLoginHandler } from "./acapela";
+import { initializeGoogleAuthHandler } from "./google";
 import { initializeNotionAuthHandler } from "./notion";
+import { initializeSlackAuthHandler } from "./slack";
 
 export function initializeAuthHandlers() {
   initializeLoginHandler();
   initializeNotionAuthHandler();
+  initializeGoogleAuthHandler();
+  initializeSlackAuthHandler();
 }

--- a/desktop/electron/auth/slack.ts
+++ b/desktop/electron/auth/slack.ts
@@ -1,0 +1,54 @@
+import { BrowserWindow, session } from "electron";
+
+import { loginSlackBridge, slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
+
+import { authWindowDefaultOptions } from "./utils";
+
+const slackURL = "https://www.slack.com";
+
+export async function getSlackAuthToken() {
+  const [authCookie] = await session.defaultSession.cookies.get({ url: slackURL, name: "oi" });
+
+  if (!authCookie) return null;
+
+  return authCookie.value;
+}
+
+export async function loginSlack() {
+  const currentToken = await getSlackAuthToken();
+  if (currentToken) {
+    slackAuthTokenBridgeValue.set(currentToken);
+    console.info("Already logged in");
+    return;
+  }
+
+  const window = new BrowserWindow({ ...authWindowDefaultOptions });
+
+  window.webContents.loadURL("https://slack.com/ssb/signin");
+
+  window.webContents.on("did-navigate-in-page", async () => {
+    const token = await getSlackAuthToken();
+
+    if (!token) {
+      return;
+    }
+
+    window.close();
+
+    slackAuthTokenBridgeValue.set(token);
+  });
+}
+
+export function initializeSlackAuthHandler() {
+  loginSlackBridge.handle(async () => {
+    await loginSlack();
+  });
+
+  syncSlackAuthState();
+}
+
+export function syncSlackAuthState() {
+  getSlackAuthToken().then((token) => {
+    slackAuthTokenBridgeValue.set(token);
+  });
+}

--- a/desktop/views/settings/index.tsx
+++ b/desktop/views/settings/index.tsx
@@ -1,18 +1,34 @@
 import React from "react";
 import styled from "styled-components";
 
-import { loginNotionBridge, notionAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
+import {
+  googleAuthTokenBridgeValue,
+  loginGoogleBridge,
+  loginNotionBridge,
+  loginSlackBridge,
+  notionAuthTokenBridgeValue,
+  slackAuthTokenBridgeValue,
+} from "@aca/desktop/bridge/auth";
 import { Button } from "@aca/ui/buttons/Button";
 import { theme } from "@aca/ui/theme";
 
 export const SettingsView = function SettingsView() {
   const notionToken = notionAuthTokenBridgeValue.use();
   const isNotionAuthorized = !!notionToken;
+  const isGoogleAuthorized = googleAuthTokenBridgeValue.use();
+
+  const isSlackAuthorized = !!slackAuthTokenBridgeValue.use();
   return (
     <UIHolder>
       <UIHeader>Settings</UIHeader>
-      {!isNotionAuthorized && <Button onClick={() => loginNotionBridge()}>Login to Notion</Button>}
+      {!isNotionAuthorized && <Button onClick={() => loginNotionBridge()}>Connect Notion</Button>}
       {isNotionAuthorized && <div>Notion authorized</div>}
+
+      {!isGoogleAuthorized && <Button onClick={() => loginGoogleBridge()}>Connect Google</Button>}
+      {isGoogleAuthorized && <div>Google authorized</div>}
+
+      {!isSlackAuthorized && <Button onClick={() => loginSlackBridge()}>Connect Slack</Button>}
+      {isSlackAuthorized && <div>Slack authorized</div>}
       <UIVersionInfo>dev</UIVersionInfo>
     </UIHolder>
   );


### PR DESCRIPTION
Adds Google and Slack auth flows.

They're also 'side-effect' of acapela sign in, so eg. if you log in with Google into Acapela, Google will also get instantly authorized as well
![CleanShot 2022-01-24 at 15 25 13](https://user-images.githubusercontent.com/7311462/150801135-088d8a5e-6e4e-4732-bbfb-5ae622c3c379.gif)
