### PR TITLE
fix(slack): simplify capture

### DIFF
--- a/backend/src/notificationCapture/slack.ts
+++ b/backend/src/notificationCapture/slack.ts
@@ -1,13 +1,12 @@
 import { Prisma } from "@prisma/client";
 import { GenericMessageEvent, App as SlackApp } from "@slack/bolt";
 import { WebClient } from "@slack/web-api";
-import { uniq } from "lodash";
 import { SingleASTNode } from "simple-markdown";
 
 import { SlackInstallation, slackClient } from "@aca/backend/src/slack/app";
 import { parseAndTransformToTipTapJSON, parseSlackMarkdown } from "@aca/backend/src/slack/md/parser";
 import { getUserSlackInstallationFilter } from "@aca/backend/src/slack/userSlackInstallation";
-import { db } from "@aca/db";
+import { UserSlackInstallation, db } from "@aca/db";
 import { convertMessageContentToPlainText } from "@aca/richEditor/content/plainText";
 import { assert } from "@aca/shared/assert";
 import { logger } from "@aca/shared/logger";
@@ -44,17 +43,15 @@ async function resolveMessageNotifications(userId: string, whereMessage: Prisma.
 
 // A special client authorized with the app token for the few API calls that need app level scopes
 const appClient = new WebClient(process.env.SLACK_APP_TOKEN);
-async function findSlackUserTokenForEvent(eventContextId: string): Promise<string | null> {
+async function findUserSlackInstallations(eventContextId: string) {
   const { authorizations } = await appClient.apps.event.authorizations.list({ event_context: eventContextId });
-
-  const userSlackInstallation = await db.user_slack_installation.findFirst({
+  return db.user_slack_installation.findMany({
     where: {
       OR: (authorizations ?? [])
         .filter((auth) => auth.team_id && auth.user_id)
         .map((auth) => getUserSlackInstallationFilter({ teamId: auth.team_id, userId: auth.user_id })),
     },
   });
-  return (userSlackInstallation?.data as unknown as SlackInstallation)?.user.token ?? null;
 }
 
 const createTextPreviewFromSlackMessage = async (
@@ -75,117 +72,79 @@ const createTextPreviewFromSlackMessage = async (
     })
   );
 
+// A user is involved in a thread if they have posted in it or were mentioned in it
+async function checkIsInvolvedInThread(
+  token: string,
+  channel: string,
+  ts: string,
+  slackUserId: string
+): Promise<boolean> {
+  const { messages } = await slackClient.conversations.replies({ token, channel, ts });
+  return (messages ?? []).some(
+    (message) =>
+      message.user === slackUserId || extractMentionedSlackUserIdsFromMd(message.text).some((id) => id == slackUserId)
+  );
+}
+
 /**
- * Creates notifications for Acapela users who are in the Slack IM conversation in which the message was posted. If the
- * conversation is a Slack channel we only create a notification if it was a mention.
- * TODO:
- * - Optional fetch! This fetches all the conversation members for every messages. To make it less expensive we should
- *   only do the fetch if its not a channel or if there is a mention.
- * - Add pagination! This fetches the first 100 channel members, which is likely more than enough for IMs, but not for
- *   channels
- *   - Same for threads, I have not run into the limit yet but if we want to scale to infinity we'll want to paginate
+ * Creates notification for the given user who are in the Slack conversation in which the message was posted. If the
+ * conversation is a Slack channel we only create a notification if it was a mention or within a thread.
  */
-async function createNotificationsFromMessage(eventContextId: string, message: GenericMessageEvent) {
-  const userToken = await findSlackUserTokenForEvent(eventContextId);
-  if (!userToken) {
-    return;
-  }
+async function createNotificationFromMessage(
+  userSlackInstallation: UserSlackInstallation,
+  message: GenericMessageEvent
+) {
+  const slackInstallData = userSlackInstallation.data as unknown as SlackInstallation;
+  const { id: slackUserId, token: userToken } = slackInstallData.user;
+  const { channel, ts: messageTs, thread_ts: threadTs, user: authorSlackUserId } = message;
 
-  const { ts: messageTs, thread_ts: threadTs, user: authorSlackUserId } = message;
-  const membersResponse = await slackClient.conversations.members({
-    token: userToken,
-    channel: message.channel,
-  });
-  const members = new Set(membersResponse.members);
-
-  // An instant message (IM) is either a direct message or a group chat between multiple people, but not a channel.
-  const isIM_or_MPIM = message.channel_type == "im" || message.channel_type == "mpim";
-
-  const membersWithoutAuthor = new Set(members);
-  membersWithoutAuthor.delete(authorSlackUserId);
-
-  const slackUserIdsToNotify: string[] = [];
-
-  if (threadTs) {
-    // For a message posted in a thread, notify all users who posted in the thread or were mentioned in it
-    const { messages } = await slackClient.conversations.replies({
-      token: userToken,
-      channel: message.channel,
-      ts: threadTs,
-    });
-    slackUserIdsToNotify.push(
-      ...(messages ?? []).flatMap(({ user: author, text }) =>
-        (author && membersWithoutAuthor.has(author) ? [author] : []).concat(
-          extractMentionedSlackUserIdsFromMd(text).filter((id) => membersWithoutAuthor.has(id))
-        )
-      )
-    );
-  } else if (isIM_or_MPIM) {
-    // For IMs outside of threads notify all members of the conversation except for the author
-    slackUserIdsToNotify.push(...membersWithoutAuthor);
-  }
-
-  // Extract all mentioned users and set/overwrite them as mentions in the slackUsersToNotify Map
   const mentionedSlackUserIds = extractMentionedSlackUserIdsFromMd(message.text);
-  const mentionedMembers = new Set(mentionedSlackUserIds.filter((id) => members.has(id)));
-  slackUserIdsToNotify.push(...mentionedMembers);
+  const isMentioned = mentionedSlackUserIds.includes(slackUserId);
 
-  // Find Acapela users for all the Slack users that would be notified
-  const userSlackInstallations = await db.user_slack_installation.findMany({
-    where: {
-      OR: uniq(slackUserIdsToNotify).map((id) => ({ data: { path: ["user", "id"], equals: id } })),
-    },
-  });
-
-  if (userSlackInstallations.length == 0) {
+  const is_IM_or_MPIM = message.channel_type == "im" || message.channel_type == "mpim";
+  const isAuthor = authorSlackUserId === slackUserId;
+  if (
+    !userToken ||
+    (isAuthor && !isMentioned) ||
+    (!is_IM_or_MPIM && !(threadTs && (await checkIsInvolvedInThread(userToken, channel, threadTs, slackUserId))))
+  ) {
     return;
   }
 
-  const [{ permalink }, { user: author }, { channel }] = await Promise.all([
-    slackClient.chat.getPermalink({
-      token: userToken,
-      channel: message.channel,
-      message_ts: messageTs,
-    }),
+  const [{ permalink }, { user: authorUser }, { channel: slackChannel }] = await Promise.all([
+    slackClient.chat.getPermalink({ token: userToken, channel, message_ts: messageTs }),
     slackClient.users.info({ token: userToken, user: authorSlackUserId }),
-    isIM_or_MPIM
+    is_IM_or_MPIM
       ? // we only need to fetch info for channels, as we use their name for the notification title
         { channel: undefined }
-      : slackClient.conversations.info({ token: userToken, channel: message.channel }),
+      : slackClient.conversations.info({ token: userToken, channel }),
   ]);
-  assert(permalink, `could not get permalink for message ${messageTs} in channel ${message.channel}`);
-  assert(author, `could not get slack user for id ${authorSlackUserId}`);
+  assert(permalink, `could not get permalink for message ${messageTs} in channel ${channel}`);
+  assert(authorUser, `could not get slack profile for id ${authorSlackUserId}`);
 
-  const textPreview = await createTextPreviewFromSlackMessage(userToken, message.text ?? "", mentionedSlackUserIds);
-
-  // We have to use a transaction due to Prisma not supporting relation-creation within createMany
-  await db.$transaction(
-    userSlackInstallations.map(({ user_id, data }) =>
-      db.notification.create({
-        data: {
-          user_id,
-          from: author.real_name ?? "Unknown",
-          url: permalink,
-          text_preview: textPreview,
-          notification_slack_message: {
-            create: {
-              slack_user_id: message.user,
-              slack_conversation_id: message.channel,
-              slack_thread_ts: threadTs,
-              slack_message_ts: messageTs,
-              is_mention: mentionedMembers.has((data as unknown as SlackInstallation).user.id),
-              conversation_type: message.channel_type,
-              conversation_name: channel
-                ? (channel.is_private ? "🔒" : "#") + channel.name_normalized
-                : message.channel_type == "im"
-                ? "Direct Message"
-                : "Group Chat",
-            },
-          },
+  await db.notification.create({
+    data: {
+      user_id: userSlackInstallation.user_id,
+      from: authorUser.real_name ?? "Unknown",
+      url: permalink,
+      text_preview: await createTextPreviewFromSlackMessage(userToken, message.text ?? "", mentionedSlackUserIds),
+      notification_slack_message: {
+        create: {
+          slack_user_id: message.user,
+          slack_conversation_id: message.channel,
+          slack_thread_ts: threadTs,
+          slack_message_ts: messageTs,
+          is_mention: isMentioned,
+          conversation_type: message.channel_type,
+          conversation_name: slackChannel
+            ? (slackChannel.is_private ? "🔒" : "#") + slackChannel.name_normalized
+            : message.channel_type == "im"
+            ? "Direct Message"
+            : "Group Chat",
         },
-      })
-    )
-  );
+      },
+    },
+  });
 }
 
 export function setupSlackCapture(app: SlackApp) {
@@ -214,10 +173,13 @@ export function setupSlackCapture(app: SlackApp) {
       }
     }
 
-    try {
-      await createNotificationsFromMessage(eventContextId, message);
-    } catch (error) {
-      logger.error(error, "Error creating slack notifications");
+    const userSlackInstallations = await findUserSlackInstallations(eventContextId);
+    for (const userSlackInstallation of userSlackInstallations) {
+      try {
+        await createNotificationFromMessage(userSlackInstallation, message);
+      } catch (error) {
+        logger.error(error, "Error creating slack notifications");
+      }
     }
   });
 

--- a/db/index.ts
+++ b/db/index.ts
@@ -14,6 +14,7 @@ export type {
   topic_event as TopicEvent,
   topic_member as TopicMember,
   user as User,
+  user_slack_installation as UserSlackInstallation,
   attachment as Attachment,
   transcription_status as TranscriptionStatus,
   transcription as Transcription,


### PR DESCRIPTION
Based on #1040, which we canned for scope-limiting / keeping-it-iterative reasons.

A week or two ago I learned that we can find out which installation an event originates from. The idea for simplifiying the capture flow was to rely on that for creating notifications instead of doing it in-bulk by fetching all the conversation members and cross-checking them with Acapela users. 

The upsides:
- much more straightforward code
- we can run different flows pending on which permissions users have given us
  - we might need to request more permissions in the future, for enriching notifications with more info. But we do not want to break the experience for users who have not yet upgrade their permissions, this should help with that

The downside:
- lower API rate limit ceiling, as we do requests separately for each user. They are [Tier 3&4](https://api.slack.com/docs/rate-limits) so the ceiling is not that low