### PR TITLE
fix: avoid calculating context menu actions at render level

### DIFF
--- a/desktop/domains/contextMenu/useActionsContextMenu.tsx
+++ b/desktop/domains/contextMenu/useActionsContextMenu.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { ActionData, resolveActionData } from "@aca/desktop/actions/action";
 import { ActionContext, createActionContext } from "@aca/desktop/actions/action/context";
 import { resolveGroupData } from "@aca/desktop/actions/action/group";
@@ -62,9 +60,7 @@ export function useActionsContextMenu(
 
   const equalActions = useEqualRef(actions);
 
-  const menuItems = useMemo(() => {
+  useContextMenu(refOrElement, () => {
     return prepareContextMenuItemsFromActions(equalActions, context);
-  }, [context, equalActions]);
-
-  useContextMenu(refOrElement, menuItems);
+  });
 }

--- a/desktop/domains/contextMenu/useContextMenu.tsx
+++ b/desktop/domains/contextMenu/useContextMenu.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { showContextMenuRequest } from "@aca/desktop/bridge/menu";
 import { createElementEvent } from "@aca/shared/domEvents";
+import { useMethod } from "@aca/shared/hooks/useMethod";
 
 import { RefOrElement, resolveRefOrElement } from "./refOrElement";
 import { ContextMenuItem } from "./types";
@@ -11,7 +12,9 @@ export type ContextMenuItemWithCallback = ContextMenuItem & {
   onSelected?: () => void;
 };
 
-export function useContextMenu(refOrElement: RefOrElement, items: ContextMenuItemWithCallback[]) {
+export function useContextMenu(refOrElement: RefOrElement, itemsGetter: () => ContextMenuItemWithCallback[]) {
+  const itemsGetterRef = useMethod(itemsGetter);
+
   useEffect(() => {
     const element = resolveRefOrElement(refOrElement);
 
@@ -19,6 +22,8 @@ export function useContextMenu(refOrElement: RefOrElement, items: ContextMenuIte
 
     return createElementEvent(element, "contextmenu", async (event) => {
       event.stopPropagation();
+
+      const items = itemsGetterRef();
 
       const rawItems = items.map((item) => omit(item, "onSelected"));
 
@@ -29,5 +34,5 @@ export function useContextMenu(refOrElement: RefOrElement, items: ContextMenuIte
         originalItem?.onSelected?.();
       }
     });
-  }, [refOrElement, items]);
+  }, [refOrElement, itemsGetter]);
 }

--- a/desktop/ui/Filters/FilterLabel.tsx
+++ b/desktop/ui/Filters/FilterLabel.tsx
@@ -30,7 +30,7 @@ export const FilterLabel = observer(function FilterLabel({ filter, onChange, onR
 
   const shouldShowFullTooltip = useElementHasOverflow(labelNameRef);
 
-  useContextMenu(labelRef, [
+  useContextMenu(labelRef, () => [
     {
       label: "Remove",
       onSelected() {


### PR DESCRIPTION
Another interesting performance bug:

I was calculating list of right click menu items  while rendering list item (including 'isEnabled' flags for context menu items). 

This is obvious waste as we dont need this list untill you actually right click.

This also meant all items were re-calculating this list on focus change in list view. (as some actions are enabled/disabled basing on which item is active, etc)

Thus I made this list lazy `Item[]` > `() => Item[]` and only calculate it inside `contextmenu` event handler, greatly reducing count of re-renders.

This is a good lesson for me:
- be more careful monitoring lists re-rendering performance.
- lazy compute everything that is not needed for visual output of any component