### PR TITLE
fix(notion): detail log for commented event

### DIFF
--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -383,6 +383,10 @@ function getNotificationProperties(
   const activityValue = recordMap.activity?.[notification.activity_id].value;
 
   if (notification.type === "user-mentioned") {
+    if (!activityValue) {
+      log.error(new Error("Missing activity value for notification " + JSON.stringify(notification, null, 2)));
+      return;
+    }
     const activity = UserMentionedActivityValue.parse(activityValue);
     const url =
       notionURL +


### PR DESCRIPTION
I want to understand this one better, which only affects a few people so far but still: https://sentry.io/organizations/acapela/issues/3136790266/

Hopefully we can turn on inclusion of input data in zod logs [soon](https://github.com/colinhacks/zod/pull/851), but even with it this case would've been low on log info, since the expectation is more contextual here, i.e. if the notification type is `commented`, we expect there to be a certain activity in the map. So manual logging it is, either way.