### PR TITLE
fix(slack): drop conversation.replies call

### DIFF
--- a/backend/src/slack/capture.ts
+++ b/backend/src/slack/capture.ts
@@ -89,14 +89,7 @@ async function checkIsInvolvedInThread(
   ts: string,
   slackUserId: string
 ): Promise<boolean> {
-  if (await db.slack_thread_involed_user.findFirst({ where: { user_id: slackUserId, thread_ts: ts } })) {
-    return true;
-  }
-  const { messages } = await slackClient.conversations.replies({ token, channel, ts });
-  return (messages ?? []).some(
-    (message) =>
-      message.user === slackUserId || extractMentionedSlackUserIdsFromMd(message.text).some((id) => id == slackUserId)
-  );
+  return Boolean(await db.slack_thread_involed_user.findFirst({ where: { user_id: slackUserId, thread_ts: ts } }));
 }
 
 /**


### PR DESCRIPTION
This is phase two of ACA-1389, which has been on prod for 3 days. That means we have 3 days worth of thread-involvedness recorded. Probably not quite enough to handle all messages reliably but since I've now seen a few more `conversation.replies`-rate-limit errors I'd merge this soon, as this also screws with reliability.