### PR TITLE
feat(slack): add text_preview

### DIFF
--- a/backend/src/slack/md/parser.ts
+++ b/backend/src/slack/md/parser.ts
@@ -288,6 +288,9 @@ export type TransformContext = {
   mentionedUsersBySlackId?: {
     [slackId: string]: EditorMentionData;
   };
+  mentionedNamesBySlackId?: {
+    [slackId: string]: string;
+  };
 };
 
 function transformNode(node: markdown.SingleASTNode, context: TransformContext = {}) {
@@ -337,7 +340,7 @@ function transformNode(node: markdown.SingleASTNode, context: TransformContext =
           },
         };
       }
-      return createBoldText(`@${textToString(node.content) || node.id}`);
+      return createBoldText(`@${textToString(node.content) || context.mentionedNamesBySlackId?.[node.id] || node.id}`);
     case "slackChannel":
     case "slackUserGroup":
       return createLink(


### PR DESCRIPTION
<img width="927" alt="Screen Shot 2022-02-07 at 09 17 57" src="https://user-images.githubusercontent.com/4051932/152760186-f835df79-ae97-43bc-966c-a2eb15ac574e.png">

Based on `text_preview` @omarduarte added over the weekend. Mostly just used the old slack-md-conversion code, with small alterations.

Fixes ACA-1207