### PR TITLE
fix: list renaming not working

### DIFF
--- a/desktop/domains/list/defineList.ts
+++ b/desktop/domains/list/defineList.ts
@@ -173,7 +173,9 @@ export function defineNotificationsList({
   return {
     kind: "notificationsList" as const,
     id,
-    name,
+    get name() {
+      return listEntity?.title ?? name;
+    },
     isCustom,
     getNotificationGroup,
     getAllGroupedNotifications,


### PR DESCRIPTION
We were 'unwrapping' list name as string at moment of list creation, resulting in this not being observable - thus resulting in list rename not working. (it technically did work but only after refreshing page you'd see result)

It surfaces kinda issue with trying to mix custom and non-custom lists into one API (we should refactor that soon)