### PR TITLE
fix(slack): simplify capture filter

### DIFF
--- a/desktop/clientdb/notification/index.ts
+++ b/desktop/clientdb/notification/index.ts
@@ -9,9 +9,7 @@ import { userIdContext } from "@aca/clientdb/utils/context";
 import { getGenericDefaultData } from "@aca/clientdb/utils/getGenericDefaultData";
 import { trackEvent } from "@aca/desktop/analytics";
 import { notificationResolvedChannel } from "@aca/desktop/bridge/notification";
-import { getIsNotificationPassingFilters } from "@aca/desktop/clientdb/list";
 import { makeLogger } from "@aca/desktop/domains/dev/makeLogger";
-import { accountStore } from "@aca/desktop/store/account";
 import {
   DesktopNotificationFragment,
   Notification_Bool_Exp,
@@ -182,16 +180,11 @@ export const notificationEntity = defineEntity<DesktopNotificationFragment>({
     },
   })
   .addAccessValidation((notification) => {
-    if (notification.inner) {
-      const user = accountStore.assertUser;
-      return (
-        notification.kind !== "notification_slack_message" ||
-        getIsNotificationPassingFilters(notification, user.importFilters)
-      );
-    } else {
+    if (!notification.inner) {
       log.error(`No inner for entity ${notification.id}`);
       return false;
     }
+    return true;
   });
 
 export type NotificationEntity = EntityByDefinition<typeof notificationEntity>;

--- a/desktop/clientdb/user.ts
+++ b/desktop/clientdb/user.ts
@@ -7,7 +7,6 @@ import { EntityByDefinition } from "@aca/clientdb";
 import { createHasuraSyncSetupFromFragment } from "@aca/clientdb/sync";
 import { getFragmentKeys } from "@aca/clientdb/utils/analyzeFragment";
 import { getGenericDefaultData } from "@aca/clientdb/utils/getGenericDefaultData";
-import { NotificationFilter } from "@aca/desktop/clientdb/list";
 import { DesktopUserFragment, User_Bool_Exp, User_Set_Input } from "@aca/gql";
 
 import { accountEntity } from "./account";
@@ -20,7 +19,7 @@ const userFragment = gql`
     email
     avatar_url
     is_slack_auto_resolve_enabled
-    import_filters
+    slack_included_channels
     updated_at
     created_at
   }
@@ -40,14 +39,14 @@ export const userEntity = defineEntity<DesktopUserFragment>({
     __typename: "user",
     has_slack_installation: null,
     avatar_url: null,
-    import_filters: [],
+    slack_included_channels: [],
     ...getGenericDefaultData(),
   }),
   customObservableAnnotations: {
-    import_filters: observable.ref,
+    slack_included_channels: observable.ref,
   },
   sync: createHasuraSyncSetupFromFragment<DesktopUserFragment, UserConstraints>(userFragment, {
-    updateColumns: ["is_slack_auto_resolve_enabled", "import_filters"],
+    updateColumns: ["is_slack_auto_resolve_enabled", "slack_included_channels"],
   }),
 }).addConnections((user, { getEntity }) => {
   return {
@@ -62,9 +61,6 @@ export const userEntity = defineEntity<DesktopUserFragment>({
     },
     get isNew() {
       return Math.abs(differenceInSeconds(new Date(), new Date(user.created_at))) < 5;
-    },
-    get importFilters() {
-      return user.import_filters as NotificationFilter[];
     },
   };
 });

--- a/desktop/domains/integrations/SlackSettings.tsx
+++ b/desktop/domains/integrations/SlackSettings.tsx
@@ -1,10 +1,11 @@
 import { observer } from "mobx-react";
 import React from "react";
+import styled from "styled-components";
 
 import { toggleSlackAutoResolve } from "@aca/desktop/actions/slack";
 import { accountStore } from "@aca/desktop/store/account";
 import { ActionTrigger } from "@aca/desktop/ui/ActionTrigger";
-import { ListFilters } from "@aca/desktop/ui/Filters";
+import { SlackConversationsDropdown } from "@aca/desktop/ui/Filters/FilterEditorSlack";
 import { SettingRow } from "@aca/desktop/ui/settings/SettingRow";
 import { VStack } from "@aca/ui/Stack";
 import { Toggle } from "@aca/ui/toggle";
@@ -15,7 +16,7 @@ export const SlackSettings = observer(() => {
     <VStack gap={16}>
       <SettingRow
         title="Resolve with reply"
-        description="Automatically resolve Slack messages to which you reply or react"
+        description="Automatically resolve Slack messages to which you reply or react."
       >
         <ActionTrigger action={toggleSlackAutoResolve}>
           <Toggle isDisabled isSet={user?.is_slack_auto_resolve_enabled} />
@@ -23,15 +24,20 @@ export const SlackSettings = observer(() => {
       </SettingRow>
 
       <VStack gap={8}>
-        <SettingRow title="Filter conversations" description="Select which conversation types should be imported" />
-        <ListFilters
-          value={user.importFilters}
-          onChange={(filters) => {
-            user.update({ import_filters: filters });
-          }}
-          singleType="notification_slack_message"
-        />
+        <SettingRow title="Include channels" description="Messages in these channels will turn into notifications.">
+          <UISlackConversationsDropdown
+            placeholder="None"
+            checkSelected={(id) => user.slack_included_channels.includes(id)}
+            onChange={(channels) => {
+              user.update({ slack_included_channels: channels.map((c) => c.id) });
+            }}
+          />
+        </SettingRow>
       </VStack>
     </VStack>
   );
 });
+
+const UISlackConversationsDropdown = styled(SlackConversationsDropdown)`
+  max-width: 200px;
+`;

--- a/desktop/ui/Filters/NewFilterCreator.tsx
+++ b/desktop/ui/Filters/NewFilterCreator.tsx
@@ -12,10 +12,9 @@ import { FilterIntegrationPicker } from "./FilterIntegrationPicker";
 
 interface Props {
   onCreateRequest: (filter: NotificationFilter) => void;
-  singleType?: NotificationFilter["__typename"];
 }
 
-export function NewFilterCreator({ singleType, onCreateRequest }: Props) {
+export function NewFilterCreator({ onCreateRequest }: Props) {
   const [isCreatingNew, setIsCreatingNew] = useState<boolean>(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -28,11 +27,7 @@ export function NewFilterCreator({ singleType, onCreateRequest }: Props) {
           kind="primarySubtle"
           icon={<IconPlus />}
           onClick={() => {
-            if (singleType) {
-              onCreateRequest({ __typename: singleType, id: getUUID() });
-            } else {
-              setIsCreatingNew(true);
-            }
+            setIsCreatingNew(true);
           }}
         >
           Add filter

--- a/desktop/ui/Filters/index.tsx
+++ b/desktop/ui/Filters/index.tsx
@@ -11,15 +11,13 @@ import { filtersEditStore } from "./store";
 interface Props {
   value: NotificationFilter[];
   onChange: (filters: NotificationFilter[]) => void;
-  singleType?: NotificationFilter["__typename"];
   className?: string;
 }
 
-export const ListFilters = styledObserver(({ value, onChange, singleType, className }: Props) => (
+export const ListFilters = styledObserver(({ value, onChange, className }: Props) => (
   <UIHolder className={className}>
     <UIFilters>
       <NewFilterCreator
-        singleType={singleType}
         onCreateRequest={(filter) => {
           onChange([...value, filter]);
           filtersEditStore.editedFilter = filter;

--- a/infrastructure/hasura/metadata/cron_triggers.yaml
+++ b/infrastructure/hasura/metadata/cron_triggers.yaml
@@ -54,12 +54,12 @@
   headers:
   - name: Authorization
     value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER
-- name: refresh-expiring-atlassian-properties
+- name: update-atlassian-refresh-token
   webhook: '{{HASURA_CRON_WEBHOOK_URL}}'
-  schedule: 0 3 * * *
+  schedule: '* * 1 * *'
   include_in_metadata: true
   payload:
-    handler: refresh-expiring-atlassian-properties
+    handler: update-atlassian-refresh-token
   headers:
   - name: Authorization
     value_from_env: HASURA_ACTIONS_WEBHOOK_AUTHORIZATION_HEADER

--- a/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
@@ -51,6 +51,7 @@ select_permissions:
     - is_bot
     - is_slack_auto_resolve_enabled
     - name
+    - slack_included_channels
     - updated_at
     computed_fields:
     - has_account
@@ -80,6 +81,7 @@ update_permissions:
     - import_filters
     - is_slack_auto_resolve_enabled
     - name
+    - slack_included_channels
     filter:
       id:
         _eq: X-Hasura-User-Id

--- a/infrastructure/hasura/migrations/default/1646647082923_alter_table_public_user_add_column_slack_included_channels/down.sql
+++ b/infrastructure/hasura/migrations/default/1646647082923_alter_table_public_user_add_column_slack_included_channels/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."user" add column "slack_included_channels" jsonb
+--  not null default '[]';

--- a/infrastructure/hasura/migrations/default/1646647082923_alter_table_public_user_add_column_slack_included_channels/up.sql
+++ b/infrastructure/hasura/migrations/default/1646647082923_alter_table_public_user_add_column_slack_included_channels/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."user" add column "slack_included_channels" jsonb
+ not null default '[]';


### PR DESCRIPTION

<img width="537" alt="image" src="https://user-images.githubusercontent.com/4051932/157014739-8cfddff3-c1bd-4402-a5ed-f9101fa28f4a.png">


Simplify Slack filters to be a purely-additive conversations selector. This was motivated by us running into rate limits quickly. It will still be possible we run into rate-limit here but to a significantly lesser degree. We might have to propagate the limits to users in the future, as limits apply on a per-workspace basis, so one noisy user can limit others.

ACA-1392 for dropping the now-unused `import_filters` column in the future when users have updated their app.

---

I just now realized that I created a bit of a hard-to-migrate-out situation here: When we flip this on, people will see a whole bunch of notifications that were previously filtered out with `import_filters`. I don't see a way around this right now. I'm curious to get other peoples' opinions on this!