### PR TITLE
ui: fix scrolling issues without making overflow hidden for not-related elements

### DIFF
--- a/desktop/views/ListView/ListView.tsx
+++ b/desktop/views/ListView/ListView.tsx
@@ -11,7 +11,6 @@ import { TraySidebarLayout } from "@aca/desktop/layout/TraySidebarLayout/TraySid
 import { uiStore } from "@aca/desktop/store/ui";
 import { useDebouncedValue } from "@aca/shared/hooks/useDebouncedValue";
 import { HorizontalScroller } from "@aca/ui/HorizontalScroller";
-import { HStack } from "@aca/ui/Stack";
 import { theme } from "@aca/ui/theme";
 
 import { ListEditTools } from "./EditTools";
@@ -72,7 +71,7 @@ export const ListView = observer(({ listId }: Props) => {
             <UINotificationZeroPanel>You've reached notification zero.</UINotificationZeroPanel>
           </UINotificationZeroHolder>
         ) : (
-          <HStack style={{ height: "100%" }}>
+          <UIListsScroller>
             {displayedList && (notificationGroups?.length ?? 0) === 0 && <ZeroNotifications key={listId} />}
 
             {displayedList && notificationGroups && notificationGroups.length > 0 && (
@@ -110,7 +109,7 @@ export const ListView = observer(({ listId }: Props) => {
                 </UINotifications>
               </>
             )}
-          </HStack>
+          </UIListsScroller>
         )}
       </UIHolder>
     </TraySidebarLayout>
@@ -118,9 +117,10 @@ export const ListView = observer(({ listId }: Props) => {
 });
 
 const UIHolder = styled.div<{}>`
-  height: 100%;
-  width: 100%;
-  overflow-y: hidden;
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  min-height: 0;
 `;
 
 const UINotifications = styled.div`
@@ -180,4 +180,11 @@ const UIListTools = styled.div`
   ${ListEditTools} {
     padding-top: 4px;
   }
+`;
+
+const UIListsScroller = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
 `;


### PR DESCRIPTION
![CleanShot 2022-02-21 at 11 04 20](https://user-images.githubusercontent.com/7311462/154933039-6b584c7b-405c-4e02-b1a9-e4c65ad9b380.gif)


Master simply added overflow-hidden for master 'list element' which had unneccesary consequences: (button is truncated on top)
<img width="244" alt="CleanShot 2022-02-21 at 11 04 43@2x" src="https://user-images.githubusercontent.com/7311462/154933088-9cf575bc-94ab-45d1-b9c1-0aeae2f39064.png">

