### PR TITLE
fix(slack): remove top-bar and resizer from embed

### DIFF
--- a/desktop/electron/bridgeHandlers/previews/siteFilters.ts
+++ b/desktop/electron/bridgeHandlers/previews/siteFilters.ts
@@ -8,11 +8,18 @@ const siteFilters: SiteFilter[] = [
   {
     on: (url) => isHostSlack(url),
     rewriteURL: (url) => url.toString().replace("/archives/", "/messages/"),
-    css: `.p-workspace-layout {
+    css: `.p-client {
+            grid-template-rows: auto min-content !important;
+            grid-template-areas: "p-client__workspace" "p-client__banners" !important;
+          }
+          .p-top_nav {
+            display: none !important;
+          }
+          .p-workspace-layout {
             grid-template-columns: 1fr fit-content(40%) !important;
             grid-template-areas: 'p-workspace__primary_view p-workspace__secondary_view' !important;  
           }
-          .p-workspace__sidebar {
+          .p-workspace__sidebar, .p-resizer {
             display: none !important;
           }
           .p-workspace__secondary_view {


### PR DESCRIPTION
<img width="1624" alt="Screen Shot 2022-03-02 at 12 03 28" src="https://user-images.githubusercontent.com/4051932/156358501-17016530-0292-445f-a9e9-5735d2c7907e.png">

Also fixes ACA-1355 