### PR TITLE
fix(notion): ignore network errors

### DIFF
--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -122,7 +122,13 @@ export async function updateAvailableSpaces() {
       cookie: sessionData.cookie,
     },
     body: JSON.stringify({}),
-  });
+  })
+    // fetch only rejects for network errors which we want to ignore
+    .catch(() => null);
+
+  if (!getSpacesResponse) {
+    return;
+  }
 
   if (getSpacesResponse.status >= 400 && getSpacesResponse.status < 500) {
     clearNotionSessionData();


### PR DESCRIPTION
We do not care about logging network errors, thus we ignore them.

Related: https://sentry.io/organizations/acapela/issues/2983410903/