### PR TITLE
fix: close command picker on click away

### DIFF
--- a/desktop/domains/commandMenu/CommandMenuView.tsx
+++ b/desktop/domains/commandMenu/CommandMenuView.tsx
@@ -1,9 +1,11 @@
 import { action } from "mobx";
 import { observer } from "mobx-react";
 import React, { useEffect, useRef, useState } from "react";
+import { useClickAway } from "react-use";
 import styled from "styled-components";
 
 import { ActionData, resolveActionData } from "@aca/desktop/actions/action";
+import { commandMenuStore } from "@aca/desktop/domains/commandMenu/store";
 import {
   getIsLastArrayElement,
   getLastElementFromArray,
@@ -29,6 +31,7 @@ interface Props {
 
 export const CommandMenuView = observer(function CommandMenuView({ session, onActionSelected }: Props) {
   const [activeAction, setActiveAction] = useState<ActionData | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
   const actionsScrollerRef = useRef<HTMLDivElement>(null);
 
   const { actionContext } = session;
@@ -106,10 +109,17 @@ export const CommandMenuView = observer(function CommandMenuView({ session, onAc
     }
   });
 
+  useClickAway(
+    bodyRef,
+    action(() => {
+      commandMenuStore.session = null;
+    })
+  );
+
   return (
     <BodyPortal>
       <UICover>
-        <UIBody>
+        <UIBody ref={bodyRef}>
           <UIHead>
             <CommandMenuTargetLabel session={session} />
           </UIHead>


### PR DESCRIPTION
@pie6k I initially went with `useHandleCloseRequest`, but noticed that there is a bug in there, where it depends on `ref.current` as hook dependencies which afaik is kind of illegal hook-dependency usage. Anyway it resulted in a bug where initial clicks outside without render-triggering actions (like scrolling or hovering) would not trigger. I decided to use `react-use`'s `useClickAway` instead since
- this seems like an unlikely multi-popover scenario
- I could not quite parse the intention of the `useHandleCloseRequest` code and the unshifting in the cleanup function
- I remember us talking about a more solid rewrite of multiple popover with the `InteractionBoundary` thing, which I assume we could just plug in here once that's done