### PR TITLE
fix: properly clean up bridge effects on page reloads

### DIFF
--- a/desktop/electron/globals.ts
+++ b/desktop/electron/globals.ts
@@ -2,6 +2,8 @@ import { BrowserWindow, IpcMainEvent, app, ipcMain } from "electron";
 
 import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base/channels";
 
+import { getSourceWindowFromIPCEvent } from "./utils/ipc";
+
 /**
  * Important note.
  *
@@ -14,6 +16,7 @@ import { ElectronChannelSubscriber } from "@aca/desktop/bridge/base/channels";
 const electronGlobal = {
   ipcMain: ipcMain,
   BrowserWindow: BrowserWindow,
+  getSourceWindowFromIPCEvent,
   appReadyPromise: app.whenReady(),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   subscribe: (channel: string, subscriber: ElectronChannelSubscriber<any>) => {


### PR DESCRIPTION
Fixes: "Fail to load BrowserView"

I hope this was the root and the only cause.

Context:

TLDR: "bridge-effects" (eg show->hide view) were not cleaned up if page gets reloaded/crashed, etc. Reason is I trusted eg `useEffect` cleanups to call 'clean it up' requests. It is obviously bad, as react cleanups have no chance of being called if eg user reloads the page.

This is interesting bug resulting from my misassumption as a web dev. I assumed 'it is always safe to reload' as in web-dev it just dumps everything. In our case it is not true. App lifecycle is way longer than single window or webContents state.

Thus we cannot trust eg. 'useEffect' cleanups of 'bridges' to be called (as they have no such chance if page eg. gets reloaded).

As a result, if you reloaded the app (page), views were never cleaned up and asserts caught it. At first I had no idea why that happens and considered converting asserts to warns. 

In the end I'm quite happy I did not. It is always tempting to remove assert and just 'oh lets just replace existing view, then'. But turns out it surfaced some more fundamental bug, which is cool.