### PR TITLE
fix(notion): collection.name and drop optional mismatched fields

### DIFF
--- a/desktop/electron/apps/notion/schema.ts
+++ b/desktop/electron/apps/notion/schema.ts
@@ -65,7 +65,6 @@ export const Notification = z.object({
   collection_id: z.string().optional(),
   end_time: z.string(),
   type: z.enum(["user-mentioned", "commented", "user-invited", "reminder"]),
-  channel: z.string(),
 });
 
 const NotificationPayload = z.object({
@@ -151,7 +150,7 @@ const CollectionPayload = z.object({
     .object({
       id: z.string(),
       version: z.number(),
-      name: z.array(z.array(z.string())).optional(), //[["Maybe a Collection"]],
+      name: z.array(z.unknown()).optional(), //[["Maybe a Collection"]],
       schema: z.unknown(),
       parent_id: z.string(),
       parent_table: z.string(), //"block",
@@ -206,11 +205,9 @@ const ActivityEdit = z.union([
 
 const ActivityValueCommon = z.object({
   id: z.string(),
-  context_id: z.string(),
   edits: z.array(ActivityEdit),
   end_time: z.string(),
 
-  in_log: z.boolean(),
   index: z.number(),
   invalid: z.boolean(),
 

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -364,7 +364,8 @@ function getPageTitle(
       return;
     }
 
-    return collection?.name?.[0]?.[0] ?? "Untitled";
+    const name = collection?.name?.flat()[0];
+    return typeof name === "string" ? name : "Untitled";
   }
 }
 


### PR DESCRIPTION
Mainly aimed to address `collection.name` which can be more deeply nested than expected:
https://sentry.io/organizations/acapela/issues/3135941342
Took a bit of a brutal approach of just flattening it and picking the first element if it's a string.

And then there were a few more fields that are [actually optional](https://sentry.io/organizations/acapela/issues/3135855521/?project=6170771&query=is%3Aunresolved+release%3A4.151.6&sort=user&statsPeriod=24h), but we're not using them anyway, so in the spirt of small surface I dropped them.