### PR TITLE
fix: check for updates directly on app start

### DIFF
--- a/desktop/electron/mainWindow.ts
+++ b/desktop/electron/mainWindow.ts
@@ -109,9 +109,12 @@ function setupAutoUpdater() {
     error: (message: string) => log.error(message),
   };
 
-  setInterval(() => {
+  const checkForUpdates = () => {
     autoUpdater.checkForUpdates();
-  }, 10 * 60 * 1000); // check for updates every 10 minutes
+    setTimeout(checkForUpdates, 10 * 60 * 1000); // check for updates every 10 minutes
+  };
+
+  checkForUpdates();
 
   autoUpdater.on("update-downloaded", (_event, _releaseNotes, releaseName) => {
     const dialogOpts = {


### PR DESCRIPTION
This will direct the update check directly after the app was started.