### PR TITLE
feat: better ui for shortcuts, option to toggle it off

### DIFF
--- a/desktop/actions/settings.tsx
+++ b/desktop/actions/settings.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
+import { applicationWideSettingsBridge } from "@aca/desktop/bridge/system";
 import { uiSettingsBridge } from "@aca/desktop/bridge/ui";
 import { uiStore } from "@aca/desktop/store/ui";
 import { uiSettings } from "@aca/desktop/store/uiSettings";
-import { IconBulb, IconChartLine } from "@aca/ui/icons";
+import { IconBulb, IconChartLine, IconKeyboardHide } from "@aca/ui/icons";
 
 import { defineAction } from "./action";
 import { defineGroup } from "./action/group";
@@ -40,5 +41,17 @@ export const toggleDarkTheme = defineAction({
     setTimeout(() => {
       document.body.classList.remove("no-transitions");
     }, 500);
+  },
+});
+
+export const toggleShowShortcutsBar = defineAction({
+  name: "Toggle show shortcuts bar",
+  group: settingsActionsGroup,
+  keywords: ["footer", "hide", "ui"],
+  icon: <IconKeyboardHide />,
+  handler() {
+    applicationWideSettingsBridge.update((settings) => {
+      settings.showShortcutsBar = !settings.showShortcutsBar;
+    });
   },
 });

--- a/desktop/bridge/system.ts
+++ b/desktop/bridge/system.ts
@@ -45,5 +45,6 @@ export const applicationWideSettingsBridge = createBridgeValue("app-wide-setting
     enableDesktopNotifications: true,
     showNotificationsCountBadge: true,
     notificationsCountBadgeListIds: [] as string[],
+    showShortcutsBar: true,
   }),
 });

