### PR TITLE
fix: frontend themes

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -24,7 +24,7 @@ import { POP_ANIMATION_CONFIG } from "@aca/ui/animations";
 import { PromiseUIRenderer } from "@aca/ui/createPromiseUI";
 import { TooltipsRenderer } from "@aca/ui/popovers/TooltipsRenderer";
 import { globalStyles } from "@aca/ui/styles/global";
-import { AppThemeProvider, theme } from "@aca/ui/theme";
+import { AppThemeProvider } from "@aca/ui/theme";
 import { ToastsRenderer } from "@aca/ui/toasts/ToastsRenderer";
 
 export interface AppConfig {
@@ -49,7 +49,7 @@ function initSentry(appConfig: AppConfig) {
   });
 }
 
-const BuiltInStyles = createGlobalStyle`
+export const BuiltInStyles = createGlobalStyle`
   ${globalStyles}
 `;
 
@@ -87,15 +87,12 @@ export default function App({
   if (isNextAuthErrorPage) {
     return (
       <>
-        <BuiltInStyles />
         <CommonMetadata />
         <RequiredSessionProvider dontRequireSession={isNextAuthErrorPage} session={appConfig.session}>
-          <AppThemeProvider theme={theme}>
-            <PromiseUIRenderer />
-            <TooltipsRenderer />
-            <ToastsRenderer />
-            {renderWithPageLayout(Component, { appConfig, ...pageProps })}
-          </AppThemeProvider>
+          <PromiseUIRenderer />
+          <TooltipsRenderer />
+          <ToastsRenderer />
+          {renderWithPageLayout(Component, { appConfig, ...pageProps })}
         </RequiredSessionProvider>
       </>
     );
@@ -103,13 +100,13 @@ export default function App({
 
   return (
     <>
-      <BuiltInStyles />
       <CommonMetadata />
       <Sentry.ErrorBoundary fallback={sentryFallbackErrorRenderer}>
         <RequiredSessionProvider session={appConfig.session}>
           <MotionConfig transition={{ ...POP_ANIMATION_CONFIG }}>
             <ApolloProvider websocketEndpoint={appConfig.hasuraWebsocketEndpoint}>
-              <AppThemeProvider theme={theme}>
+              <AppThemeProvider>
+                <BuiltInStyles />
                 <CurrentTeamProvider>
                   <ClientDbProvider>
                     <AppStateStoreProvider>

--- a/frontend/src/auth/RequiredSessionProvider.tsx
+++ b/frontend/src/auth/RequiredSessionProvider.tsx
@@ -5,6 +5,9 @@ import { ReactNode } from "react";
 import { FocusedActionLayout } from "@aca/frontend/layouts/FocusedActionLayout/FocusedActionLayout";
 import { LoginOptionsView } from "@aca/frontend/views/LoginOptionsView";
 import { useConst } from "@aca/shared/hooks/useConst";
+import { AppThemeProvider } from "@aca/ui/theme";
+
+import { BuiltInStyles } from "../../pages/_app";
 
 interface Props {
   session: Session | null;
@@ -21,10 +24,17 @@ export function RequiredSessionProvider({ session, children, dontRequireSession 
 
   return (
     <SessionProvider session={sessionFromServer}>
-      {!sessionFromServer && !dontRequireSession && (
-        <FocusedActionLayout title="Log in to start using Acapela">{<LoginOptionsView />}</FocusedActionLayout>
-      )}
-      {(sessionFromServer || dontRequireSession) && children}
+      {/* SessionProvider seems to be eating up the Styled Components context. */}
+      {/* AppThemeProvider should be set nested inside SessionProvider to avoid this. */}
+      <AppThemeProvider>
+        <BuiltInStyles />
+        {!sessionFromServer && !dontRequireSession && (
+          <FocusedActionLayout title="Log in to start using Acapela">
+            <LoginOptionsView />
+          </FocusedActionLayout>
+        )}
+        {(sessionFromServer || dontRequireSession) && children}
+      </AppThemeProvider>
     </SessionProvider>
   );
 }

--- a/ui/theme/index.tsx
+++ b/ui/theme/index.tsx
@@ -33,8 +33,8 @@ export const darkTheme: typeof defaultTheme = {
   colors: darkThemeColors,
 };
 
-export function AppThemeProvider<T extends object>({ theme, children }: PropsWithChildren<{ theme: T }>) {
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+export function AppThemeProvider({ children }: PropsWithChildren<{}>) {
+  return <ThemeProvider theme={defaultTheme}>{children}</ThemeProvider>;
 }
 
 export const theme = buildStyledTheme(defaultTheme);


### PR DESCRIPTION
A couple of bugs:

- Next Auth SessionProvider was breaking up the provided context from Styled Component's `ThemeProvider`. This was fixed by nested `AppThemeProvider` inside `SessionProvider`
- We were passing the proxy instead of the original theme object into our `AppThemeProvider`.  I've hardcoded the default theme in frontend for the meantime.