### PR TITLE
fix: route change not re-registring action targets

### DIFF
--- a/desktop/routes/index.ts
+++ b/desktop/routes/index.ts
@@ -1,4 +1,4 @@
-import { computed, createAtom } from "mobx";
+import { createAtom } from "mobx";
 import { createRouter } from "react-chicane";
 import { ExtractRoutesParams, GetNestedRoutes, ParamsArg, PrependBasePath } from "react-chicane/dist/types";
 
@@ -40,14 +40,10 @@ desktopRouter.subscribe(() => {
   routeChangeAtom.reportChanged();
 });
 
-const observedRouterComputed = computed(() => {
-  routeChangeAtom.reportObserved();
-  return desktopRouter;
-});
-
 // It simply returns router, but in case this function is called in mobx context, mobx will know to re-run it if route changes
 export function getObservedRouter() {
-  return observedRouterComputed.get();
+  routeChangeAtom.reportObserved();
+  return desktopRouter;
 }
 
 type Routes = typeof routes;


### PR DESCRIPTION
This one was super hard to track down as I don't understand our architecture fully.

My guess is that mobx's `atom.reportChanged` was not triggering another `computed` run that gave back an updated router. Because of that, the correct context for the `focus` route was never provided.

P.S.: Anyone recommend a good mobx book? Those docs are giving me a headache

## What does this fix?

Focus view actions: up/down arrows, clicking on resolve, etc.

It was previously working because it was picking up the List view actions.