### PR TITLE
feat: return all channels user is member of

### DIFF
--- a/desktop/ui/Filters/FilterEditorSlack.tsx
+++ b/desktop/ui/Filters/FilterEditorSlack.tsx
@@ -100,6 +100,7 @@ async function querySlackConversations() {
         }
       }
     `,
+    fetchPolicy: "no-cache",
   });
   return data?.slack_conversations ?? [];
 }


### PR DESCRIPTION
# Fix

The approach we were using was not querying for all of the channels (it was excluding quite a few). We needed to take a paginated approach to grab all of them.

<img width="275" alt="Screenshot 2022-03-21 at 13 57 26" src="https://user-images.githubusercontent.com/4765697/159276517-75307568-6f3d-4eeb-a1de-0e950c9a3d8f.png">

This new approach also only returns channels that you're member of and slack connect channels.

## TODO:

I have not tested this with multiple workspaces. Need to fix my dev setup to take care of that, but releasing this on the meantime.