### PR TITLE
ux: bunch of ux tweaks around filters

### DIFF
--- a/desktop/ui/settings/SettingRow.tsx
+++ b/desktop/ui/settings/SettingRow.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { theme } from "@aca/ui/theme";
 
@@ -7,16 +7,17 @@ interface Props {
   title: string;
   description?: string;
   children: ReactNode;
+  fixedOptionWidth?: number;
 }
 
-export function SettingRow({ title, description, children }: Props) {
+export function SettingRow({ title, description, children, fixedOptionWidth }: Props) {
   return (
     <UIHolder>
       <UIInfo>
         <UITitle>{title}</UITitle>
         {description && <UIDescription>{description}</UIDescription>}
       </UIInfo>
-      <UIOption>{children}</UIOption>
+      <UIOption $fixedWidth={fixedOptionWidth}>{children}</UIOption>
     </UIHolder>
   );
 }
@@ -41,7 +42,7 @@ const UIDescription = styled.div`
   ${theme.typo.item.description}
 `;
 
-const UIOption = styled.div`
+const UIOption = styled.div<{ $fixedWidth?: number }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -49,4 +50,11 @@ const UIOption = styled.div`
 
   /* Same size of "+ Connect" button */
   min-width: 135px;
+
+  ${(props) =>
+    props.$fixedWidth &&
+    css`
+      width: ${props.$fixedWidth}px;
+      min-width: ${props.$fixedWidth}px;
+    `}
 `;

--- a/desktop/views/ListView/Filters/FilterEditor.tsx
+++ b/desktop/views/ListView/Filters/FilterEditor.tsx
@@ -16,12 +16,12 @@ import { getFilterIntegration } from "./utils";
 interface Props {
   filter: NotificationFilter;
   onChange: (filter: NotificationFilter) => void;
-  onSubmit: (filter: NotificationFilter) => void;
+  onCloseRequest: () => void;
   onRemove?: (filter: NotificationFilter) => void;
   saveLabel?: string;
 }
 
-export function FilterEditor({ filter, onChange, onSubmit, onRemove, saveLabel = "Save filter" }: Props) {
+export function FilterEditor({ filter, onChange, onRemove, onCloseRequest }: Props) {
   function renderCorrespondingEditor() {
     if (getIsFilterOfType(filter, "notification_figma_comment")) {
       return <FilterEditorFigma filter={filter} onChange={onChange} />;
@@ -57,15 +57,8 @@ export function FilterEditor({ filter, onChange, onSubmit, onRemove, saveLabel =
       {renderIntegrationHeader()}
       {editor}
       <UIButtons>
-        <Button
-          isWide
-          kind="primary"
-          icon={<IconCheck />}
-          onClick={() => {
-            onSubmit(filter);
-          }}
-        >
-          {saveLabel}
+        <Button isWide kind="primary" icon={<IconCheck />} onClick={onCloseRequest}>
+          Done
         </Button>
         {onRemove && (
           <Button

--- a/desktop/views/ListView/Filters/FilterEditorFigma.tsx
+++ b/desktop/views/ListView/Filters/FilterEditorFigma.tsx
@@ -4,13 +4,13 @@ import React from "react";
 import styled from "styled-components";
 
 import { getDb } from "@aca/desktop/clientdb";
-import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
 import { ServiceUsersFilterRow } from "@aca/desktop/views/ListView/Filters/ServiceUsersFilterRow";
 import { isNotNullish } from "@aca/shared/nullish";
 import { updateValue } from "@aca/shared/updateValue";
 import { SingleOptionDropdown } from "@aca/ui/forms/OptionsDropdown/single";
 
 import { NotificationFilterKind, NotificationFilterOption } from "./types";
+import { FilterSettingRow } from "./utils";
 
 type FigmaFilter = NotificationFilterKind<"notification_figma_comment">;
 interface Props {
@@ -49,7 +49,7 @@ export const FilterEditorFigma = observer(({ filter, onChange }: Props) => {
   return (
     <UIHolder>
       <ServiceUsersFilterRow<FigmaFilter> users={figmaUsers} filter={filter} field="author_id" onChange={onChange} />
-      <SettingRow title="Notification type">
+      <FilterSettingRow title="Notification type">
         <SingleOptionDropdown<NotificationFilterOption<FigmaFilter>>
           items={figmaNotificationOptions}
           keyGetter={(option) => option.label}
@@ -59,7 +59,7 @@ export const FilterEditorFigma = observer(({ filter, onChange }: Props) => {
             onChange(updateValue(filter, option.updater));
           }}
         />
-      </SettingRow>
+      </FilterSettingRow>
     </UIHolder>
   );
 });

--- a/desktop/views/ListView/Filters/FilterEditorSlack.tsx
+++ b/desktop/views/ListView/Filters/FilterEditorSlack.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 
 import { useSlackUsers } from "@aca/desktop/domains/slack/useSlackUsers";
-import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
 import { getIsValueMatchingFilter } from "@aca/shared/filters";
 import { isPlainObjectEqual } from "@aca/shared/isPlainObjectEqual";
 import { typedKeys } from "@aca/shared/object";
@@ -12,6 +11,7 @@ import { SingleOptionDropdown } from "@aca/ui/forms/OptionsDropdown/single";
 
 import { ServiceUsersFilterRow } from "./ServiceUsersFilterRow";
 import { NotificationFilterKind, NotificationFilterOption } from "./types";
+import { FilterSettingRow } from "./utils";
 
 type SlackFilter = NotificationFilterKind<"notification_slack_message">;
 interface Props {
@@ -73,7 +73,7 @@ export function FilterEditorSlack({ filter, onChange }: Props) {
 
   return (
     <UIHolder>
-      <SettingRow title="Conversation type">
+      <FilterSettingRow title="Conversation type">
         <MultipleOptionsDropdown
           placeholder="All Conversations"
           items={slackConversationTypes}
@@ -94,8 +94,8 @@ export function FilterEditorSlack({ filter, onChange }: Props) {
             );
           }}
         />
-      </SettingRow>
-      <SettingRow title="Message type">
+      </FilterSettingRow>
+      <FilterSettingRow title="Message type">
         <SingleOptionDropdown<NotificationFilterOption<SlackFilter>>
           items={slackNotificationTypeOptions}
           keyGetter={(option) => option.label}
@@ -105,14 +105,14 @@ export function FilterEditorSlack({ filter, onChange }: Props) {
             onChange(updateValue(filter, option.updater));
           }}
         />
-      </SettingRow>
+      </FilterSettingRow>
       <ServiceUsersFilterRow<SlackFilter>
         users={slackUsers}
         filter={filter}
         field="slack_user_id"
         onChange={onChange}
       />
-      <SettingRow title="Threads">
+      <FilterSettingRow title="Threads">
         <SingleOptionDropdown<NotificationFilterOption<SlackFilter>>
           items={slackThreadedOptions}
           keyGetter={(option) => option.label}
@@ -122,7 +122,7 @@ export function FilterEditorSlack({ filter, onChange }: Props) {
             onChange(updateValue(filter, option.updater));
           }}
         />
-      </SettingRow>
+      </FilterSettingRow>
     </UIHolder>
   );
 }

--- a/desktop/views/ListView/Filters/FilterLabel.tsx
+++ b/desktop/views/ListView/Filters/FilterLabel.tsx
@@ -2,11 +2,14 @@ import { AnimatePresence } from "framer-motion";
 import { action } from "mobx";
 import { observer } from "mobx-react";
 import React, { useRef } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { NotificationFilter } from "@aca/desktop/clientdb/list";
+import { useElementHasOverflow } from "@aca/shared/hooks/useElementHasOverflow";
 import { Button } from "@aca/ui/buttons/Button";
 import { PopoverPanel } from "@aca/ui/popovers/PopoverPanel";
+import { Tooltip } from "@aca/ui/popovers/Tooltip";
+import { theme } from "@aca/ui/theme";
 
 import { FilterDescriptionLabel } from "./FilterDescriptionLabel";
 import { FilterEditor } from "./FilterEditor";
@@ -22,18 +25,32 @@ interface Props {
 export const FilterLabel = observer(function FilterLabel({ filter, onChange, onRemoveRequest }: Props) {
   const isEdited = filtersEditStore.editedFilter?.id === filter.id;
   const labelRef = useRef<HTMLDivElement>(null);
+  const labelNameRef = useRef<HTMLDivElement>(null);
+
+  const shouldShowFullTooltip = useElementHasOverflow(labelNameRef);
 
   return (
     <>
+      <Tooltip
+        anchorRef={labelRef}
+        label={
+          shouldShowFullTooltip ? (
+            <UITooltipFullVersion>
+              Edit or remove filter - <FilterDescriptionLabel filter={filter} />
+            </UITooltipFullVersion>
+          ) : (
+            "Edit or remove filter..."
+          )
+        }
+      />
       <UILabel ref={labelRef}>
         <Button
-          tooltip="Edit or remove filter..."
           icon={getFilterIntegration(filter)?.icon}
           onClick={action(() => {
             filtersEditStore.editedFilter = filter;
           })}
         >
-          <UILabelParts>
+          <UILabelParts ref={labelNameRef}>
             <FilterDescriptionLabel filter={filter} />
           </UILabelParts>
         </Button>
@@ -53,12 +70,10 @@ export const FilterLabel = observer(function FilterLabel({ filter, onChange, onR
               onChange={(filter) => {
                 onChange(filter);
               }}
-              onSubmit={(filter) => {
-                onChange(filter);
+              onRemove={onRemoveRequest}
+              onCloseRequest={() => {
                 filtersEditStore.editedFilter = null;
               }}
-              onRemove={onRemoveRequest}
-              saveLabel="Save"
             />
           </CustomizePopoverPanel>
         )}
@@ -70,10 +85,36 @@ export const FilterLabel = observer(function FilterLabel({ filter, onChange, onR
 const UILabel = styled.div``;
 
 const CustomizePopoverPanel = styled(PopoverPanel)`
-  width: 400px;
+  width: 460px;
+`;
+
+const ensureSpacesBetweenParts = css`
+  span {
+    &:after {
+      content: " ";
+    }
+    &:before {
+      content: " ";
+    }
+  }
+`;
+
+const UITooltipFullVersion = styled.div`
+  ${ensureSpacesBetweenParts}
 `;
 
 const UILabelParts = styled.div`
-  display: flex;
-  gap: 4px;
+  overflow: hidden;
+  max-width: 260px;
+  ${theme.common.ellipsisText}
+
+  /* Will put spaces between parts of label */
+  span {
+    &:after {
+      content: " ";
+    }
+    &:before {
+      content: " ";
+    }
+  }
 `;

--- a/desktop/views/ListView/Filters/NewFilterCreator.tsx
+++ b/desktop/views/ListView/Filters/NewFilterCreator.tsx
@@ -9,32 +9,19 @@ import { IconPlus } from "@aca/ui/icons";
 import { PopoverPanel } from "@aca/ui/popovers/PopoverPanel";
 import { theme } from "@aca/ui/theme";
 
-import { FilterEditor } from "./FilterEditor";
 import { FilterIntegrationPicker } from "./FilterIntegrationPicker";
-
-type NewFilterState = boolean | NotificationFilter;
 
 interface Props {
   onCreateRequest: (filter: NotificationFilter) => void;
 }
 
 export function NewFilterCreator({ onCreateRequest }: Props) {
-  const [isCreatingNew, setIsCreatingNew] = useState<NewFilterState>(false);
+  const [isCreatingNew, setIsCreatingNew] = useState<boolean>(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
   return (
     <>
       <UIHolder>
-        {/* <IconButton
-          ref={buttonRef}
-          tooltip="Add new filter..."
-          kind="primarySubtle"
-          icon={<IconPlus />}
-          onClick={() => {
-            setIsCreatingNew(true);
-          }}
-        >
-          Add filter
-        </IconButton> */}
         <Button
           ref={buttonRef}
           tooltip="Add new filter..."
@@ -60,32 +47,12 @@ export function NewFilterCreator({ onCreateRequest }: Props) {
           >
             <FilterIntegrationPicker
               onPicked={(integration) => {
-                setIsCreatingNew({ __typename: integration.notificationTypename, id: getUUID() });
-              }}
-            />
-          </CompactPopoverPanel>
-        )}
-        {typeof isCreatingNew !== "boolean" && (
-          <CustomizePopoverPanel
-            enableScreenCover
-            key={"customize"}
-            placement="bottom-start"
-            anchorRef={buttonRef}
-            onCloseRequest={() => {
-              setIsCreatingNew(false);
-            }}
-          >
-            <FilterEditor
-              filter={isCreatingNew}
-              onChange={(filter) => {
-                setIsCreatingNew(filter);
-              }}
-              onSubmit={(filter) => {
+                const filter: NotificationFilter = { __typename: integration.notificationTypename, id: getUUID() };
                 setIsCreatingNew(false);
                 onCreateRequest(filter);
               }}
             />
-          </CustomizePopoverPanel>
+          </CompactPopoverPanel>
         )}
       </AnimatePresence>
     </>
@@ -96,8 +63,4 @@ const UIHolder = styled.div``;
 
 const CompactPopoverPanel = styled(PopoverPanel)`
   ${theme.box.popover}
-`;
-
-const CustomizePopoverPanel = styled(PopoverPanel)`
-  width: 400px;
 `;

--- a/desktop/views/ListView/Filters/ServiceUsersFilterRow.tsx
+++ b/desktop/views/ListView/Filters/ServiceUsersFilterRow.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 
-import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
 import { ServiceUser } from "@aca/gql";
 import { FilterValue, FiltersData, getIsValueMatchingFilter } from "@aca/shared/filters";
 import { updateValue } from "@aca/shared/updateValue";
 import { MultipleOptionsDropdown } from "@aca/ui/forms/OptionsDropdown/multiple";
-import { theme } from "@aca/ui/theme";
+import { Avatar, OverlayingAvatars } from "@aca/ui/users/Avatar";
+
+import { FilterSettingRow } from "./utils";
 
 type FilterUser = Omit<ServiceUser, "__typename">;
 
@@ -21,15 +22,28 @@ export const ServiceUsersFilterRow = <F extends FiltersData<unknown>>({
   field: keyof F;
   onChange: (filter: F) => void;
 }) => (
-  <SettingRow title="People">
+  <FilterSettingRow title="People">
     <MultipleOptionsDropdown<FilterUser>
       items={users}
       keyGetter={(user) => user.id}
       labelGetter={(user) => user.real_name ?? user.display_name}
-      iconGetter={(user) => <UIAvatar style={{ backgroundImage: `url(${user.avatar_url})` }} />}
+      iconGetter={(user) => <Avatar src={user.avatar_url} name={user.real_name ?? user.display_name} />}
       selectedItems={users.filter((user) => {
         return getIsValueMatchingFilter(filter[field] as unknown as FilterValue<string>, user.id);
       })}
+      selectedItemsPreviewRenderer={(users) => {
+        if (!users.length) return null;
+
+        return (
+          <UISelectedPreview>
+            <OverlayingAvatars>
+              {users.map((user) => {
+                return <Avatar key={user.id} src={user.avatar_url} name={user.real_name ?? user.display_name} />;
+              })}
+            </OverlayingAvatars>
+          </UISelectedPreview>
+        );
+      }}
       onChange={(users) => {
         onChange(
           updateValue(filter, (filter) => {
@@ -43,13 +57,13 @@ export const ServiceUsersFilterRow = <F extends FiltersData<unknown>>({
       }}
       placeholder="Everyone"
     />
-  </SettingRow>
+  </FilterSettingRow>
 );
 
-const UIAvatar = styled.div`
-  height: 1em;
-  width: 1em;
-  ${theme.radius.circle};
-  background-size: cover;
-  background-color: #8884;
+const UISelectedPreview = styled.div`
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  max-width: 200px;
 `;

--- a/desktop/views/ListView/Filters/index.tsx
+++ b/desktop/views/ListView/Filters/index.tsx
@@ -6,6 +6,7 @@ import { styledObserver } from "@aca/shared/component";
 
 import { FilterLabel } from "./FilterLabel";
 import { NewFilterCreator } from "./NewFilterCreator";
+import { filtersEditStore } from "./store";
 
 interface Props {
   listId: string;
@@ -20,7 +21,7 @@ export const ListFilters = styledObserver(function ListFilters({ listId, classNa
         <NewFilterCreator
           onCreateRequest={(filter) => {
             list.update({ filters: [...list.filters, filter] });
-            //
+            filtersEditStore.editedFilter = filter;
           }}
         />
         {list.typedFilters.map((filter, index) => {

--- a/desktop/views/ListView/Filters/utils.ts
+++ b/desktop/views/ListView/Filters/utils.ts
@@ -1,5 +1,7 @@
 import { NotificationFilter } from "@aca/desktop/clientdb/list";
 import { integrationClientList } from "@aca/desktop/domains/integrations";
+import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
+import { injectProps } from "@aca/shared/components/injectProps";
 
 export function getFilterIntegration(filter: NotificationFilter) {
   const targetIntegration = integrationClientList.find(
@@ -8,3 +10,7 @@ export function getFilterIntegration(filter: NotificationFilter) {
 
   return targetIntegration ?? null;
 }
+
+export const FILTER_EDITOR_OPTION_WIDTH = 220;
+
+export const FilterSettingRow = injectProps(SettingRow, { fixedOptionWidth: FILTER_EDITOR_OPTION_WIDTH });

--- a/shared/components/injectProps.tsx
+++ b/shared/components/injectProps.tsx
@@ -1,4 +1,5 @@
 import { ComponentType } from "react";
+import React from "react";
 import styled from "styled-components";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/forms/FieldWithLabel.tsx
+++ b/ui/forms/FieldWithLabel.tsx
@@ -2,8 +2,8 @@ import { LayoutGroup, motion } from "framer-motion";
 import React, { ReactNode } from "react";
 import styled, { css } from "styled-components";
 
+import { styledForwardRef } from "@aca/shared/component";
 import { useId } from "@aca/shared/id";
-import { namedForwardRef } from "@aca/shared/react/namedForwardRef";
 import { POP_ANIMATION_CONFIG } from "@aca/ui/animations";
 import { IconChevronDown } from "@aca/ui/icons";
 import { theme } from "@aca/ui/theme";
@@ -19,16 +19,17 @@ export interface Props {
   onClick?: () => void;
   indicateDropdown?: boolean;
   cursorType?: CursorType;
+  className?: string;
 }
-export const FieldWithLabel = namedForwardRef<HTMLDivElement, Props>(function FieldWithLabel(
-  { pushLabel, icon, label, children, onClick, indicateDropdown, cursorType = "input", hasError = false },
+export const FieldWithLabel = styledForwardRef<HTMLDivElement, Props>(function FieldWithLabel(
+  { className, pushLabel, icon, label, children, onClick, indicateDropdown, cursorType = "input", hasError = false },
   forwardedRef
 ) {
   const id = useId();
 
   return (
     <LayoutGroup>
-      <UIHolder className="FOOBAR" onClick={onClick} ref={forwardedRef} cursorType={cursorType} hasError={hasError}>
+      <UIHolder className={className} onClick={onClick} ref={forwardedRef} cursorType={cursorType} hasError={hasError}>
         {icon && <UIIconHolder>{icon}</UIIconHolder>}
         <UIContentHolder>
           <UIFlyingOverlay>
@@ -53,7 +54,7 @@ export const FieldWithLabel = namedForwardRef<HTMLDivElement, Props>(function Fi
       </UIHolder>
     </LayoutGroup>
   );
-});
+})``;
 
 const UIHolder = styled.div<{ cursorType: CursorType; hasError: boolean }>`
   position: relative;

--- a/ui/forms/OptionsDropdown/SelectedOptionPreview.tsx
+++ b/ui/forms/OptionsDropdown/SelectedOptionPreview.tsx
@@ -8,3 +8,17 @@ export const SelectedOptionPreview = styled(OptionLabel)<{}>`
   ${theme.typo.label.medium}
   ${theme.common.ellipsisText};
 `;
+
+export const CommaSelectedOptionsPreview = styled.div<{}>`
+  ${theme.typo.content.medium};
+  white-space: normal;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  user-select: none;
+
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  display: -webkit-box;
+`;

--- a/ui/forms/OptionsDropdown/multiple.tsx
+++ b/ui/forms/OptionsDropdown/multiple.tsx
@@ -11,7 +11,7 @@ import { theme } from "@aca/ui/theme";
 
 import { DropdownItem } from "./DropdownItem";
 import { ItemsDropdown } from "./ItemsDropdown";
-import { SelectedOptionPreview } from "./SelectedOptionPreview";
+import { CommaSelectedOptionsPreview, SelectedOptionPreview } from "./SelectedOptionPreview";
 
 interface Props<I> {
   name?: string;
@@ -32,6 +32,7 @@ interface Props<I> {
   closeAfterItemPicked?: boolean;
   icon?: ReactNode;
   isDisabled?: boolean;
+  className?: string;
 }
 
 export const MultipleOptionsDropdown = observer(function MultipleOptionsDropdown<I>({
@@ -50,6 +51,7 @@ export const MultipleOptionsDropdown = observer(function MultipleOptionsDropdown
   icon,
   isDisabled,
   placeholder,
+  className,
 }: Props<I>) {
   const openerRef = useRef<HTMLDivElement>(null);
   const [isOpen, { unset: close, set: open }] = useBoolean(false);
@@ -93,17 +95,15 @@ export const MultipleOptionsDropdown = observer(function MultipleOptionsDropdown
         indicateDropdown
         cursorType="action"
         ref={openerRef}
+        className={className}
       >
         <UIHolder>
           <UIMenuOpener>
             <UISelectedItemsPreview>
               {selectedItemsPreviewRenderer && selectedItemsPreviewRenderer(selectedItems)}
-              {!selectedItemsPreviewRenderer &&
-                selectedItems.map((selectedItem) => {
-                  const key = keyGetter(selectedItem);
-                  const label = labelGetter(selectedItem);
-                  return <SelectedOptionPreview key={key} label={label} icon={iconGetter?.(selectedItem)} />;
-                })}
+              {!selectedItemsPreviewRenderer && selectedItems.length > 0 && (
+                <CommaSelectedOptionsPreview children={selectedItems.map(labelGetter).join(", ")} />
+              )}
 
               {!selectedItems.length && <SelectedOptionPreview label={placeholder ?? "Select..."} />}
             </UISelectedItemsPreview>

--- a/ui/users/Avatar.tsx
+++ b/ui/users/Avatar.tsx
@@ -1,0 +1,45 @@
+import { first } from "lodash";
+import React from "react";
+import styled from "styled-components";
+
+interface Props {
+  src?: string | null;
+  name?: string | null;
+  className?: string;
+}
+
+export const Avatar = styled(function Avatar({ src, name, className }: Props) {
+  return (
+    <UIAvatar data-tooltip={name} style={{ backgroundImage: `url(${src})` }} className={className}>
+      {!src && <UIName>{first(name)?.toUpperCase()}</UIName>}
+    </UIAvatar>
+  );
+})``;
+
+export const OverlayingAvatars = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  ${Avatar} {
+    margin-right: -8px;
+  }
+`;
+
+const UIAvatar = styled.div`
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  border-radius: 1em;
+  background-size: cover;
+  background-position: center;
+  background-color: #8884;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const UIName = styled.div`
+  font-size: 0.5em;
+  font-weight: 500;
+`;


### PR DESCRIPTION
- instantly show preview for new filters before they're 'saved'
- user select improvements
- filters labels truncating for super long ones
- unified pickers size and made it fixed so they're not flickering during selecting options
<img width="629" alt="CleanShot 2022-02-21 at 14 43 47@2x" src="https://user-images.githubusercontent.com/7311462/154966728-d6da6ef2-c8c3-4b83-9953-c9a1c076d38d.png">
