### PR TITLE
fix: make resolve action applicable to resolved notifications

### DIFF
--- a/desktop/actions/notification.tsx
+++ b/desktop/actions/notification.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { ActionContext } from "@aca/desktop/actions/action/context";
 import { trackingEvent } from "@aca/desktop/analytics";
 import { OpenAppUrl, openAppUrl } from "@aca/desktop/bridge/apps";
 import { getIntegration } from "@aca/desktop/bridge/apps/shared";
@@ -35,16 +34,6 @@ async function convertToLocalAppUrlIfAny(notification: NotificationEntity): Prom
   } else {
     return { fallback };
   }
-}
-
-function isNotificationResolved(ctx: ActionContext) {
-  const notification = ctx.getTarget("notification");
-  if (notification) {
-    return notification.isResolved;
-  }
-
-  const group = ctx.getTarget("group");
-  return Boolean(group && group.notifications.every((notification) => notification.isResolved));
 }
 
 export const openNotificationInApp = defineAction({
@@ -108,9 +97,6 @@ export const resolveNotification = defineAction({
   icon: <IconCheck />,
   group: currentNotificationActionsGroup,
   name: (ctx) => {
-    if (isNotificationResolved(ctx)) {
-      return ctx.isContextual ? "Next" : "Move to next notification";
-    }
     if (ctx.hasTarget("group")) {
       return ctx.isContextual ? "Resolve all" : "Resolve all notifications in group";
     }


### PR DESCRIPTION
This is a bit sub-optimal, so this very fix might be more of a conversation starter than what we actually want to merge. The problem is I do not quite know how to make the behavior we want fit to our action framework. Here is what we want:

## Status Quo

You are looking at a Slack notification, with auto-resolved turned on, and reply to it, thus it being marked as resolved. Now you want to move on to the next notification with `Cmd + D` which currently does not work, since the notification you are viewing has already been resolved and thus the action can not be applied.

## With this PR...

...the resolve action becomes always applicable, even when the notification is already resolved. This is what we want in the sense that we want `Cmd + D` to move you through the list always. But it also means that the icon in the top bar becomes non-disabled and the resolve button in the footer is always visible.
I made it so that the label says "Next" for the action when the notification is already resolved, but that also introduce some duplication here, where right next to it sits the `⬇️ Next` button.

## What do we want here?

Maybe this is already what we want? The duplication in the footer is a bit sub-optimal, but the resolve button still being clickable (and taking one to the next time) seems somewhat correct.
I guess this is necessity by definition, we are calling it "resolveNotification" but actually the action does "resolve and move on", which are kind of two actions and we still want to apply the latter, even if the former does not apply.


Wdyt?