### PR TITLE
feat(desktop): embed rewrite and custom css

### DIFF
--- a/desktop/electron/bridgeHandlers/browserView/index.ts
+++ b/desktop/electron/bridgeHandlers/browserView/index.ts
@@ -10,6 +10,8 @@ import {
 import { appState } from "@aca/desktop/electron/appState";
 import { assert, assertDefined } from "@aca/shared/assert";
 
+import { loadURLWithFilters } from "./siteFilters";
+
 const DESTROY_BROWSER_VIEW_TIMEOUT_MS = 5000;
 
 type StringURL = string;
@@ -42,7 +44,8 @@ async function registerBrowserViewSubscriber(url: string, id: string) {
       subscribers: new Set([id]),
       destroyTimeout: null,
     };
-    await browserView.webContents.loadURL(url);
+
+    await loadURLWithFilters(browserView, url);
   }
 
   return ref.view;

--- a/desktop/electron/bridgeHandlers/browserView/siteFilters.ts
+++ b/desktop/electron/bridgeHandlers/browserView/siteFilters.ts
@@ -1,0 +1,37 @@
+import { BrowserView } from "electron";
+
+type SiteFilter = { on: (url: URL) => boolean; rewriteURL?: (url: URL) => string; css?: string };
+const siteFilters: SiteFilter[] = [
+  {
+    on: (url) => url.hostname.endsWith(".slack.com"),
+    rewriteURL: (url) => url.toString().replace("/archives/", "/messages/"),
+    css: `.p-workspace-layout {
+            position: relative;
+            left: -210px;
+            width: calc(100% + 210px);
+        }
+        
+        .p-workspace__sidebar, .p-resizer {
+            display: none;
+        }`,
+  },
+  {
+    on: (url) => url.hostname.endsWith("notion.so"),
+    css: `.notion-sidebar-container {
+            display: none;
+          }
+          .notion-frame {
+            width: 100% !important;
+          }`,
+  },
+];
+
+export async function loadURLWithFilters(browserView: BrowserView, url: string) {
+  const applicableSiteFilters = siteFilters.filter((filter) => filter.on(new URL(url)));
+  const filteredURL = applicableSiteFilters.reduce(
+    (currentURL, filter) => filter.rewriteURL?.(new URL(currentURL)) ?? currentURL,
+    url
+  );
+  await browserView.webContents.loadURL(filteredURL);
+  await browserView.webContents.insertCSS(applicableSiteFilters.map((filter) => filter.css).join("\n"));
+}

--- a/desktop/electron/bridgeHandlers/index.ts
+++ b/desktop/electron/bridgeHandlers/index.ts
@@ -1,7 +1,7 @@
 import { initializeAuthHandlers } from "@aca/desktop/electron/auth";
 
+import { initPreviewHandler } from "./browserView";
 import { initializePersistance } from "./persistance";
-import { initPreviewHandler } from "./preview";
 import { initializeSystemHandlers } from "./system";
 
 export function initializeBridgeHandlers() {


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/151386090-7f1bab5a-9b96-4a54-8704-33fecd81f1ad.mov

Adds a `siteFilter` which kicks in when its `on` check for a URL is true, and can then rewrite the URL (needed for Slack which has this interstitial) or add CSS (needed for all sites, as we want to hide sidebars).