--- a/desktop/ui/ActionTrigger.tsx
+++ b/desktop/ui/ActionTrigger.tsx
@@ -28,11 +28,14 @@ export const ActionTrigger = styledObserver<Props>(function ActionTrigger({
   className,
   onMouseEnter,
   onMouseLeave,
+  ...restProps
 }: Props) {
   const context = createActionContext(target);
 
   return (
     <UIHolder
+      // Could include eg. tooltip
+      {...restProps}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={className}

--- a/desktop/ui/ShortcutsFooter/ShortcutLabel.tsx
+++ b/desktop/ui/ShortcutsFooter/ShortcutLabel.tsx
@@ -1,10 +1,11 @@
 import { observer } from "mobx-react";
-import React from "react";
+import React, { useRef } from "react";
 import styled, { css } from "styled-components";
 
 import { ActionData, resolveActionData } from "@aca/desktop/actions/action";
 import { ActionContext } from "@aca/desktop/actions/action/context";
 import { ActionTrigger } from "@aca/desktop/ui/ActionTrigger";
+import { useElementHasOverflow } from "@aca/shared/hooks/useElementHasOverflow";
 import { ShortcutDescriptor } from "@aca/ui/keyboard/ShortcutLabel";
 import { theme } from "@aca/ui/theme";
 
@@ -15,12 +16,21 @@ interface Props {
 
 export const FooterShortcutLabel = observer(function FooterShortcutLabel({ action, context }: Props) {
   const { name, shortcut, canApply } = resolveActionData(action, context);
+  const nameRef = useRef<HTMLDivElement>(null);
+
+  // If we're truncating names, show tooltips
+  const shouldShowTooltip = useElementHasOverflow(nameRef);
 
   const isEnabled = canApply(context);
 
   return (
-    <UIHolder action={action} target={context.forcedTarget} $isEnabled={isEnabled}>
-      <UIName>{name}</UIName>
+    <UIHolder
+      action={action}
+      data-tooltip={shouldShowTooltip ? name : undefined}
+      target={context.forcedTarget}
+      $isEnabled={isEnabled}
+    >
+      <UIName ref={nameRef}>{name}</UIName>
       {shortcut && <UIShortcut shortcut={shortcut} />}
     </UIHolder>
   );
@@ -31,11 +41,11 @@ const UIHolder = styled(ActionTrigger)<{ $isEnabled: boolean }>`
   align-items: center;
   gap: 4px;
   min-width: 0;
-  ${theme.box.label};
+  ${theme.box.hint};
   ${theme.radius.button};
   ${theme.transitions.hover("all")};
 
-  ${theme.colors.layout.background.interactive};
+  ${theme.colors.layout.backgroundAccent.interactive};
 
   ${(props) =>
     !props.$isEnabled &&
@@ -52,8 +62,9 @@ const UIHolder = styled(ActionTrigger)<{ $isEnabled: boolean }>`
 `;
 
 const UIName = styled.div`
-  ${theme.typo.content.medium};
+  ${theme.typo.action.regular.medium};
   white-space: nowrap;
+  ${theme.common.ellipsisText};
 `;
 
 export const UIShortcut = styled(ShortcutDescriptor)`
@@ -61,5 +72,5 @@ export const UIShortcut = styled(ShortcutDescriptor)`
   padding: 3px;
   ${theme.transitions.hover("all")};
   ${theme.radius.badge};
-  ${theme.typo.label.medium};
+  ${theme.typo.action.regular.medium};
 `;

--- a/desktop/ui/ShortcutsFooter/index.tsx
+++ b/desktop/ui/ShortcutsFooter/index.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import { ActionData } from "@aca/desktop/actions/action";
 import { createActionContext } from "@aca/desktop/actions/action/context";
 import { showCommandMenu } from "@aca/desktop/actions/app";
+import { applicationWideSettingsBridge } from "@aca/desktop/bridge/system";
 import { theme } from "@aca/ui/theme";
 
 import { FooterShortcutLabel } from "./ShortcutLabel";
@@ -15,10 +16,18 @@ interface Props {
 }
 
 export const ShortcutsFooter = observer(function ShortcutsFooter({ actions, target }: Props) {
+  if (!applicationWideSettingsBridge.get().showShortcutsBar) {
+    return null;
+  }
+
   const context = createActionContext(target, { isContextual: true });
+
+  const applicableActions = actions.filter((action) => {
+    return action.canApply(context);
+  });
   return (
     <UIHolder>
-      {actions.map((action) => {
+      {applicableActions.map((action) => {
         return <FooterShortcutLabel action={action} context={context} key={action.id} />;
       })}
       <FooterShortcutLabel action={showCommandMenu} context={context} key={showCommandMenu.id} />

--- a/desktop/views/ListView/ListView.tsx
+++ b/desktop/views/ListView/ListView.tsx
@@ -127,7 +127,6 @@ const UINotifications = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 4px;
   min-height: 0;
   overflow-y: auto;
 

--- a/desktop/views/ListView/NotificationRow.tsx
+++ b/desktop/views/ListView/NotificationRow.tsx
@@ -96,7 +96,7 @@ export const NotificationRow = styledObserver(({ notification, list }: Props) =>
 })``;
 
 const UIHolder = styled.div<{ $isFocused: boolean; $isPreloading?: "loading" | "ready" | false }>`
-  padding: 8px 8px;
+  padding: 10px 8px;
   display: flex;
   align-items: center;
   gap: 24px;

--- a/desktop/views/ListView/NotificationsGroupRow.tsx
+++ b/desktop/views/ListView/NotificationsGroupRow.tsx
@@ -152,7 +152,7 @@ const UISendersPerson = styled.span`
 const UISendersMore = styled.span``;
 
 const UIHolder = styled.div<{ $isFocused: boolean }>`
-  padding: 8px 8px;
+  padding: 10px 8px;
   display: flex;
   align-items: center;
   gap: 24px;
@@ -177,8 +177,6 @@ const UITitleText = styled.div`
 const UINotifications = styled.div`
   margin-left: 18px;
   padding-left: 20px;
-  margin-top: 8px;
-  margin-bottom: 8px;
   border-left: 2px solid ${theme.colors.layout.divider};
 `;
 

--- a/desktop/views/SettingsView/General.tsx
+++ b/desktop/views/SettingsView/General.tsx
@@ -1,0 +1,23 @@
+import { observer } from "mobx-react";
+import React from "react";
+
+import { toggleShowShortcutsBar } from "@aca/desktop/actions/settings";
+import { applicationWideSettingsBridge } from "@aca/desktop/bridge/system";
+import { ActionTrigger } from "@aca/desktop/ui/ActionTrigger";
+import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
+import { SettingsList } from "@aca/desktop/ui/settings/SettingsList";
+import { Toggle } from "@aca/ui/toggle";
+
+export const GeneralSettings = observer(function ThemeSelector() {
+  const { showShortcutsBar } = applicationWideSettingsBridge.get();
+
+  return (
+    <SettingsList>
+      <SettingRow title="Show shortcuts footer">
+        <ActionTrigger action={toggleShowShortcutsBar}>
+          <Toggle size="small" isDisabled isSet={showShortcutsBar} />
+        </ActionTrigger>
+      </SettingRow>
+    </SettingsList>
+  );
+});

--- a/desktop/views/SettingsView/index.tsx
+++ b/desktop/views/SettingsView/index.tsx
@@ -9,6 +9,7 @@ import { theme } from "@aca/ui/theme";
 
 import { AccountSettings } from "./Account";
 import { ExperimentalSettings } from "./Experimental";
+import { GeneralSettings } from "./General";
 import { NotificationsSettings } from "./Notifications";
 
 interface SettingsSection {
@@ -20,6 +21,10 @@ export const settingsSections: SettingsSection[] = [
   {
     id: "integrations",
     label: "Integrations",
+  },
+  {
+    id: "general",
+    label: "General",
   },
   {
     id: "account",
@@ -66,6 +71,7 @@ export const SettingsView = observer(function SettingsView({ sectionId }: Props)
           </UINav>
           <UIActiveSection>
             {sectionId === "integrations" && <IntegrationsManager />}
+            {sectionId === "general" && <GeneralSettings />}
             {sectionId === "experimental" && <ExperimentalSettings />}
             {sectionId === "notifications" && <NotificationsSettings />}
             {sectionId === "account" && <AccountSettings />}

--- a/shared/hooks/useElementHasOverflow.ts
+++ b/shared/hooks/useElementHasOverflow.ts
@@ -1,0 +1,17 @@
+import { RefObject, useState } from "react";
+
+import { useResizeCallback } from "./useResizeCallback";
+
+function getElementHasOverflow(element: HTMLElement) {
+  return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientWidth;
+}
+
+export function useElementHasOverflow(ref: RefObject<HTMLElement>) {
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  useResizeCallback(ref, (_, element) => {
+    setHasOverflow(getElementHasOverflow(element));
+  });
+
+  return hasOverflow;
+}

--- a/shared/hooks/useResizeCallback.ts
+++ b/shared/hooks/useResizeCallback.ts
@@ -14,7 +14,10 @@ function getSizeChange(previous: ResizeObserverEntry, current: ResizeObserverEnt
  * It is useful for use cases like making sure tooltips has proper position, even if it's content
  * resizes for reasons undetectable for react.
  */
-export function useResizeCallback(ref: RefObject<HTMLElement>, callback: (entry: ResizeObserverEntry) => void) {
+export function useResizeCallback(
+  ref: RefObject<HTMLElement>,
+  callback: (entry: ResizeObserverEntry, element: HTMLElement) => void
+) {
   const previousEntryRef = useRef<ResizeObserverEntry | null>(null);
   useIsomorphicLayoutEffect(() => {
     const element = ref.current;
@@ -24,7 +27,7 @@ export function useResizeCallback(ref: RefObject<HTMLElement>, callback: (entry:
     const resizeObserver = new ResizeObserver(([entry]) => {
       if (previousEntryRef.current === null) {
         previousEntryRef.current = entry;
-        callback(entry);
+        callback(entry, element);
         return;
       }
 
@@ -34,7 +37,7 @@ export function useResizeCallback(ref: RefObject<HTMLElement>, callback: (entry:
 
       if (sizeChange < 1) return;
 
-      callback(entry);
+      callback(entry, element);
     });
 
     resizeObserver.observe(element);

--- a/ui/theme/colors.ts
+++ b/ui/theme/colors.ts
@@ -25,7 +25,7 @@ const secondary = color("hsl(34, 100%, 68%)", {
 });
 
 const lightGray = color("hsl(220, 33%, 98%)", {
-  hover: color("hsla(0, 0%, 0%, 0.03)"),
+  hover: color("hsla(0, 0%, 0%, 0.05)"),
   active: color("hsla(0, 0%, 0%, 0.075)"),
 });
 


### PR DESCRIPTION
<img width="562" alt="CleanShot 2022-02-21 at 11 41 09@2x" src="https://user-images.githubusercontent.com/7311462/154939255-3fff57ba-caef-431d-8e9b-12c516c132b3.png">

Option to enable / disable it


<img width="636" alt="CleanShot 2022-02-21 at 11 41 29@2x" src="https://user-images.githubusercontent.com/7311462/154939309-3f2ed3a3-967d-4883-910f-30cb275d742c.png">

We're only showing 'enabled' shortcuts (before grayed out)


<img width="919" alt="CleanShot 2022-02-21 at 11 41 58@2x" src="https://user-images.githubusercontent.com/7311462/154939383-cf054bc2-faec-4447-a3c5-375a91d9048b.png">
In case there are too many, nicely truncate instead of breaking the layout


<img width="189" alt="CleanShot 2022-02-21 at 11 42 20@2x" src="https://user-images.githubusercontent.com/7311462/154939445-94df6b6c-97eb-462d-bb86-ac0376c9ddd0.png">
Show tooltip for truncated (but no for non-truncated)

