### PR TITLE
fix(slack): re-connect with correct target

### DIFF
--- a/backend/src/slack/app.ts
+++ b/backend/src/slack/app.ts
@@ -100,10 +100,9 @@ const sharedOptions: Options<typeof SlackBolt.ExpressReceiver> & Options<typeof 
   installationStore: {
     async storeInstallation(installation) {
       const { userId } = parseMetadata(installation);
-      if (!userId) {
-        return;
+      if (userId) {
+        await storeUserSlackInstallation(userId, installation);
       }
-      await storeUserSlackInstallation(userId, installation);
     },
 
     async fetchInstallation(query) {

--- a/desktop/domains/integrations/slack.tsx
+++ b/desktop/domains/integrations/slack.tsx
@@ -59,14 +59,15 @@ export const slackIntegrationClient: IntegrationClient = {
   async connect(teamId) {
     const url = await querySlackInstallationURL(teamId);
 
-    const getInstallationsCount = () => accountStore.user?.slackInstallations.count ?? 0;
-    const initialInstallationsCount = getInstallationsCount();
+    const getFullInstallationsCount = () =>
+      accountStore.user?.slackInstallations.query({ hasAllScopes: true }).count ?? 0;
+    const initialInstallationsCount = getFullInstallationsCount();
 
     const closeSlackInstallWindow = await connectSlackBridge({ url });
 
     return new Promise<void>((resolve) => {
       const stop = autorun(() => {
-        if (initialInstallationsCount < getInstallationsCount()) {
+        if (initialInstallationsCount < getFullInstallationsCount()) {
           if (closeSlackInstallWindow) {
             closeSlackInstallWindow();
             trackEvent("Slack Integration Added");

--- a/desktop/views/ToastsAndCommunicates/SlackToasts.tsx
+++ b/desktop/views/ToastsAndCommunicates/SlackToasts.tsx
@@ -11,14 +11,14 @@ export const SlackToasts = observer(() => {
   return (
     <>
       {slackInstallations
-        ?.filter((install) => Boolean(install && !install?.hasAllScopes))
+        ?.filter((install) => Boolean(install && !install.hasAllScopes))
         .map((install) => (
           <Toast
             key={install.id}
             title={`Missing Slack permissions for ${install.team_name}`}
             description="A permission update is needed to make the Slack integration work smoothly"
             action={connectSlack}
-            target={install}
+            target={{ id: install.team_id, name: install.team_name, kind: "account" }}
           />
         ))}
     </>


### PR DESCRIPTION
I accidentally broke the re-connect flow when adding multi-workspaces. Two fixes in here:
- supply the correct target for the connect button (still wish we had type checking for the whole action-target-thing)
- change install slack to be not just based on number of installations but also their scope-completeness