### PR TITLE
fix(slack): use slack installation to determine slack connection

### DIFF
--- a/desktop/actions/auth.tsx
+++ b/desktop/actions/auth.tsx
@@ -6,9 +6,7 @@ import {
   loginFigmaBridge,
   loginGoogleBridge,
   loginNotionBridge,
-  loginSlackBridge,
   notionAuthTokenBridgeValue,
-  slackAuthTokenBridgeValue,
 } from "@aca/desktop/bridge/auth";
 
 import { defineAction } from "./action";
@@ -26,14 +24,6 @@ export const connectGoogle = defineAction({
   canApply: () => !googleAuthTokenBridgeValue.get(),
   handler() {
     loginGoogleBridge();
-  },
-});
-
-export const connectSlack = defineAction({
-  name: "Start Slack session",
-  canApply: () => !slackAuthTokenBridgeValue.get(),
-  handler() {
-    loginSlackBridge();
   },
 });
 

--- a/desktop/bridge/auth.ts
+++ b/desktop/bridge/auth.ts
@@ -1,3 +1,5 @@
+import { createInvokeWithCleanupBridge } from "@aca/desktop/bridge/base/invokeWithCleanup";
+
 import { createInvokeBridge } from "./base/invoke";
 import { createBridgeValue } from "./base/persistance";
 
@@ -25,12 +27,12 @@ export const googleAuthTokenBridgeValue = createBridgeValue<boolean>("google-aut
 });
 export const loginGoogleBridge = createInvokeBridge("login-google");
 
