### PR TITLE
fix(notion): more optional fields

### DIFF
--- a/desktop/electron/apps/notion/schema.ts
+++ b/desktop/electron/apps/notion/schema.ts
@@ -7,8 +7,7 @@ const NotionUserPayload = z.object({
   value: z.object({
     email: z.string(),
     id: z.string(),
-    name: z.string(),
-    onboarding_completed: z.boolean(),
+    name: z.string().optional(),
     profile_photo: z.string().optional(),
     version: z.number(),
   }),
@@ -146,7 +145,7 @@ const CollectionPayload = z.object({
     .object({
       id: z.string(),
       version: z.number(),
-      name: z.array(z.array(z.string())), //[["Maybe a Collection"]],
+      name: z.array(z.array(z.string())).optional(), //[["Maybe a Collection"]],
       schema: z.unknown(),
       parent_id: z.string(),
       parent_table: z.string(), //"block",


### PR DESCRIPTION
Took me a while yesterday to realize that our sentry errors are truncated, so I only saw one schema mismatch at a time. So I upped the error length yesterday and this is resulting more learning from it.