### PR TITLE
fix(slack): cleaner sidebar remove

### DIFF
--- a/desktop/electron/bridgeHandlers/previews/siteFilters.ts
+++ b/desktop/electron/bridgeHandlers/previews/siteFilters.ts
@@ -20,7 +20,7 @@ const siteFilters: SiteFilter[] = [
   {
     on: (url) => isHostSlack(url) && url.searchParams.has("thread_ts"),
     css: `.p-workspace-layout {
-            grid-template-columns: auto 320px !important;
+            grid-template-columns: auto 40% !important;
           }`,
   },
   {


### PR DESCRIPTION
https://user-images.githubusercontent.com/4051932/152357272-4706b827-022e-4e99-a773-07d6ca8822ef.mov

Fiddling with Slack's CSS grid was straight-forward enough after all. ~Threads are still a bit thin on fullscreen, but I'm not sure yet how to solve for this.~