### PR TITLE
fix: acapela pops up for no reason

### DIFF
--- a/desktop/electron/apps/figma/worker.ts
+++ b/desktop/electron/apps/figma/worker.ts
@@ -57,6 +57,7 @@ export async function getFigmaSessionData(): Promise<FigmaSessionData> {
   const figmaWindow = new BrowserWindow({
     width: 0,
     height: 0,
+    show: false,
   });
 
   figmaWindow.hide();


### PR DESCRIPTION
Fix: 
Creating a new BrowserWindow will focus the app unless `show: true` is used.

