### PR TITLE
fix: correct atlassian cron handler name

### DIFF
--- a/backend/src/cron/cron.ts
+++ b/backend/src/cron/cron.ts
@@ -10,7 +10,7 @@ import { HttpStatus } from "../http";
 export const router = Router();
 
 const handlers: Record<string, Function> = {
-  "refresh-expiring-atlassian-properties": refreshExpiringAtlassianProperties,
+  "update-atlassian-refresh-token": refreshExpiringAtlassianProperties,
 };
 
 interface CronPayload {


### PR DESCRIPTION
I guess that means we did not rotate tokens so far, might be a problem?