### PR TITLE
fix: jira status update showed null

### DIFF
--- a/backend/src/atlassian/capturing.ts
+++ b/backend/src/atlassian/capturing.ts
@@ -244,7 +244,7 @@ async function handleJiraIssueUpdate(payload: JiraWebhookPayload) {
     }
 
     // Notifies all issue watchers when the status of the issue was updated
-    if (payload.changelog.items.some(({ fieldId }) => fieldId === "status")) {
+    if (changeLogItem.fieldId === "status") {
       // We're attempting to do a round-robin of access_token usage based on "least recently used access token"
       // The point is that we would like to distribute api rate limit "cost" of making an api call between
       // all users of the same jira cloud is. This way, we don't overexpose a single users' access_token


### PR DESCRIPTION
A bug allowed another changeLog item to be used.

We were getting the data from this:

```
{
  changeLogItem: {
    field: 'resolution',
    fieldtype: 'jira',
    fieldId: 'resolution',
    from: null,
    fromString: null,
    to: '10000',
    toString: 'Done'
  }
}
```

instead of this:

```
{
  changeLogItem: {
    field: 'status',
    fieldtype: 'jira',
    fieldId: 'status',
    from: '10000',
    fromString: 'To Do',
    to: '10001',
    toString: 'Done'
  }
}
```