### PR TITLE
fix: do not update seen_at for removed list

### DIFF
--- a/clientdb/entity/entity.ts
+++ b/clientdb/entity/entity.ts
@@ -18,6 +18,7 @@ type EntityMethods<Data, Connections> = {
   getKeyName(): string;
   getUpdatedAt(): Date;
   remove(source?: EntityChangeSource): void;
+  isRemoved(): boolean;
   waitForSync(): Promise<void>;
   definition: EntityDefinition<Data, Connections>;
   db: DatabaseLinker;
@@ -105,6 +106,9 @@ export function createEntity<D, C>({ data, definition, store, linker }: CreateEn
     db: linker,
     remove(source) {
       store.removeById(entityMethods.getKey(), source);
+    },
+    isRemoved() {
+      return !store.findById(entityMethods.getKey());
     },
     waitForSync() {
       return waitForEntityAllAwaitingPushOperations(entity);

--- a/desktop/views/ListView/ListView.tsx
+++ b/desktop/views/ListView/ListView.tsx
@@ -43,7 +43,10 @@ export const ListView = observer(({ listId }: Props) => {
     displayedList.listEntity?.update({ seen_at: new Date().toISOString() });
 
     return () => {
-      displayedList.listEntity?.update({ seen_at: new Date().toISOString() });
+      const list = displayedList.listEntity;
+      if (list && !list.isRemoved()) {
+        list.update({ seen_at: new Date().toISOString() });
+      }
     };
   }, [displayedList]);
 


### PR DESCRIPTION
Cause: we update a `notification_list`'s `seen_at` after it was removed.

Possible solutions:
- (the one I picked) add a method for checking whether a thing was already removed. I could've done that inline, but I assumed this would be useful for other places as well
- throw an error when updating removed items
- ???

I'm pushing it through like this to fix the prod bug, but happy to circle back on it.

fyi @pie6k 