### PR TITLE
fix: try to disable 2nd instance lock to see if it fixes auto updater

### DIFF
--- a/desktop/electron/singleInstance.ts
+++ b/desktop/electron/singleInstance.ts
@@ -1,28 +1,23 @@
-import { app } from "electron";
-
-import { appState } from "./appState";
-import { initializeMainWindow } from "./mainWindow";
-
 export function initializeSingleInstanceLock() {
-  const isFirstInstance = app.requestSingleInstanceLock();
-
-  if (!isFirstInstance) {
-    app.quit();
-    return;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  app.on("second-instance", (event, commandLine, workingDirectory) => {
-    const { mainWindow } = appState;
-    if (!mainWindow) {
-      initializeMainWindow();
-      return;
-    }
-
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore();
-    }
-
-    mainWindow.focus();
-  });
+  /**
+   * It is possible that instance lock is the reason auto-updater fails. Not sure.
+   * Case: updater opens '2nd' instance before closing 1st one, and it is blocked.
+   */
+  // const isFirstInstance = app.requestSingleInstanceLock();
+  // if (!isFirstInstance) {
+  //   app.quit();
+  //   return;
+  // }
+  // // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // app.on("second-instance", (event, commandLine, workingDirectory) => {
+  //   const { mainWindow } = appState;
+  //   if (!mainWindow) {
+  //     initializeMainWindow();
+  //     return;
+  //   }
+  //   if (mainWindow.isMinimized()) {
+  //     mainWindow.restore();
+  //   }
+  //   mainWindow.focus();
+  // });
 }


### PR DESCRIPTION
It's a bet.

I think 2nd instance lock is breaking auto-updater.

Hipotesis: auto-updater opens 2nd instance before 1st one is closed. And it is blocked and 'new version' is instantly closed.

I discovered it while debugging why 'nothing happens' when you click 'install update' by opening Acapela from CLI. And it worked then. And maybe CLI 'instance' is not considered '2nd' instance the same way.