### PR TITLE
test: remove e2e caddy routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -15,11 +15,6 @@ handle_path /api/auth/* {
 	reverse_proxy {$BACKEND_HOST}
 }
 
-handle_path /api/e2e/* {
-	rewrite * /api/e2e{path}
-	reverse_proxy {$BACKEND_HOST}
-}
-
 handle_path /api/backend/healthz {
 	rewrite * /healthz
 	reverse_proxy {$BACKEND_HOST}

--- a/desktop/electron/auth/acapela.ts
+++ b/desktop/electron/auth/acapela.ts
@@ -56,7 +56,7 @@ export async function loginAcapela(provider: "slack" | "google") {
 }
 
 async function fetchTestUserJWT() {
-  const response = await fetch("http://localhost:3000/api/e2e/test_user");
+  const response = await fetch("http://localhost:3000/api/backend/e2e/test_user");
   const { jwt } = await response.json();
   return jwt;
 }


### PR DESCRIPTION
We did some ungodly things when scrambling to get fake-testing-auth working, Chris gave me a nudge on how to reduce the sin count of that code so this is that.

aka no routes that are only necessary for testing in stage/prod no more