### PR TITLE
fix: onboarding always appearing on app load

### DIFF
--- a/desktop/domains/integrations/figma.tsx
+++ b/desktop/domains/integrations/figma.tsx
@@ -13,6 +13,7 @@ export const figmaIntegrationClient: IntegrationClient = {
   kind: "integration",
   name: "Figma",
   description: "Get important updates and comments",
+  isReady: figmaAuthTokenBridgeValue.observables.isReady,
   getIsConnected: () => !!figmaAuthTokenBridgeValue.get(),
   disconnect: async () => {
     figmaAuthTokenBridgeValue.reset();

--- a/desktop/domains/integrations/linear.tsx
+++ b/desktop/domains/integrations/linear.tsx
@@ -13,6 +13,7 @@ export const linearIntegrationClient: IntegrationClient = {
   kind: "integration",
   name: "Linear",
   description: "New issues, task assignments and comments.",
+  isReady: linearAuthTokenBridgeValue.observables.isReady,
   getIsConnected: () => !!linearAuthTokenBridgeValue.get(),
   convertToLocalAppUrl: async ({ url }) => {
     return {

--- a/desktop/domains/integrations/notion.tsx
+++ b/desktop/domains/integrations/notion.tsx
@@ -17,6 +17,7 @@ export const notionIntegrationClient: IntegrationClient = {
   kind: "integration",
   name: "Notion",
   description: "Comments, mentions and page invitations.",
+  isReady: notionAuthTokenBridgeValue.observables.isReady,
   getIsConnected: () => !!notionAuthTokenBridgeValue.get(),
   convertToLocalAppUrl: async ({ url }) => {
     return {

--- a/desktop/domains/integrations/slack.tsx
+++ b/desktop/domains/integrations/slack.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { autorun } from "mobx";
+import { autorun, computed } from "mobx";
 import React from "react";
 
 import { trackEvent } from "@aca/desktop/analytics";
@@ -28,6 +28,9 @@ export const slackIntegrationClient: IntegrationClient = {
   icon: <IntegrationIcon imageUrl={integrationLogos.slack} />,
 
   additionalSettings: <SlackSettings />,
+  get isReady() {
+    return computed(() => accountStore.user !== null);
+  },
   getIsConnected: () => {
     return getIsConnected();
   },

--- a/desktop/domains/integrations/types.ts
+++ b/desktop/domains/integrations/types.ts
@@ -1,3 +1,4 @@
+import { IComputedValue, IObservableValue } from "mobx";
 import { ReactNode } from "react";
 
 import { OpenAppUrl } from "@aca/desktop/bridge/apps";
@@ -9,6 +10,7 @@ export interface IntegrationClient {
   description: string;
   icon: ReactNode;
   convertToLocalAppUrl?: (notification: NotificationEntity) => Promise<OpenAppUrl>;
+  isReady: IObservableValue<boolean> | IComputedValue<boolean>;
   getCanConnect?(): boolean;
   getIsConnected(): boolean;
   connect(): Promise<void>;

--- a/desktop/store/onboarding.ts
+++ b/desktop/store/onboarding.ts
@@ -7,14 +7,15 @@ import { integrationClients } from "../domains/integrations";
 /**
  * Store responsible for keeping information about current onboarding.
  */
+const clients = Object.values(integrationClients);
 
 export const onboardingStore = makeAutoObservable({
   get isReady() {
-    return authTokenBridgeValue.observables.isReady;
+    return authTokenBridgeValue.observables.isReady && clients.every((client) => client.isReady.get());
   },
 
-  get hasLinkedApps(): boolean {
-    return Object.values(integrationClients).some((ic) => ic.getIsConnected());
+  get hasLinkedApps() {
+    return clients.some((ic) => ic.getIsConnected());
   },
 
   onboardingStatus: "unknown" as "unknown" | "ongoing" | "complete",


### PR DESCRIPTION
There was a race condition happening that allowed the onboarding screen to always be shown on app start. This fixes it.