### PR TITLE
fix: disallow most permissions

### DIFF
--- a/desktop/electron/index.ts
+++ b/desktop/electron/index.ts
@@ -14,6 +14,7 @@ import { initializeBridgeHandlers } from "./bridgeHandlers";
 import { initializeGlobalShortcuts } from "./globalShortcuts";
 import { initializeMainWindow } from "./mainWindow";
 import { initializeProtocolHandlers } from "./protocol";
+import { initializeDefaultSession } from "./session";
 import { initializeSingleInstanceLock } from "./singleInstance";
 
 // Mark default scheme as secure, thus allowing us to make credentialed requests for secure sites
@@ -43,6 +44,8 @@ function initializeApp() {
   initializeServiceSync();
 
   initializeGlobalShortcuts();
+
+  initializeDefaultSession();
 }
 
 app.on("ready", action(initializeApp));

--- a/desktop/electron/session.ts
+++ b/desktop/electron/session.ts
@@ -1,0 +1,11 @@
+import { session } from "electron";
+
+export function initializeDefaultSession() {
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    // Electron allows all permissions by default, we only want to let the ones through that could be useful within
+    // embeds, like voice/screen-recording. We specifically do not want to allow "notifications" as those would
+    // create native notifications.
+    const ALLOWED_PERMISSIONS: typeof permission[] = ["display-capture", "media"];
+    callback(ALLOWED_PERMISSIONS.includes(permission));
+  });
+}


### PR DESCRIPTION
Funky move that Electron allows all permissions by default. This PR changes it to only allow `media` & `display_capture` as these could be used e.g. from Slack message composition.