### PR TITLE
feat: app icon badge for new notifications

### DIFF
--- a/desktop/bridge/system.ts
+++ b/desktop/bridge/system.ts
@@ -10,6 +10,7 @@ export const toggleFullscreenRequest = createInvokeBridge("toggle-fullscreen");
 export const toggleDevtoolsRequest = createInvokeBridge<boolean>("toggle-devtools");
 export const appUpdateAndRestartRequest = createInvokeBridge("update-and-restart");
 export const checkForUpdatesRequest = createInvokeBridge("check-for-updates");
+export const setBadgeCountRequest = createInvokeBridge<number>("set-badge-count");
 export const showErrorToUserChannel = createChannelBridge<PublicErrorData>("show-error-to-user");
 
 export const openLinkRequest = createInvokeBridge<{ url: string }>("open-link");

--- a/desktop/electron/bridgeHandlers/system.ts
+++ b/desktop/electron/bridgeHandlers/system.ts
@@ -5,6 +5,7 @@ import {
   clearAllDataRequest,
   openLinkRequest,
   restartAppRequest,
+  setBadgeCountRequest,
   toggleDevtoolsRequest,
   toggleFullscreenRequest,
   toggleMaximizeRequest,
@@ -71,6 +72,10 @@ export function initializeSystemHandlers() {
 
   openLinkRequest.handle(async ({ url }) => {
     shell.openExternal(url);
+  });
+
+  setBadgeCountRequest.handle(async (count) => {
+    app.setBadgeCount(count);
   });
 
   autorunEffect(() => {

--- a/desktop/views/ToastsAndCommunicates/index.tsx
+++ b/desktop/views/ToastsAndCommunicates/index.tsx
@@ -4,8 +4,10 @@ import styled from "styled-components";
 
 import { defineAction } from "@aca/desktop/actions/action";
 import { installUpdate } from "@aca/desktop/actions/app";
-import { applicationStateBridge, showErrorToUserChannel } from "@aca/desktop/bridge/system";
+import { applicationStateBridge, setBadgeCountRequest, showErrorToUserChannel } from "@aca/desktop/bridge/system";
+import { getDb } from "@aca/desktop/clientdb";
 import { PublicErrorData } from "@aca/desktop/domains/errors/types";
+import { useAutorun } from "@aca/shared/sharedState";
 import { BodyPortal } from "@aca/ui/BodyPortal";
 
 import { Toast } from "./Toast";
@@ -18,6 +20,11 @@ export const ToastsAndCommunicatesView = observer(() => {
     return showErrorToUserChannel.subscribe((newError) => {
       setErrors((errors) => [...errors, newError]);
     });
+  });
+
+  useAutorun(() => {
+    const unresolvedNotifications = getDb().notification.query({ isResolved: false, isSnoozed: false }).count;
+    setBadgeCountRequest(unresolvedNotifications);
   });
 
   return (


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/154256740-fab1e4b7-8bf6-45e0-8c71-3f2c7adabd7a.mov

I decided against adding a setting, since MacOS itself has settings for that so I think we should rather inform people to configure it over there.