### PR TITLE
feat: refresh expiring jira webhooks

### DIFF
--- a/backend/src/atlassian/rest.ts
+++ b/backend/src/atlassian/rest.ts
@@ -78,6 +78,15 @@ export function deleteWebhooks(webhookIds: string[]): JiraRequest<void> {
   };
 }
 
+export function refreshWebhooks(webhookIds: number[]): JiraRequest<void> {
+  return async function refreshWebhooksRest(headers, meta) {
+    return await axios.put(`${jiraBaseApiUrl}/${meta.jiraCloudId}/rest/api/3/webhook/refresh`, {
+      headers,
+      data: { webhookIds },
+    });
+  };
+}
+
 export function getIssueWatchers(issueKey: string): JiraRequest<GetWatchersResponse> {
   return async function getWatchersRest(headers, meta) {
     return await axios.get(`${jiraBaseApiUrl}/${meta.jiraCloudId}/rest/api/3/issue/${issueKey}/watchers`, { headers });

--- a/backend/src/cron/cron.ts
+++ b/backend/src/cron/cron.ts
@@ -5,7 +5,7 @@ import { dailyMessageNotification } from "@aca/backend/src/cron/dailyMessageNoti
 import { UnprocessableEntityError, isHttpError } from "@aca/backend/src/errors/errorTypes";
 import { logger } from "@aca/shared/logger";
 
-import { updateAtlassianRefreshToken } from "../atlassian/utils";
+import { refreshExpiringAtlassianProperties } from "../atlassian/utils";
 import { HttpStatus } from "../http";
 import { autoArchiveOrCloseTopics } from "./autoArchiveOrCloseTopics";
 import { delayedTopicRequestsDoneNotifications } from "./delayedTopicRequestsDoneNotifications";
@@ -18,7 +18,7 @@ const handlers: Record<string, Function> = {
   "delayed-topic-requests-done-notification": delayedTopicRequestsDoneNotifications,
   "daily-message-notification": dailyMessageNotification,
   "proactive-notifications": proactiveNotifications,
-  "update-atlassian-refresh-token": updateAtlassianRefreshToken,
+  "refresh-expiring-atlassian-properties": refreshExpiringAtlassianProperties,
 };
 
 interface CronPayload {

--- a/infrastructure/hasura/metadata/cron_triggers.yaml
+++ b/infrastructure/hasura/metadata/cron_triggers.yaml
@@ -54,12 +54,12 @@
   headers:
   - name: Authorization
     value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
-- name: update-atlassian-refresh-token
+- name: refresh-expiring-atlassian-properties
   webhook: '{{HASURA_CRON_WEBHOOK_URL}}'
-  schedule: '* * 1 * *'
+  schedule: 0 3 * * *
   include_in_metadata: true
   payload:
-    handler: update-atlassian-refresh-token
+    handler: refresh-expiring-atlassian-properties
   headers:
   - name: Authorization
     value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER


### PR DESCRIPTION
Atlassian webhooks expire after 30 days. We added a mechanism to an existing cron job so that expiring webhooks would get refreshed