### PR TITLE
fix: remove default menu

### DIFF
--- a/desktop/electron/mainWindow.ts
+++ b/desktop/electron/mainWindow.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 import * as Sentry from "@sentry/electron";
-import { BrowserWindow, app } from "electron";
+import { BrowserWindow, Menu, MenuItemConstructorOptions, app } from "electron";
 import IS_DEV from "electron-is-dev";
 import { action, runInAction } from "mobx";
 
@@ -62,6 +62,8 @@ export function initializeMainWindow() {
     fullscreenable: true,
   });
 
+  addCustomMenu();
+
   mainWindow.focus();
   // mainWindow.webContents.openDevTools();
 
@@ -91,4 +93,29 @@ export function initializeMainWindow() {
   });
 
   return mainWindow;
+}
+
+function addCustomMenu() {
+  const template: MenuItemConstructorOptions[] = [
+    {
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+
+    {
+      label: "Debug",
+      submenu: [{ role: "reload" }, { role: "forceReload" }, { role: "toggleDevTools" }],
+    },
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
 }


### PR DESCRIPTION
The default menu in electron was also providing a set of shortcuts. 

The "close window" item was present in the default menu and its shortcut was set to "CMD+W". Whenever the snooze action was not able to be applied, the "close window" shortcut would be used and the application would close.

This PR includes a very minimal menu that only includes basic items.

The app name will be `Acapela` or `Alepaca` on the final builds:

<img width="233" alt="Screenshot 2022-02-14 at 15 15 30" src="https://user-images.githubusercontent.com/4765697/153871108-64dc4e08-321a-440e-8287-03cfb5a69a8d.png">
<img width="353" alt="Screenshot 2022-02-14 at 15 15 32" src="https://user-images.githubusercontent.com/4765697/153871087-32183aa1-af24-4217-9c6c-1e9fbccfd2cb.png">
.