### PR TITLE
feat(slack): filter by conversation

### DIFF
--- a/backend/src/actions/actionHandlers.ts
+++ b/backend/src/actions/actionHandlers.ts
@@ -4,6 +4,7 @@ import { linearUsers } from "@aca/backend/src/linear/hasuraActions";
 import { getIndividualSlackInstallationURLHandler } from "@aca/backend/src/notificationCapture/hasuraActions";
 import {
   getTeamSlackInstallationURLHandler,
+  slackConversations,
   slackUser,
   slackUsers,
   uninstallSlack,
@@ -26,5 +27,6 @@ export const handlers: ActionHandler<any, any>[] = [
   linearUsers,
   slackUser,
   slackUsers,
+  slackConversations,
   uninstallSlack,
 ];

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -23,6 +23,10 @@ type Query {
 }
 
 type Query {
+  slack_conversations: [SlackConversation!]!
+}
+
+type Query {
   slack_user(team_id: uuid!): SlackUserOutput
 }
 
@@ -118,4 +122,10 @@ type ServiceUser {
   display_name: String!
   real_name: String
   avatar_url: String
+}
+
+type SlackConversation {
+  id: String!
+  name: String!
+  is_private: Boolean!
 }

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -53,6 +53,15 @@ actions:
       value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
   permissions:
   - role: user
+- name: slack_conversations
+  definition:
+    kind: ""
+    handler: '{{HASURA_ACTIONS_WEBHOOK_URL}}'
+    headers:
+    - name: Authorization
+      value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
+  permissions:
+  - role: user
 - name: slack_user
   definition:
     kind: ""
@@ -120,4 +129,5 @@ custom_types:
   - name: GetSlackInstallationURLOutput
   - name: SlackUser
   - name: ServiceUser
+  - name: SlackConversation
   scalars: []


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/155004220-43037c16-9238-4784-86d6-e07a60619097.mov

So far it only shows public&private channels. IMs and MPIMs would require multiple API requests to piece a namer together, and they are somewhat solved by the user picker already. I'd say let's wait til someone requests it.

It could maybe be combined with the conversation-type picker as these two are mutually exclusive. Maybe as two lists with a divider, e.g.?

- channels
- private channels
- group chats
- IMs
- ___
- #general
- #random
- ...

I didn't feel strongly enough about it yet, to go for it but maybe I should?