### PR TITLE
fix(slack): propagate notification delete

### DIFF
--- a/backend/src/events/eventHandlers.ts
+++ b/backend/src/events/eventHandlers.ts
@@ -1,9 +1,0 @@
-import { Account, LinearIssue, User } from "@aca/db";
-
-import { createHasuraEventsHandler } from "../hasura";
-
-export const hasuraEvents = createHasuraEventsHandler<{
-  account_updates: Account;
-  user_updates: User;
-  linear_issue_updates: LinearIssue;
-}>();

--- a/backend/src/events/events.ts
+++ b/backend/src/events/events.ts
@@ -2,19 +2,29 @@ import { Request, Response, Router } from "express";
 
 import { extractAndAssertBearerToken } from "@aca/backend/src/authentication";
 import { AuthenticationError } from "@aca/backend/src/errors/errorTypes";
-import { handleLinearIssueChanges } from "@aca/backend/src/linear/events";
+import { createHasuraEventsHandler } from "@aca/backend/src/hasura";
+import { Account, LinearIssue, NotificationSlackMessage, User } from "@aca/db";
 import { logger } from "@aca/shared/logger";
 
 import { handleAccountUpdates } from "../atlassian";
-import { hasuraEvents } from "./eventHandlers";
+import { handleLinearIssueChanges } from "../linear/events";
+import { handleNotificationSlackMessageChanges } from "../slack/events";
 import { handleCreateSyncRequests } from "./handleCreateSyncRequests";
 
 export const router = Router();
 
 logger.info("Initialize hasura event handlers");
 
+const hasuraEvents = createHasuraEventsHandler<{
+  account_updates: Account;
+  linear_issue_updates: LinearIssue;
+  notification_slack_message: NotificationSlackMessage;
+  user_updates: User;
+}>();
+
 hasuraEvents.addHandler("account_updates", ["INSERT", "UPDATE", "DELETE"], handleAccountUpdates);
 hasuraEvents.addHandler("linear_issue_updates", ["INSERT", "UPDATE"], handleLinearIssueChanges);
+hasuraEvents.addHandler("notification_slack_message", ["DELETE"], handleNotificationSlackMessageChanges);
 hasuraEvents.addAnyEventHandler(handleCreateSyncRequests);
 
 router.post("/v1/events", middlewareAuthenticateHasura, async (req: Request, res: Response) => {

--- a/backend/src/slack/events.ts
+++ b/backend/src/slack/events.ts
@@ -1,0 +1,8 @@
+import { HasuraEvent } from "@aca/backend/src/hasura";
+import { NotificationSlackMessage, db } from "@aca/db";
+
+export async function handleNotificationSlackMessageChanges(event: HasuraEvent<NotificationSlackMessage>) {
+  if (event.type == "delete") {
+    await db.notification.delete({ where: { id: event.item.notification_id } });
+  }
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -12,6 +12,7 @@ export type {
   linear_issue as LinearIssue,
   linear_oauth_token as LinearOauthToken,
   notification_linear as NotificationLinear,
+  notification_slack_message as NotificationSlackMessage,
   user as User,
   user_slack_installation as UserSlackInstallation,
   whitelist as Whitelist,

--- a/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_message.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_notification_slack_message.yaml
@@ -25,3 +25,17 @@ select_permissions:
         user_id:
           _eq: X-Hasura-User-Id
   role: user
+event_triggers:
+- definition:
+    delete:
+      columns: "*"
+    enable_manual: false
+  headers:
+  - name: Authorization
+    value_from_env: HASURA_EVENTS_WEBHOOK_AUTHORIZATION_HEADER
+  name: notification_slack_message_updates
+  retry_conf:
+    interval_sec: 10
+    num_retries: 0
+    timeout_sec: 60
+  webhook_from_env: HASURA_EVENTS_WEBHOOK_URL


### PR DESCRIPTION
We use the pg delete cascade to get rid of `notification_slack_message` rows for disconnected `user_slack_installation`s. This did not propagate to `notification`. Since the parent-child relationship is backwards here (for pseudo-union reasons), we have to manually propagate the delete.