### PR TITLE
fix: notion-spaces reset on re-install

### DIFF
--- a/desktop/bridge/apps/notion.ts
+++ b/desktop/bridge/apps/notion.ts
@@ -31,10 +31,12 @@ export interface NotionSpace {
   name: string;
 }
 
+const DEFAULT_SELECTED_SPACE_VALUE = {
+  selected: [],
+  allSpaces: [],
+};
+
 export const notionSelectedSpaceValue = createBridgeValue<NotionSpaces>("notion-spaces", {
-  getDefault: () => ({
-    selected: [],
-    allSpaces: [],
-  }),
+  getDefault: () => DEFAULT_SELECTED_SPACE_VALUE,
   isPersisted: true,
 });

--- a/desktop/bridge/base/persistance.ts
+++ b/desktop/bridge/base/persistance.ts
@@ -77,6 +77,10 @@ export function createBridgeValue<T>(valueKey: string, { getDefault, isPersisted
     return useObserver(() => get());
   }
 
+  function reset() {
+    return set(getDefault());
+  }
+
   return {
     get isReady() {
       return isReady.get();
@@ -85,5 +89,6 @@ export function createBridgeValue<T>(valueKey: string, { getDefault, isPersisted
     set,
     use,
     update,
+    reset,
   };
 }

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -13,6 +13,7 @@ import { authTokenBridgeValue, notionAuthTokenBridgeValue } from "@aca/desktop/b
 import { ServiceSyncController } from "@aca/desktop/electron/apps/types";
 import { assert } from "@aca/shared/assert";
 
+import { clearNotionSessionData } from "../../auth/notion";
 import { ActivityPayload, BlockPayload, GetNotificationLogResult, GetSpacesResult, NotificationPayload } from "./types";
 
 const WINDOW_BLURRED_INTERVAL = 15 * 60 * 1000; // 15 minutes;
@@ -132,7 +133,7 @@ async function fetchNotionNotificationLog(window: BrowserWindow) {
   });
 
   if (response.status === 401) {
-    notionAuthTokenBridgeValue.set(null);
+    clearNotionSessionData();
     throw new Error("[Notion] Unauthorized");
   }
 
@@ -167,7 +168,7 @@ async function fetchCurrentSpace(window: BrowserWindow) {
   });
 
   if (response.status === 401) {
-    notionAuthTokenBridgeValue.set(null);
+    clearNotionSessionData();
     throw new Error("[Notion] 401 - Unauthorized");
   }
 

--- a/desktop/electron/auth/notion.ts
+++ b/desktop/electron/auth/notion.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, session } from "electron";
 
+import { notionSelectedSpaceValue } from "@aca/desktop/bridge/apps/notion";
 import { loginNotionBridge, notionAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { tryInitializeServiceSync } from "@aca/desktop/electron/apps";
 
@@ -48,4 +49,9 @@ export function initializeNotionAuthHandler() {
   getNotionAuthToken().then((token) => {
     notionAuthTokenBridgeValue.set(token);
   });
+}
+
+export function clearNotionSessionData() {
+  notionAuthTokenBridgeValue.reset();
+  notionSelectedSpaceValue.reset();
 }

--- a/desktop/views/settings/index.tsx
+++ b/desktop/views/settings/index.tsx
@@ -1,12 +1,12 @@
 import { toJS } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 import { connectFigma, connectGoogle, connectNotion, connectSlack } from "@aca/desktop/actions/auth";
 import { forceWorkerSyncRun } from "@aca/desktop/bridge/apps";
 import { NotionSpace, notionSelectedSpaceValue } from "@aca/desktop/bridge/apps/notion";
-import { slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
+import { notionAuthTokenBridgeValue, slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { getDb } from "@aca/desktop/clientdb";
 import { TraySidebarLayout } from "@aca/desktop/layout/TraySidebarLayout/TraySidebarLayout";
 import { authStore } from "@aca/desktop/store/authStore";
@@ -42,8 +42,16 @@ export const SettingsView = observer(function SettingsView() {
 
 const NotionSpaceSelector = observer(function NotionSpaceSelector() {
   const savedSpaces = notionSelectedSpaceValue.use();
+  const notionAuthBridge = notionAuthTokenBridgeValue.use();
 
-  if (savedSpaces?.selected?.length === 0) {
+  useEffect(() => {
+    // Covers corner case of losing notion session without resetting spaces
+    if (!notionAuthBridge) {
+      notionSelectedSpaceValue.reset();
+    }
+  }, [notionAuthBridge]);
+
+  if (!savedSpaces?.selected?.length) {
     return <></>;
   }
 


### PR DESCRIPTION
Fixes a few corner cases for notion spaces:
- The app is loaded before a proper notion space default value is in place
- When an app is re-installed and the notion spaces from a previous session are still available