### PR TITLE
fix(slack): drop unused import_filters

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user.yaml
@@ -38,7 +38,6 @@ select_permissions:
     - created_at
     - email
     - id
-    - import_filters
     - is_bot
     - is_slack_auto_resolve_enabled
     - name
@@ -63,7 +62,6 @@ update_permissions:
     columns:
     - avatar_url
     - current_team_id
-    - import_filters
     - is_slack_auto_resolve_enabled
     - name
     - slack_included_channels

--- a/infrastructure/hasura/migrations/default/1647012421117_alter_table_public_user_drop_column_import_filters/down.sql
+++ b/infrastructure/hasura/migrations/default/1647012421117_alter_table_public_user_drop_column_import_filters/down.sql
@@ -1,0 +1,19 @@
+alter table "public"."user" alter column "import_filters" set default ((((('[
+    {
+      "id": "'::text || gen_random_uuid()) || '",
+      "__typename": "notification_slack_message",
+      "conversation_type": {
+        "$in": [
+          "im",
+          "mpim"
+        ]
+      }
+    },
+    {
+      "id": "'::text) || gen_random_uuid()) || '",
+      "__typename": "notification_slack_message",
+      "is_mention": true
+    }
+  ]'::text))::jsonb;
+alter table "public"."user" alter column "import_filters" drop not null;
+alter table "public"."user" add column "import_filters" jsonb;

--- a/infrastructure/hasura/migrations/default/1647012421117_alter_table_public_user_drop_column_import_filters/up.sql
+++ b/infrastructure/hasura/migrations/default/1647012421117_alter_table_public_user_drop_column_import_filters/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."user" drop column "import_filters" cascade;


### PR DESCRIPTION
2nd stage of #1121, dropping the now-unused column since it's been enough days to update the app