### PR TITLE
fix: broken consolidation given snoozed_util not null in insert

### DIFF
--- a/desktop/clientdb/notification/index.ts
+++ b/desktop/clientdb/notification/index.ts
@@ -57,6 +57,7 @@ export const notificationEntity = defineEntity<DesktopNotificationFragment>({
     __typename: "notification",
     user_id: getContextValue(userIdContext) ?? undefined,
     resolved_at: null,
+    snoozed_until: null,
     ...getGenericDefaultData(),
   }),
   sync: createHasuraSyncSetupFromFragment<DesktopNotificationFragment, DesktopNotificationConstraints>(


### PR DESCRIPTION
# Bug
The `figma` and `notion` sync pipeline broke as they were missing `snoozed_util` param when creating a new entity. 
Fixed by making `snoozed_util` default to null on `notification` creation