### PR TITLE
fix(notion): don't skip non-comments

### DIFF
--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -293,12 +293,7 @@ function extractNotifications(payload: Awaited<ReturnType<typeof fetchNotionNoti
 
       const updated_at = created_at;
 
-      if (activity.type !== "commented") {
-        continue;
-      }
-
       const authorId = activity.edits[0]?.authors?.[0]?.id ?? "Notion";
-
       if (authorId === "Notion") {
         log.error("unable to extract authorId from activity" + JSON.stringify(activity, null, 2));
       }


### PR DESCRIPTION
I am not quite sure why that line was there, which blocks non-comment notifications from being created. With the try-catch around each row we'll see if it blows up, but for me locally it made page invites work again.

Do you remember @omarduarte?