### PR TITLE
feat(theme): sync-with-os option

### DIFF
--- a/desktop/actions/settings.tsx
+++ b/desktop/actions/settings.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 
 import { applicationWideSettingsBridge } from "@aca/desktop/bridge/system";
-import { uiSettingsBridge } from "@aca/desktop/bridge/ui";
-import { uiStore } from "@aca/desktop/store/ui";
 import { uiSettings } from "@aca/desktop/store/uiSettings";
-import { IconBulb, IconChartLine, IconKeyboardHide } from "@aca/ui/icons";
+import { IconChartLine, IconKeyboardHide } from "@aca/ui/icons";
 
 import { defineAction } from "./action";
 import { defineGroup } from "./action/group";
@@ -21,21 +19,6 @@ export const toggleFocusModeStats = defineAction({
   icon: <IconChartLine />,
   handler() {
     uiSettings.showFocusModeStats = !uiSettings.showFocusModeStats;
-  },
-});
-
-export const toggleDarkTheme = defineAction({
-  name: "Toggle dark theme",
-  group: settingsActionsGroup,
-  keywords: ["dark mode", "mode"],
-  icon: <IconBulb />,
-  handler() {
-    const newDarkModeValue = !uiStore.isInDarkMode;
-
-    const prev = uiSettingsBridge.get();
-
-    // Avoid 'animated' change where all the buttons might change theme in a slightly different time.
-    uiSettingsBridge.set({ ...prev, isDarkMode: newDarkModeValue });
   },
 });
 

--- a/desktop/bridge/ui.ts
+++ b/desktop/bridge/ui.ts
@@ -1,10 +1,10 @@
 import { createBridgeValue } from "./base/persistance";
 
 interface UISettings {
-  isDarkMode: boolean;
+  theme: "auto" | "light" | "dark";
 }
 
 export const uiSettingsBridge = createBridgeValue<UISettings>("ui-settings", {
-  getDefault: () => ({ isDarkMode: false }),
+  getDefault: () => ({ theme: "auto" }),
   isPersisted: true,
 });

--- a/desktop/store/ui.ts
+++ b/desktop/store/ui.ts
@@ -107,16 +107,20 @@ autorun(() => {
 });
 
 // Updates the uiStore dark mode settings depending on the stored value in the settings bridge
+const preferDarkMediaQuery = "(prefers-color-scheme: dark)";
+const isSystemDarkBox = observable.box(window.matchMedia(preferDarkMediaQuery).matches);
+window.matchMedia(preferDarkMediaQuery).addEventListener("change", (event) => {
+  isSystemDarkBox.set(event.matches);
+});
+
 autorun(() => {
   const { isReady: isPersistedSettingsReady, value: persistedSettings } = uiSettingsBridge.observables;
 
   if (isPersistedSettingsReady.get()) {
-    const isInDarkMode = persistedSettings.get().isDarkMode;
-
-    if (typeof isInDarkMode !== "undefined") {
-      runInAction(() => {
-        uiStore.isInDarkMode = isInDarkMode;
-      });
-    }
+    const { theme } = persistedSettings.get();
+    const isInDarkMode = theme == "dark" || (theme == "auto" && isSystemDarkBox.get());
+    runInAction(() => {
+      uiStore.isInDarkMode = isInDarkMode;
+    });
   }
 });

--- a/desktop/views/SettingsView/Experimental.tsx
+++ b/desktop/views/SettingsView/Experimental.tsx
@@ -1,25 +1,38 @@
 import { observer } from "mobx-react";
 import React from "react";
 
-import { toggleDarkTheme } from "@aca/desktop/actions/settings";
 import { applicationWideSettingsBridge } from "@aca/desktop/bridge/system";
-import { uiStore } from "@aca/desktop/store/ui";
-import { ActionTrigger } from "@aca/desktop/ui/ActionTrigger";
+import { uiSettingsBridge } from "@aca/desktop/bridge/ui";
 import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
 import { SettingsList } from "@aca/desktop/ui/settings/SettingsList";
+import { typedKeys } from "@aca/shared/object";
+import { SingleOptionDropdown } from "@aca/ui/forms/OptionsDropdown/single";
 import { ShortcutPicker } from "@aca/ui/keyboard/ShortcutPicker";
-import { Toggle } from "@aca/ui/toggle";
+
+const THEME_LABELS = {
+  auto: "Sync with system",
+  dark: "Dark",
+  light: "Light",
+};
 
 export const ExperimentalSettings = observer(function ThemeSelector() {
-  const isDarkMode = uiStore.isInDarkMode;
   const settings = applicationWideSettingsBridge.get();
 
   return (
     <SettingsList>
-      <SettingRow title="Dark theme">
-        <ActionTrigger action={toggleDarkTheme}>
-          <Toggle size="small" isDisabled isSet={isDarkMode} />
-        </ActionTrigger>
+      <SettingRow title="Theme">
+        <SingleOptionDropdown
+          items={typedKeys(THEME_LABELS)}
+          selectedItem={uiSettingsBridge.get().theme}
+          keyGetter={(k) => k}
+          labelGetter={(key) => THEME_LABELS[key]}
+          onChange={(theme) => {
+            const prev = uiSettingsBridge.get();
+
+            // Avoid 'animated' change where all the buttons might change theme in a slightly different time.
+            uiSettingsBridge.set({ ...prev, theme });
+          }}
+        />
       </SettingRow>
       <SettingRow title="Global shortcut" description="System wide shortcut that will show up Acapela">
         <ShortcutPicker


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/156440732-15066d11-8db7-4c92-bcc1-204ccf9044db.mov

I had to end my day with a self-serving one i.e. I wanted Acapela to adjust with my system's theme.

I renamed the pre-existing persisted setting, because it's a string union now and the old name did not quite capture that. No effort to migrate previously persisted values was undertaken. My thinking was: people who want dark mode likely have it set in their system as well, hence the default `auto` option has got their back.

Now this also promotes dark mode to a first-class citizen by it being default-on for some people. Is that cool? You tell me!