### PR TITLE
fix(desktop): prevent invalid auth refresh

### DIFF
--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -30,11 +30,12 @@ const BuiltInStyles = createGlobalStyle`
 
 function BridgeSessionProvider({ children }: { children: React.ReactNode }) {
   const session = authTokenBridgeValue.use();
+
   if (!session) {
     return <LoginView />;
   }
   return (
-    <SessionProvider baseUrl={"http://localhost:3000"} session={jwt.decode(session) as never}>
+    <SessionProvider session={jwt.decode(session) as never} refetchInterval={0} refetchOnWindowFocus={false}>
       {children}
     </SessionProvider>
   );

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,7 @@
     "styled-components": "*"
   },
   "scripts": {
-    "dev": "NEXT_PUBLIC_NEXTAUTH_URL=http://localhost:3000 ts-node dev.ts",
+    "dev": "ts-node dev.ts",
     "build:bundle": "ts-node build.ts",
     "build:electron": "electron-builder build --mac zip --universal --dir",
     "build": "yarn build:bundle && yarn build:electron",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "immer": "^9.0.7",
     "mobx-react": "^7.2.1",
     "next": "^12.0.7",
-    "next-auth": "npm:next-auth-danger-link@4.1.0",
+    "next-auth": "npm:next-auth-danger-link@4.1.2-714d80",
     "react-popper": "^2.2.5",
     "styled-normalize": "^8.0.7",
     "styled-reset": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,7 +161,7 @@ __metadata:
     mobx-react: ^7.2.1
     msw: ^0.36.3
     next: ^12.0.7
-    next-auth: "npm:next-auth-danger-link@4.1.0"
+    next-auth: "npm:next-auth-danger-link@4.1.2-714d80"
     next-compose-plugins: ^2.2.1
     next-transpile-modules: ^9.0.0
     next-unused: ^0.0.6
@@ -17617,9 +17617,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"next-auth@npm:next-auth-danger-link@4.1.0":
-  version: 4.1.0
-  resolution: "next-auth-danger-link@npm:4.1.0"
+"next-auth@npm:next-auth-danger-link@4.1.2-714d80":
+  version: 4.1.2-714d80
+  resolution: "next-auth-danger-link@npm:4.1.2-714d80"
   dependencies:
     "@babel/runtime": ^7.16.3
     "@panva/hkdf": ^1.0.1
@@ -17632,12 +17632,12 @@ fsevents@^1.2.7:
     uuid: ^8.3.2
   peerDependencies:
     nodemailer: ^6.6.5
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ^17.0.2 || ^18.0.0-0
+    react-dom: ^17.0.2 || ^18.0.0-0
   peerDependenciesMeta:
     nodemailer:
       optional: true
-  checksum: 94ca07f6c0f31727ecce48cb21914ed893c63178915336c4705ea796f1c7d6ad8d50e510f76403eea2e9a263562d0eb2babdf5b9ca61cd018b6ed9aa0f943bb7
+  checksum: a2bceb34926fab57ae79663b7eb9aa2d6833e1a862222768d5ca676182ecb03e16630eefc5970db54efbe4da010bf010e10d46fdfece3707a754032ffd2ee287
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
What took like 2 hours, turned into a relative little amount of changes. But I think is more of a hotpatch and we'll want to look at this again.

Omar made me aware that the session-erroring issue still persists. I assumed that I had fixed it with either passing `baseUrl` in or `NEXT_AUTH_URL` in the `dev`-script. Clearly I went with redundancy because I had no certainty which would fix it.
Well now I know that both did not work, because `next-auth` does not want you to change the host, as the cookie depends on it being `same-origin`. So I started looking into two proxying/intercepting approaches with Electron ((`interceptFileProtocol` & `webRequest.onBeforeRequest`) , none of which lead to a satisfactory implementation.

Ultimately I ended up looking for ways to just disable refetching when a windows re-focuses. Fortunately `next-auth` merged a [PR](https://github.com/nextauthjs/next-auth/pull/3730) for that just 2 days ago. They did not do a release yet, but since we're already on our own fork I just kicked of a release for that.

As alluded to in the beginning, longer term we should build a mechanism for refreshing the session token.

