### PR TITLE
fix(desktop): frontend URL var and lax cookies

### DIFF
--- a/desktop/apolloClient.tsx
+++ b/desktop/apolloClient.tsx
@@ -14,6 +14,7 @@ import { GraphQLError } from "graphql";
 import { memoize } from "lodash";
 import React, { ReactNode } from "react";
 
+import { FRONTEND_URL } from "@aca/desktop/vars";
 import { createDateParseLink } from "@aca/frontend/src/apollo/dateStringParseLink";
 import { readAppInitialPropByName } from "@aca/frontend/src/utils/next";
 import { TypedTypePolicies } from "@aca/gql";
@@ -87,7 +88,7 @@ interface ApolloClientOptions {
 const DEBUG_PRODUCTION_LOCALLY = IS_DEV && false;
 
 function getGraphqlUrl() {
-  const rootUrl = process.env.FRONTEND_URL ?? process.env.NEXTAUTH_URL ?? "";
+  const rootUrl = FRONTEND_URL;
 
   if (DEBUG_PRODUCTION_LOCALLY) {
     return `https://app.acape.la/graphql`;

--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -11,6 +11,7 @@ import { CurrentTeamProvider } from "@aca/desktop/auth/CurrentTeam";
 import { authTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { ClientDbProvider } from "@aca/desktop/clientdb/ClientDbProvider";
 import { GlobalDesktopStyles } from "@aca/desktop/styles/GlobalDesktopStyles";
+import { WEBSOCKET_URL } from "@aca/desktop/vars";
 import { LoginView } from "@aca/desktop/views/LoginView";
 import { RootView } from "@aca/desktop/views/RootView";
 import { global } from "@aca/frontend/styles/global";
@@ -55,7 +56,7 @@ render(
     <GlobalDesktopStyles />
     <MotionConfig transition={{ ...POP_ANIMATION_CONFIG }}>
       <BridgeSessionProvider>
-        <ApolloClientProvider websocketEndpoint={"ws://localhost:3000"}>
+        <ApolloClientProvider websocketEndpoint={WEBSOCKET_URL}>
           <AppThemeProvider theme={theme}>
             <CurrentTeamProvider>
               <ClientDbProvider>

--- a/desktop/electron/auth/acapela.ts
+++ b/desktop/electron/auth/acapela.ts
@@ -1,17 +1,26 @@
 import { BrowserWindow, session } from "electron";
 
 import { authTokenBridgeValue, loginBridge } from "@aca/desktop/bridge/auth";
+import { FRONTEND_URL } from "@aca/desktop/vars";
 
 import { syncGoogleAuthState } from "./google";
 import { syncSlackAuthState } from "./slack";
 import { authWindowDefaultOptions } from "./utils";
 
 async function getAcapelaAuthToken() {
-  const cookies = await session.defaultSession.cookies.get({ name: "next-auth.session-token" });
-
-  const [cookie] = cookies;
-
+  const [cookie] = await session.defaultSession.cookies.get({ name: "next-auth.session-token" });
   if (!cookie) return null;
+
+  await session.defaultSession.cookies.set({
+    url: "https://" + cookie.domain,
+    domain: cookie.domain,
+    name: cookie.name,
+    value: cookie.value,
+    sameSite: "no_restriction",
+    secure: true,
+    httpOnly: true,
+    expirationDate: cookie.expirationDate,
+  });
 
   return cookie.value;
 }
@@ -26,7 +35,7 @@ export async function loginAcapela() {
 
   const window = new BrowserWindow({ ...authWindowDefaultOptions });
 
-  window.webContents.loadURL(`http://localhost:3000/app/login`);
+  window.webContents.loadURL(FRONTEND_URL + `/app/login`);
 
   window.webContents.on("did-navigate-in-page", async () => {
     const token = await getAcapelaAuthToken();

--- a/desktop/electron/index.ts
+++ b/desktop/electron/index.ts
@@ -1,6 +1,7 @@
 import "./globals";
 
-import { app } from "electron";
+import { app, protocol } from "electron";
+import IS_DEV from "electron-is-dev";
 
 import { initializeServiceSync } from "./apps";
 import { appState } from "./appState";
@@ -8,6 +9,8 @@ import { initializeBridgeHandlers } from "./bridgeHandlers";
 import { initializeMainWindow } from "./mainWindow";
 import { initializeProtocolHandlers } from "./protocol";
 import { initializeSingleInstanceLock } from "./singleInstance";
+
+protocol.registerSchemesAsPrivileged([{ scheme: IS_DEV ? "http" : "file", privileges: { secure: true } }]);
 
 // Has to be done before app ready
 initializeSingleInstanceLock();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,7 +10,7 @@
     "styled-components": "*"
   },
   "scripts": {
-    "dev": "ts-node dev.ts",
+    "dev": "FRONTEND_URL=http://localhost:3000 ts-node dev.ts",
     "build:bundle": "NODE_ENV=production ts-node build.ts",
     "build:electron": "electron-builder build --mac zip --universal --dir",
     "build": "yarn build:bundle && yarn build:electron",

--- a/desktop/vars.ts
+++ b/desktop/vars.ts
@@ -1,0 +1,3 @@
+export const FRONTEND_URL = process.env.FRONTEND_URL ?? "https://app-staging.acape.la";
+const urlObject = new URL(FRONTEND_URL);
+export const WEBSOCKET_URL = `${urlObject.protocol === "https:" ? "wss" : "ws"}://${urlObject.host}`;


### PR DESCRIPTION
This is truly the week of PR disclaimers. Here is this one:

- since we don't bundle env vars into the build (and also don't want to really, to not leak credentials into the electron app) we have to have another passing mechanism. I basically hardcoded staging into `var.ts` right now. We probably want to somehow pull the default `.env`s for stage/prod during bundling in, maybe sth you want to look at next week @christophwitzko?
- we have to rewrite the cookie we get from our frontend to be laxer, and additionally mark `http` (in dev) or `file` (in prod) as secure schemes. That's not great, but seemed like the straightest path right now. Maybe we want to abandon that in favor of proxying after all? Not sure, yet.

Also have not tested the bundled version yet, will do that now!