### PR TITLE
feat: mutes the preview when not focused

### DIFF
--- a/desktop/electron/bridgeHandlers/previews/index.ts
+++ b/desktop/electron/bridgeHandlers/previews/index.ts
@@ -64,6 +64,8 @@ function requestPreviewLoad(url: string, window: BrowserWindow) {
     const browserView = new BrowserView({ webPreferences: {} });
     const loadingPromise = loadURLWithFilters(browserView, url);
 
+    browserView.webContents.setAudioMuted(true);
+
     browserView.webContents.on("before-input-event", async (event, input) => {
       // Handle Esc press only
       if (input.type !== "keyDown" || input.key !== "Escape") return;
@@ -93,6 +95,7 @@ function requestPreviewLoad(url: string, window: BrowserWindow) {
     });
 
     listenToWebContentsFocus(browserView.webContents, (isFocused) => {
+      browserView.webContents.setAudioMuted(!isFocused);
       previewEventsBridge.send({ url, type: isFocused ? "focus" : "blur" });
     });
 


### PR DESCRIPTION
I thought I was going crazy... 
The slack notifications appear to be  sounding "double", as if 2 notifications were coming at the same exact time, but I was only sent one notification.

Then I realised that I had slack and acapela open. Which made me to believe that detached browser windows were generating these sounds waves.

This PR mutes the BrowserViews when they're not focused