### PR TITLE
fix: hide footer actions when preview focused

### DIFF
--- a/desktop/actions/focus.tsx
+++ b/desktop/actions/focus.tsx
@@ -6,8 +6,13 @@ import { uiStore } from "@aca/desktop/store/ui";
 import { IconArrowBottom, IconArrowLeft, IconArrowTop, IconKeyboard } from "@aca/ui/icons";
 
 import { defineAction } from "./action";
+import { ActionContext, ActionContextCallback } from "./action/context";
 import { currentNotificationActionsGroup } from "./groups";
 import { focusPageView } from "./views/focus";
+
+export function isNotFocusingPreviewAnd(fn: ActionContextCallback<boolean>) {
+  return (ctx: ActionContext) => !uiStore.getIsAnyPreviewFocused() && fn(ctx);
+}
 
 export const exitFocusMode = defineAction({
   name: (ctx) => (ctx.isContextual ? "Exit" : "Go back to list"),
@@ -15,7 +20,7 @@ export const exitFocusMode = defineAction({
   icon: <IconArrowLeft />,
   keywords: ["exit", "back"],
   shortcut: "Esc",
-  canApply: () => getIsRouteActive("focus"),
+  canApply: isNotFocusingPreviewAnd(() => getIsRouteActive("focus")),
   handler(context) {
     const notification = context.view(focusPageView)?.notification;
     const { listId } = assertGetActiveRouteParams("focus");
@@ -33,9 +38,8 @@ export const focusOnNotificationPreview = defineAction({
   group: currentNotificationActionsGroup,
   name: (ctx) => (ctx.isContextual ? "Focus" : "Focus on notification screen"),
   shortcut: ["Mod", "Enter"],
-  canApply: () => {
-    return getIsRouteActive("focus") && !uiStore.isAnyPreviewFocused;
-  },
+  canApply: isNotFocusingPreviewAnd(() => getIsRouteActive("focus")),
+
   handler(context) {
     const notification = context.assertTarget("notification");
 
@@ -48,9 +52,7 @@ export const goToNextNotification = defineAction({
   group: currentNotificationActionsGroup,
   name: (ctx) => (ctx.isContextual ? "Next" : "Go to next notification"),
   shortcut: "ArrowDown",
-  canApply: (context) => {
-    return !!context.view(focusPageView)?.nextNotification;
-  },
+  canApply: isNotFocusingPreviewAnd((context) => !!context.view(focusPageView)?.nextNotification),
   handler(context) {
     const nextNotification = context.view(focusPageView)?.nextNotification;
 
@@ -68,9 +70,7 @@ export const goToPreviousNotification = defineAction({
   group: currentNotificationActionsGroup,
   name: (ctx) => (ctx.isContextual ? "Previous" : "Go to previous notification"),
   shortcut: "ArrowUp",
-  canApply: (context) => {
-    return !!context.view(focusPageView)?.prevNotification;
-  },
+  canApply: isNotFocusingPreviewAnd((context) => !!context.view(focusPageView)?.prevNotification),
   handler(context) {
     const previousNotification = context.view(focusPageView)?.prevNotification;
 

--- a/desktop/actions/snooze.tsx
+++ b/desktop/actions/snooze.tsx
@@ -5,12 +5,14 @@ import { DateSuggestion, autosuggestDate } from "@aca/shared/dates/autocomplete/
 import { niceFormatDateTime } from "@aca/shared/dates/format";
 import { IconClockCross, IconClockZzz } from "@aca/ui/icons";
 
+import { uiStore } from "../store/ui";
 import { defineAction } from "./action";
 import { ActionContext } from "./action/context";
 import { currentNotificationActionsGroup } from "./groups";
 import { displayZenModeIfFinished, focusNextItemIfAvailable } from "./views/common";
 
 function canApplySnooze(context: ActionContext) {
+  if (uiStore.isAnyPreviewFocused) return false;
   if (context.getTarget("notification")?.canSnooze === true) return true;
   if (context.getTarget("group")?.notifications.some((notification) => notification.canSnooze) === true) return true;
 

--- a/desktop/store/ui.ts
+++ b/desktop/store/ui.ts
@@ -56,13 +56,20 @@ export const uiStore = makeAutoObservable({
   get isAppFocused() {
     return applicationStateBridge.get().isFocused;
   },
-  get isAnyPreviewFocused() {
+  get isAnyPreviewFocused(): boolean {
     // If 'client' is directly focused, there is no way some preview is
     if (hasDirectFocus.get()) return false;
 
     // 'client' is not directly focused. Thus if app is focused - it must be some preview
     return uiStore.isAppFocused;
   },
+
+  // This is useful in when we don't want the current value
+  // of `isAnyPreviewFocused` used in closures
+  getIsAnyPreviewFocused() {
+    return this.isAnyPreviewFocused;
+  },
+
   // Main 'client' part is focused
   get hasDirectFocus() {
     return hasDirectFocus.get();


### PR DESCRIPTION
<img width="903" alt="Screenshot 2022-02-14 at 17 01 57" src="https://user-images.githubusercontent.com/4765697/153888706-fb698bc3-aae8-4c0e-847a-b3a8b0d0a969.png">

Looks into the `uiStore.isAnyPreviewSelected` and only allows focus view actions when the preview is not selected.

P.S. `Meep`