### PR TITLE
ui: tweaks to dark mode

### DIFF
--- a/desktop/actions/settings.tsx
+++ b/desktop/actions/settings.tsx
@@ -31,6 +31,13 @@ export const toggleDarkTheme = defineAction({
     const newDarkModeValue = !uiStore.isInDarkMode;
 
     const prev = uiSettingsBridge.get();
+
+    // Avoid 'animated' change where all the buttons might change theme in a slightly different time.
+    document.body.classList.add("no-transitions");
     uiSettingsBridge.set({ ...prev, isDarkMode: newDarkModeValue });
+
+    setTimeout(() => {
+      document.body.classList.remove("no-transitions");
+    }, 500);
   },
 });

--- a/desktop/styles/GlobalDesktopStyles.tsx
+++ b/desktop/styles/GlobalDesktopStyles.tsx
@@ -15,6 +15,12 @@ export const GlobalDesktopStyles = createGlobalStyle`
     ${theme.colors.layout.background.asBg}    
   }
 
+  body.no-transitions {
+    * {
+      transition: none !important;
+    }
+  }
+
   * {
     cursor: default;
   }

--- a/desktop/ui/IntegrationsManager/IntegrationCard.tsx
+++ b/desktop/ui/IntegrationsManager/IntegrationCard.tsx
@@ -45,7 +45,7 @@ export function IntegrationCard({ service }: Props) {
 const UIHolder = styled.div`
   display: flex;
   gap: 16px;
-  border: 1px solid #cdcdcd3b;
+  border: 1px solid #8882;
   padding: 16px;
   border-radius: 8px;
 `;

--- a/ui/theme/colors.ts
+++ b/ui/theme/colors.ts
@@ -33,7 +33,7 @@ const blue = color("hsl(204, 100%, 50%)");
 
 const green = color("hsl(169,100%,37%)");
 
-const divider = color("#E0E0E0");
+const divider = color("#8883");
 
 const selectedTab = color("#f3f4f6");
 
@@ -99,17 +99,17 @@ export const darkThemeColors: typeof defaultColors = {
   ...defaultColors,
   text: white,
   layout: {
-    actionPanel: blue,
+    actionPanel: darkGrey.hover,
     // Root background of the app
     background: darkGrey,
     // Used eg. for app sidebar
-    backgroundAccent: white.opacity(0.2),
+    backgroundAccent: darkGrey.hover,
     divider,
   },
   panels: {
+    ...defaultColors.panels,
     popover: white,
     secondaryPopover: darkGrey,
-    tooltip: white,
     notification: primary,
     modal: darkGrey,
     selectedTab,
@@ -117,5 +117,6 @@ export const darkThemeColors: typeof defaultColors = {
   action: {
     ...defaultColors.action,
     transparent: darkGrey,
+    secondary: darkGrey.hover,
   },
 };


### PR DESCRIPTION
<img width="1185" alt="CleanShot 2022-02-16 at 11 15 53@2x" src="https://user-images.githubusercontent.com/7311462/154243758-0589a980-23b3-491f-9d9a-5ba24f9e0e6a.png">

Did a few small tweaks to dark theme + made change between them not-animated as it was looking a bit ugly where buttons etc, where transitioning from dark/white in a bit different time