### PR TITLE
fix(slack): add disconnect option

### DIFF
--- a/backend/src/slack/actions.ts
+++ b/backend/src/slack/actions.ts
@@ -279,8 +279,13 @@ export function setupSlackActionHandlers(slackApp: App) {
     }
   });
 
-  slackApp.event("app_uninstalled", async ({ body }) => {
+  slackApp.event("app_uninstalled", async ({ body, context }) => {
     const slack_team_id = body.team_id;
+    if (context.userToken) {
+      await db.user_slack_installation.deleteMany({
+        where: { data: { path: ["user", "token"], equals: context.userToken } },
+      });
+    }
     await db.$transaction([
       db.team_slack_installation.deleteMany({ where: { slack_team_id } }),
       db.team_member_slack.deleteMany({

--- a/desktop/actions/slack.tsx
+++ b/desktop/actions/slack.tsx
@@ -26,7 +26,7 @@ export const toggleSlackAutoResolve = defineAction({
   name: () => (getIsAutoResolveEnabled() ? "Disable Slack Auto Resolve" : "Enable Slack Auto Resolve"),
   group: accountActionsGroup,
   icon: () => (getIsAutoResolveEnabled() ? <IconToggleOn /> : <IconToggleOff />),
-  canApply: () => Boolean(accountStore.user?.has_slack_installation),
+  canApply: () => Boolean(accountStore.user?.slackInstallation),
   handler() {
     const user = assertDefined(accountStore.user, "missing user");
     user.update({ is_slack_auto_resolve_enabled: !user.is_slack_auto_resolve_enabled });

--- a/desktop/clientdb/user.ts
+++ b/desktop/clientdb/user.ts
@@ -16,7 +16,6 @@ const userFragment = gql`
     name
     email
     avatar_url
-    has_slack_installation
     is_slack_auto_resolve_enabled
     updated_at
     created_at

--- a/desktop/domains/integrations/slack.tsx
+++ b/desktop/domains/integrations/slack.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { trackEvent } from "@aca/desktop/analytics";
 import { apolloClient } from "@aca/desktop/apolloClient";
 import { integrationLogos } from "@aca/desktop/assets/integrations/logos";
-import { connectSlackBridge } from "@aca/desktop/bridge/auth";
+import { clearServiceCookiesBridge, connectSlackBridge } from "@aca/desktop/bridge/auth";
 import { accountStore } from "@aca/desktop/store/account";
 import { GetIndividualSlackInstallationUrlQuery, GetIndividualSlackInstallationUrlQueryVariables } from "@aca/gql";
 import { assertDefined } from "@aca/shared/assert";
@@ -16,7 +16,7 @@ import { IntegrationClient } from "./types";
 
 const getIsConnected = () => {
   const user = accountStore.user;
-  return Boolean(user && user.has_slack_installation);
+  return Boolean(user && user.slackInstallation);
 };
 
 const SLACK_URL_SCHEME = "slack://";
@@ -82,6 +82,12 @@ export const slackIntegrationClient: IntegrationClient = {
         }
       });
     });
+  },
+  async disconnect() {
+    if (getIsConnected()) {
+      await clearServiceCookiesBridge({ url: "https://slack.com" });
+      accountStore.user?.slackInstallation?.remove();
+    }
   },
 };
 

--- a/infrastructure/hasura/metadata/databases/default/tables/public_user_slack_installation.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user_slack_installation.yaml
@@ -20,3 +20,9 @@ select_permissions:
       user_id:
         _eq: X-Hasura-User-Id
   role: user
+delete_permissions:
+- permission:
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: user


### PR DESCRIPTION
(The video is 90% me signing into Slack again after clicking Disconnect, I assume you get the point)

https://user-images.githubusercontent.com/4051932/154266188-e48f4bac-66d6-4585-aef2-b464af83a2e0.mov

I started off calling into slack's uninstall API function, and reacting to the event falling out of it. But then at the end of that journey I realized that we do not install a workspace app/bot with our permissions, so dropped the installation on our side is actually enough. Hence I changed it to do that instead.