### PR TITLE
fix: notion space persisted and selection trigger sync

### DIFF
--- a/desktop/bridge/apps/index.ts
+++ b/desktop/bridge/apps/index.ts
@@ -1,4 +1,5 @@
 import { createInvokeBridge } from "@aca/desktop/bridge/base/invoke";
+import { WorkerService } from "@aca/desktop/electron/apps/types";
 
 /*
   The render thread has to load up quite a few things before it is ready to take in
@@ -7,3 +8,8 @@ import { createInvokeBridge } from "@aca/desktop/bridge/base/invoke";
   can start syncing.
 */
 export const workerSyncStart = createInvokeBridge<boolean>("worker-sync-ready");
+
+/*
+  In some cases we need the worker syncs to run on changes in some other threads.
+*/
+export const forceWorkerSyncRun = createInvokeBridge<WorkerService[]>("worker-sync-run");

--- a/desktop/bridge/apps/notion.ts
+++ b/desktop/bridge/apps/notion.ts
@@ -36,4 +36,5 @@ export const notionSelectedSpaceValue = createBridgeValue<NotionSpaces>("notion-
     selected: [],
     allSpaces: [],
   }),
+  isPersisted: true,
 });

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -80,6 +80,7 @@ export function startNotionSync(): ServiceSyncController {
   runSync();
 
   return {
+    serviceName: "notion",
     onWindowFocus() {
       const now = new Date();
       const isLongTimeSinceLastFocus = !timeOfLastSync || differenceInMinutes(now, timeOfLastSync) > 5;
@@ -91,6 +92,9 @@ export function startNotionSync(): ServiceSyncController {
     },
     onWindowBlur() {
       restartPullInterval(WINDOW_BLURRED_INTERVAL);
+    },
+    forceSync() {
+      runSync();
     },
   };
 }
@@ -132,7 +136,9 @@ async function fetchNotionNotificationLog(window: BrowserWindow) {
     throw new Error("[Notion] Unauthorized");
   }
 
-  return (await response.json()) as GetNotificationLogResult;
+  const result = (await response.json()) as GetNotificationLogResult;
+
+  return result;
 }
 
 async function fetchCurrentSpace(window: BrowserWindow) {

--- a/desktop/electron/apps/types.ts
+++ b/desktop/electron/apps/types.ts
@@ -1,4 +1,8 @@
+export type WorkerService = "notion" | "figma";
+
 export interface ServiceSyncController {
+  serviceName: WorkerService;
   onWindowFocus: () => void;
   onWindowBlur: () => void;
+  forceSync: () => void;
 }

--- a/desktop/views/settings/index.tsx
+++ b/desktop/views/settings/index.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { connectFigma, connectGoogle, connectNotion, connectSlack } from "@aca/desktop/actions/auth";
+import { forceWorkerSyncRun } from "@aca/desktop/bridge/apps";
 import { NotionSpace, notionSelectedSpaceValue } from "@aca/desktop/bridge/apps/notion";
 import { slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { getDb } from "@aca/desktop/clientdb";
@@ -55,6 +56,7 @@ const NotionSpaceSelector = observer(function NotionSpaceSelector() {
       selected: [space.id],
       allSpaces,
     });
+    forceWorkerSyncRun(["notion"]);
   }
 
   return (


### PR DESCRIPTION
## Bug fix

I was using the `createBridgeValue` without `isPersisted: true`. Without this, the selected notion space would not be persisted between app restarts

## Other

We now trigger a new `sync` when a new notion space is selected