### PR TITLE
fix: onboarding notion spaces work

### DIFF
--- a/desktop/clientdb/notification/notion/notionSpaceUser.ts
+++ b/desktop/clientdb/notification/notion/notionSpaceUser.ts
@@ -66,6 +66,15 @@ export const notionSpaceUserEntity = defineEntity<NotionSpaceUserFragment>({
     },
   }))
   .addEventHandlers({
+    itemAdded(dataNow, { getEntity }) {
+      if (dataNow.is_sync_enabled) {
+        const selected = getEntity(notionSpaceUserEntity)
+          .all.filter((spaceUser) => spaceUser.is_sync_enabled)
+          .map((spaceUser) => spaceUser.notionSpace.space_id);
+        notionSelectedSpaceValue.set({ selected });
+      }
+    },
+
     itemUpdated(dataNow, dataBefore, { getEntity }) {
       if (dataNow.is_sync_enabled !== dataBefore.is_sync_enabled) {
         const selected = getEntity(notionSpaceUserEntity)

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -90,7 +90,7 @@ export function startNotionSync(): ServiceSyncController {
       isSyncing = true;
       log.info(`Capturing started`);
 
-      await updateAvailableSpaces(sessionData);
+      await updateAvailableSpaces();
 
       const syncEnabledSpaces = notionSelectedSpaceValue.get();
 
@@ -166,7 +166,9 @@ async function fetchNotionNotificationLog(sessionData: NotionSessionData, spaceI
   return result;
 }
 
-async function updateAvailableSpaces(sessionData: NotionSessionData) {
+export async function updateAvailableSpaces() {
+  const sessionData = await getNotionSessionData();
+
   const getSpacesResponse = await fetch(notionURL + "/api/v3/getSpaces", {
     method: "POST",
     headers: {

--- a/desktop/electron/auth/notion.ts
+++ b/desktop/electron/auth/notion.ts
@@ -4,6 +4,7 @@ import { notionSelectedSpaceValue } from "@aca/desktop/bridge/apps/notion";
 import { clearServiceCookiesBridge, loginNotionBridge, notionAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { tryInitializeServiceSync } from "@aca/desktop/electron/apps";
 
+import { updateAvailableSpaces } from "../apps/notion/worker";
 import { authWindowDefaultOptions } from "./utils";
 
 export const notionURL = "https://www.notion.so";
@@ -43,6 +44,7 @@ export async function loginNotion() {
 export function initializeNotionAuthHandler() {
   loginNotionBridge.handle(async () => {
     await loginNotion();
+    await updateAvailableSpaces();
     tryInitializeServiceSync("notion");
   });
 

--- a/desktop/electron/bridgeHandlers/system.ts
+++ b/desktop/electron/bridgeHandlers/system.ts
@@ -36,6 +36,7 @@ export function initializeSystemHandlers() {
   clearAllDataRequest.handle(async () => {
     await clearPersistance();
     await session.defaultSession.clearStorageData();
+    await session.defaultSession.clearCache();
     await restartApp();
   });
 


### PR DESCRIPTION
We now update the notion spaces bridge whenever a new notion_space_user is added.

We also prefill the available spaces before the notion sync starts, so that we get initial notifications right away 