### PR TITLE
fix(slack): capture Connect-users names

### DIFF
--- a/backend/src/notificationCapture/slack.ts
+++ b/backend/src/notificationCapture/slack.ts
@@ -125,7 +125,7 @@ async function createNotificationFromMessage(
   await db.notification.create({
     data: {
       user_id: userSlackInstallation.user_id,
-      from: authorUser.real_name ?? "Unknown",
+      from: authorUser.profile?.real_name ?? authorUser.real_name ?? "Unknown",
       url: permalink,
       text_preview: await createTextPreviewFromSlackMessage(userToken, message.text ?? "", mentionedSlackUserIds),
       notification_slack_message: {


### PR DESCRIPTION
For reasons unknowable to peoplekind, Slack nests **Slack Connnect**'s users name information only within their profile, not in the user object itself. Hence this.