### PR TITLE
feat: show proper actions for snoozed / resolved rows

### DIFF
--- a/desktop/ui/ActionIconButton.tsx
+++ b/desktop/ui/ActionIconButton.tsx
@@ -8,7 +8,9 @@ import { IconButton } from "@aca/ui/buttons/IconButton";
 import { ButtonKind, ButtonSize } from "@aca/ui/buttons/variants";
 import { describeShortcut } from "@aca/ui/keyboard/describeShortcut";
 
-interface Props {
+import { SharedActionButtonProps } from "./actionShared";
+
+interface Props extends SharedActionButtonProps {
   action: ActionData;
   target?: unknown;
   hideShortcutTooltip?: boolean;
@@ -26,18 +28,19 @@ export const ActionIconButton = styledObserver(function ActionIconButton({
   kind,
   size,
   className,
+  notApplicableMode = "disable",
 }: Props) {
   const context = createActionContext(target);
   const { icon, canApply, shortcut, name } = resolveActionData(action, context);
 
-  const isDisabled = !canApply(context);
+  const isApplicable = canApply(context);
 
   function getTooltip() {
     const parts: string[] = [];
 
     if (showTitleInTooltip) parts.push(name);
 
-    if (!hideShortcutTooltip && shortcut && !isDisabled) {
+    if (!hideShortcutTooltip && shortcut && !isApplicable) {
       if (showTitleInTooltip) {
         parts.push(`(${describeShortcut(shortcut)})`);
       } else {
@@ -49,6 +52,10 @@ export const ActionIconButton = styledObserver(function ActionIconButton({
 
     return parts.join(" ");
   }
+
+  if (!isApplicable && notApplicableMode === "hide") return null;
+
+  const isDisabled = notApplicableMode === "disable" && !isApplicable;
 
   return (
     <IconButton

--- a/desktop/views/ListView/NotificationRow.tsx
+++ b/desktop/views/ListView/NotificationRow.tsx
@@ -85,13 +85,10 @@ export const NotificationRow = styledObserver(({ notification }: Props) => {
         {title && <UINotificationRowTitle>{title}&nbsp;</UINotificationRowTitle>}
         <UINotificationPreviewText>{notification.text_preview}</UINotificationPreviewText>
 
-        {!isFocused && (
-          <>
-            {!notification.isResolved && <SnoozeLabel notificationOrGroup={notification} />}
+        {!notification.isResolved && <SnoozeLabel notificationOrGroup={notification} />}
 
-            <NotificationDate notification={notification} />
-          </>
-        )}
+        <NotificationDate notification={notification} />
+
         {isFocused && <RowQuickActions target={notification} />}
       </UIHolder>
     </ActionTrigger>

--- a/desktop/views/ListView/NotificationsGroupRow.tsx
+++ b/desktop/views/ListView/NotificationsGroupRow.tsx
@@ -144,12 +144,8 @@ export const NotificationsGroupRow = styledObserver(({ group }: Props) => {
               {group.notifications.find((n) => !!n.text_preview)?.text_preview}
             </UINotificationPreviewText>
           </UITitle>
-          {!isFocused && (
-            <>
-              {group.notifications.some((n) => !n.isResolved) && <SnoozeLabel notificationOrGroup={group} />}
-              <NotificationDate notification={firstNotification} />
-            </>
-          )}
+          {group.notifications.some((n) => !n.isResolved) && <SnoozeLabel notificationOrGroup={group} />}
+          <NotificationDate notification={firstNotification} />
           {isFocused && <RowQuickActions target={group} />}
         </UIHolder>
         {!group.isOnePreviewEnough && isOpened && (

--- a/desktop/views/ListView/RowQuickActions.tsx
+++ b/desktop/views/ListView/RowQuickActions.tsx
@@ -2,8 +2,8 @@ import { observer } from "mobx-react";
 import React from "react";
 import styled from "styled-components";
 
-import { resolveNotification } from "@aca/desktop/actions/notification";
-import { snoozeNotification } from "@aca/desktop/actions/snooze";
+import { resolveNotification, unresolveNotification } from "@aca/desktop/actions/notification";
+import { snoozeNotification, unsnoozeNotification } from "@aca/desktop/actions/snooze";
 import { NotificationEntity } from "@aca/desktop/clientdb/notification";
 import { NotificationsGroup } from "@aca/desktop/domains/group/group";
 import { ActionIconButton } from "@aca/desktop/ui/ActionIconButton";
@@ -21,6 +21,7 @@ export const RowQuickActions = observer(({ target }: Props) => {
         action={resolveNotification}
         target={target}
         showTitleInTooltip
+        notApplicableMode="hide"
       />
       <ActionIconButton
         kind="transparent"
@@ -28,6 +29,23 @@ export const RowQuickActions = observer(({ target }: Props) => {
         action={snoozeNotification}
         target={target}
         showTitleInTooltip
+        notApplicableMode="hide"
+      />
+      <ActionIconButton
+        kind="transparent"
+        size="compact"
+        action={unsnoozeNotification}
+        target={target}
+        showTitleInTooltip
+        notApplicableMode="hide"
+      />
+      <ActionIconButton
+        kind="transparent"
+        size="compact"
+        action={unresolveNotification}
+        target={target}
+        showTitleInTooltip
+        notApplicableMode="hide"
       />
     </UIHolder>
   );


### PR DESCRIPTION
will show unresolve / unsnooze quick actions on hover