### PR TITLE
fix(sentry): set crash tag

### DIFF
--- a/desktop/domains/errorRecovery/RootErrorBoundary.tsx
+++ b/desktop/domains/errorRecovery/RootErrorBoundary.tsx
@@ -12,5 +12,7 @@ const ErrorRecoveryView = () => (
 );
 
 export const RootErrorBoundary = ({ children }: { children: React.ReactNode }) => (
-  <Sentry.ErrorBoundary fallback={ErrorRecoveryView}>{children}</Sentry.ErrorBoundary>
+  <Sentry.ErrorBoundary fallback={ErrorRecoveryView} beforeCapture={(scope) => scope.setTag("severity", "crash")}>
+    {children}
+  </Sentry.ErrorBoundary>
 );


### PR DESCRIPTION
Also set-up the sentry-slack integrations to post into #bugs when an issue with this tag is created:
https://sentry.io/organizations/acapela/alerts/rules/acapela/10521723/

Currently it's also enabled for staging, once I've verified it to work, I'll switch the rule to be prod-only.