### PR TITLE
fix(slack): record slack thread activity

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_slack_thread_involed_user.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_slack_thread_involed_user.yaml
@@ -1,0 +1,3 @@
+table:
+  name: slack_thread_involed_user
+  schema: public

--- a/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/tables.yaml
@@ -27,6 +27,7 @@
 - "!include public_priority.yaml"
 - "!include public_slack_conversation_type.yaml"
 - "!include public_slack_notification_queue.yaml"
+- "!include public_slack_thread_involed_user.yaml"
 - "!include public_sync_request.yaml"
 - "!include public_task.yaml"
 - "!include public_task_slack_message.yaml"

--- a/infrastructure/hasura/migrations/default/1646645659342_create_table_public_slack_thread_involed_user/down.sql
+++ b/infrastructure/hasura/migrations/default/1646645659342_create_table_public_slack_thread_involed_user/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."slack_thread_involed_user";

--- a/infrastructure/hasura/migrations/default/1646645659342_create_table_public_slack_thread_involed_user/up.sql
+++ b/infrastructure/hasura/migrations/default/1646645659342_create_table_public_slack_thread_involed_user/up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE "public"."slack_thread_involed_user" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "thread_ts" Text NOT NULL, "user_id" text NOT NULL, PRIMARY KEY ("id") , UNIQUE ("thread_ts", "user_id"));COMMENT ON TABLE "public"."slack_thread_involed_user" IS E'Collect mentioned or authoring users within a thread to reduce Slack API requests';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;


### PR DESCRIPTION
A two-staged process for reducing rate-limit issues when capturing Slack messages:

This introduces a `slack_thread_involved_user` table for capturing users which have authored or were mentioned in a thread. We already use it for lookups and an early-return when checking thread-involvedness, thereby reducing rate-limit situations a bit.
In a few days we will then completely drop the Slack API thread lookup (ACA-1390) as by then most thread activity should be recorded on our side as well.