### PR TITLE
feat: better notion and figma session management

### DIFF
--- a/desktop/actions/dev.ts
+++ b/desktop/actions/dev.ts
@@ -1,4 +1,4 @@
-import { requestRestartApp } from "@aca/desktop/bridge/system";
+import { clearAllData, requestRestartApp } from "@aca/desktop/bridge/system";
 
 import { defineAction } from "./action";
 
@@ -14,6 +14,6 @@ export const restartAndClearElectronData = defineAction({
   name: "Clear all data and restart",
   shortcut: ["Mod", "Shift", "C"],
   handler() {
-    requestRestartApp();
+    clearAllData();
   },
 });

--- a/desktop/electron/apps/index.ts
+++ b/desktop/electron/apps/index.ts
@@ -2,8 +2,8 @@ import { workerSyncStart } from "@aca/desktop/bridge/apps";
 import { appState } from "@aca/desktop/electron/appState";
 import { autorunEffect } from "@aca/shared/mobxUtils";
 
-import { startFigmaSync } from "./figma/worker";
-import { startNotionSync } from "./notion/worker";
+import { isFigmaReadyToSync, startFigmaSync } from "./figma/worker";
+import { isNotionReadyToSync, startNotionSync } from "./notion/worker";
 import { ServiceSyncController } from "./types";
 
 export type NotificationServiceName = "notion";
@@ -16,12 +16,29 @@ function addHandler(controller: ServiceSyncController) {
   onWindowsBlurHandlers.push(controller.onWindowBlur);
 }
 
+function startNotionIfReady() {
+  if (!isNotionReadyToSync()) {
+    console.info("[Notion] Not ready to sync: session not present");
+    return;
+  }
+  addHandler(startNotionSync());
+}
+
+function startFigmaIfReady() {
+  if (!isFigmaReadyToSync()) {
+    console.info("[Figma] Not ready to sync: session not present");
+    return;
+  }
+  startFigmaSync();
+}
+
 export function initializeServiceSync() {
   workerSyncStart.handle(async (isAbleToStart: boolean) => {
-    if (isAbleToStart) {
-      addHandler(startNotionSync());
-      startFigmaSync();
+    if (!isAbleToStart) {
+      return;
     }
+    startNotionIfReady();
+    startFigmaIfReady();
   });
 
   function handleWindowFocus() {
@@ -41,4 +58,16 @@ export function initializeServiceSync() {
     mainWindow.on("blur", handleWindowBlur);
     mainWindow.on("focus", handleWindowFocus);
   });
+}
+
+// This assumes that the db / user threads are ready
+// Use full when initializing service right after login into them
+export function tryInitializeServiceSync(name: "notion" | "figma") {
+  console.info(`Attempting to initialize ${name} sync`);
+  if (name === "notion") {
+    startNotionIfReady();
+  }
+  if (name === "figma") {
+    startFigmaIfReady();
+  }
 }

--- a/desktop/electron/bridgeHandlers/browserView/index.ts
+++ b/desktop/electron/bridgeHandlers/browserView/index.ts
@@ -26,13 +26,13 @@ const browserViewRefs: Record<
 
 async function registerBrowserViewSubscriber(url: string, id: string) {
   const { mainWindow } = appState;
-  assert(mainWindow, "mainWindow is not defined");
+  assert(mainWindow, "[BrowserView] mainWindow is not defined");
 
   let ref = browserViewRefs[url];
-  console.info("registering browser view subscriber for", url);
+  console.info("[BrowserView] registering browser view subscriber for", url);
   if (ref) {
     if (ref.destroyTimeout !== null) {
-      console.info("cancelling browser view destroy timeout for", url);
+      console.info("[BrowserView] cancelling browser view destroy timeout for", url);
       clearTimeout(ref.destroyTimeout);
       ref.destroyTimeout = null;
     }
@@ -53,16 +53,14 @@ async function registerBrowserViewSubscriber(url: string, id: string) {
 }
 
 function unregisterBrowserViewSubscriber(url: string, id: string) {
-  const ref = assertDefined(browserViewRefs[url], `browserViewRef is missing for: ${url}`);
-  console.info("unregistering browser view subscriber for", url);
+  const ref = assertDefined(browserViewRefs[url], `[BrowserView] browserViewRef is missing for: ${url}`);
+
   const wasPresent = ref.subscribers.delete(id);
   if (!wasPresent) {
     // eslint-disable-next-line no-console
-    console.trace("no subscribers found for url", url, "with id", id);
+    console.trace("[BrowserView] no subscribers found for url", url, "with id", id);
   } else if (ref.subscribers.size == 0 && !ref.destroyTimeout) {
-    console.info("starting browser view destroy timeout for", url);
     ref.destroyTimeout = setTimeout(() => {
-      console.info("destroying browser view for", url);
       // As of this writing destroy() is an undocumented method for getting rid of a BrowserView.
       // https://github.com/electron/electron/issues/10096#issuecomment-882837830
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,7 +83,7 @@ export function initPreviewHandler() {
 
   showBrowserView.handle(async ({ url, id, bounds }) => {
     const { mainWindow } = appState;
-    assert(mainWindow, "mainWindow is not defined");
+    assert(mainWindow, "[BrowserView] mainWindow is not defined");
 
     const browserView = await registerBrowserViewSubscriber(url, id);
     if (!mainWindow.getBrowserViews().includes(browserView)) {
@@ -106,7 +104,7 @@ export function initPreviewHandler() {
     const browserView = browserViewRefs[url]?.view;
     if (browserView) {
       const { mainWindow } = appState;
-      assert(mainWindow, "mainWindow is not defined");
+      assert(mainWindow, "[BrowserView] mainWindow is not defined");
       mainWindow.removeBrowserView(browserView);
     }
 


### PR DESCRIPTION
This includes some scrappy work to take better management of our notion and figma sessions:

- We'll remove the sessions cookies if we receive a 401 or any other error from in the capturing phase
- We'll be able to start worker sync right after we login to one of the services

Next up:
Move most of these error logs over to Sentry