### PR TITLE
feat: grab notion notification from guest spaces

### DIFF
--- a/desktop/electron/apps/notion/types.ts
+++ b/desktop/electron/apps/notion/types.ts
@@ -5,12 +5,19 @@ export type GetSpacesResult = Record<
     notion_user: Record<string, NotionUserPayload>;
     user_root: unknown;
     user_settings: unknown;
-    space_view: unknown;
+    space_view: Record<string, SpaceView>;
     space: Record<string, SpacePayload>;
     block: unknown;
     collection: unknown;
   }
 >;
+
+interface SpaceView {
+  role: Role;
+  value: {
+    space_id: string;
+  };
+}
 
 interface SpacePayload {
   role: Role;
@@ -40,6 +47,14 @@ export interface UserPermission {
   role: Role;
   type: "user_permission";
   user_id: string;
+}
+
+export interface GetPublicSpaceDataResult {
+  results: {
+    id: string;
+    name: string;
+    // A lot of properties ignored
+  }[];
 }
 
 export interface GetNotificationLogResult {


### PR DESCRIPTION
<img width="563" alt="Screenshot 2022-02-11 at 14 52 32" src="https://user-images.githubusercontent.com/4765697/153594644-511bff01-2a4e-412e-bc84-6f4a8ad030c3.png">

We needed an extra REST call to figure out the names of spaces the user was a guest in. Now we can get notification from all spaces the user is involved with.