-export const slackAuthTokenBridgeValue = createBridgeValue<string | null>("slack-auth-token", {
-  getDefault: () => null,
+export const slackAuthTokenBridgeValue = createBridgeValue<boolean>("slack-auth-token", {
+  getDefault: () => false,
   isPersisted: true,
 });
 export const loginSlackBridge = createInvokeBridge("login-slack");
-export const connectSlackBridge = createInvokeBridge<{ url: string }>("connect-slack");
+export const connectSlackBridge = createInvokeWithCleanupBridge<{ url: string }>("connect-slack");
 
 export async function logout() {
   authTokenBridgeValue.set(null);

--- a/desktop/electron/auth/acapela.ts
+++ b/desktop/electron/auth/acapela.ts
@@ -4,7 +4,6 @@ import { authTokenBridgeValue, loginBridge } from "@aca/desktop/bridge/auth";
 import { FRONTEND_URL } from "@aca/desktop/lib/env";
 
 import { syncGoogleAuthState } from "./google";
-import { syncSlackAuthState } from "./slack";
 import { authWindowDefaultOptions } from "./utils";
 
 async function getAcapelaAuthToken() {
@@ -61,7 +60,7 @@ export async function loginAcapela() {
      *
      * TODO: Maybe there is some 'cookie change' listener so we could avoid such imperative code.
      */
-    await Promise.all([syncGoogleAuthState(), syncSlackAuthState()]);
+    await syncGoogleAuthState();
   });
 }
 

--- a/desktop/electron/auth/slack.ts
+++ b/desktop/electron/auth/slack.ts
@@ -1,58 +1,15 @@
-import { BrowserWindow, session } from "electron";
+import { BrowserWindow } from "electron";
 
-import { connectSlackBridge, loginSlackBridge, slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
+import { connectSlackBridge } from "@aca/desktop/bridge/auth";
 
 import { authWindowDefaultOptions } from "./utils";
 
-const slackURL = "https://www.slack.com";
-
-export async function getSlackAuthToken() {
-  const [authCookie] = await session.defaultSession.cookies.get({ url: slackURL, name: "oi" });
-
-  if (!authCookie) return null;
-
-  return authCookie.value;
-}
-
-export async function loginSlack() {
-  const currentToken = await getSlackAuthToken();
-  if (currentToken) {
-    slackAuthTokenBridgeValue.set(currentToken);
-    console.info("Already logged in");
-    return;
-  }
-
-  const window = new BrowserWindow({ ...authWindowDefaultOptions });
-
-  window.webContents.loadURL("https://slack.com/ssb/signin");
-
-  window.webContents.on("did-navigate-in-page", async () => {
-    const token = await getSlackAuthToken();
-
-    if (!token) {
-      return;
-    }
-
-    window.close();
-
-    slackAuthTokenBridgeValue.set(token);
-  });
-}
-
 export function initializeSlackAuthHandler() {
-  loginSlackBridge.handle(async () => {
-    await loginSlack();
-  });
   connectSlackBridge.handle(async ({ url }) => {
     const window = new BrowserWindow({ ...authWindowDefaultOptions });
-    window.webContents.loadURL(url);
-  });
-
-  syncSlackAuthState();
-}
-
-export function syncSlackAuthState() {
-  getSlackAuthToken().then((token) => {
-    slackAuthTokenBridgeValue.set(token);
+    await window.webContents.loadURL(url);
+    return () => {
+      window.destroy();
+    };
   });
 }

--- a/desktop/views/settings/InstallSlackButton.tsx
+++ b/desktop/views/settings/InstallSlackButton.tsx
@@ -1,14 +1,20 @@
 import { gql } from "@apollo/client";
-import React from "react";
+import { observer } from "mobx-react";
+import React, { useEffect, useState } from "react";
 
 import { apolloClient } from "@aca/desktop/apolloClient";
 import { connectSlackBridge } from "@aca/desktop/bridge/auth";
+import { getDb } from "@aca/desktop/clientdb";
+import { authStore } from "@aca/desktop/store/authStore";
 import { GetIndividualSlackInstallationUrlQuery, GetIndividualSlackInstallationUrlQueryVariables } from "@aca/gql";
 import { useAsyncEffect } from "@aca/shared/hooks/useAsyncEffect";
 import { Button } from "@aca/ui/buttons/Button";
 
-export function InstallSlackButton() {
-  const [installationURL, setInstallationURL] = React.useState<string | null>(null);
+export const InstallSlackButton = observer(() => {
+  const [installationURL, setInstallationURL] = useState<string | null>(null);
+  const user = getDb().user.findById(authStore.user.id);
+  const [closeConnectBridge, setCloseConnectBridge] = useState<(() => void) | null>(null);
+
   useAsyncEffect(async ({ getIsCancelled }) => {
     const {
       data: { slackInstallation },
@@ -30,9 +36,23 @@ export function InstallSlackButton() {
     }
   });
 
+  useEffect(() => {
+    if (user?.has_slack_installation) {
+      closeConnectBridge?.();
+    }
+  }, [user]);
+
   return (
-    <Button disabled={!installationURL} onClick={() => installationURL && connectSlackBridge({ url: installationURL })}>
+    <Button
+      isDisabled={!user || user.has_slack_installation || !installationURL}
+      onClick={() => {
+        if (installationURL) {
+          const cleanup = connectSlackBridge({ url: installationURL });
+          setCloseConnectBridge(cleanup ?? null);
+        }
+      }}
+    >
       Connect Slack
     </Button>
   );
-}
+});

--- a/desktop/views/settings/index.tsx
+++ b/desktop/views/settings/index.tsx
@@ -3,13 +3,11 @@ import { observer } from "mobx-react";
 import React, { useEffect } from "react";
 import styled from "styled-components";
 
-import { connectFigma, connectGoogle, connectNotion, connectSlack } from "@aca/desktop/actions/auth";
+import { connectFigma, connectGoogle, connectNotion } from "@aca/desktop/actions/auth";
 import { forceWorkerSyncRun } from "@aca/desktop/bridge/apps";
 import { NotionSpace, notionSelectedSpaceValue } from "@aca/desktop/bridge/apps/notion";
-import { notionAuthTokenBridgeValue, slackAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
-import { getDb } from "@aca/desktop/clientdb";
+import { notionAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { TraySidebarLayout } from "@aca/desktop/layout/TraySidebarLayout/TraySidebarLayout";
-import { authStore } from "@aca/desktop/store/authStore";
 import { ActionButton } from "@aca/desktop/ui/ActionButton";
 import { SingleOptionDropdown } from "@aca/ui/forms/OptionsDropdown/single";
 import { HStack } from "@aca/ui/Stack";
@@ -18,8 +16,6 @@ import { theme } from "@aca/ui/theme";
 import { InstallSlackButton } from "./InstallSlackButton";
 
 export const SettingsView = observer(function SettingsView() {
-  const isSlackAuthorized = !!slackAuthTokenBridgeValue.get();
-  const user = getDb().user.findById(authStore.user.id);
   return (
     <TraySidebarLayout>
       <UIHolder>
@@ -32,8 +28,7 @@ export const SettingsView = observer(function SettingsView() {
         </HStack>
         <ActionButton action={connectFigma} />
 
-        <ActionButton action={connectSlack} />
-        {isSlackAuthorized && user && !user.has_slack_installation && <InstallSlackButton />}
+        <InstallSlackButton />
         <UIVersionInfo>v{window.electronBridge.env.version}</UIVersionInfo>
       </UIHolder>
     </TraySidebarLayout>


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/152018043-1bd5ca88-75f5-403d-bdea-e79d882346f4.mov

What a day, I almost lost all my beautiful hair over puzzling through Slack's internal API.

The bug was that we did not detect an active Slack session correctly, as we tied it to the `oid` cookie which stands for OpenID and is thus not set for E-Mail login (I had the brilliant idea of using it, so I guess I dug my grave here).
That's where I went on an multi-hour journey of determining a cookie which indicates auth (no candidate here), or an internal API call we could use (no non-brittle options in sight here) and in the end I gave up and decided to treat the login page's HTML as an API to determine auth-ness by the presence of an element there.

Fortunately I had a call with Omar, just before running into a dead-end with my last ditch approach (that element actually does not show up until you also select a workspace). He gave me the idea that a session's aliveness is less interesting here anyway, in settings we need to make sure Slack is capturing. And in my opinion, in the rare cases that a session dies, it is completely fine to sign-in within the focus-view.
Two major benefits here:
- we can just use the presence of a slack installation to consider the connection done, no brittle Slack internals dependency
- connecting Slack is now a one-button-only process

@pie6k your invoke bridge with cleanup was also super helpful here, for closing the dialog from the frontend once we detect an installation. I still have a small bug here where sometimes dialog seem to close too early, but I'll push this through already since the bug in master (login not possible for many) is the bigger issue.
