### PR TITLE
fix(slack): use legacy state verification

### DIFF
--- a/backend/src/slack/app.ts
+++ b/backend/src/slack/app.ts
@@ -1,6 +1,5 @@
 import { ServerResponse } from "http";
 
-import * as Sentry from "@sentry/node";
 import * as SlackBolt from "@slack/bolt";
 import { noop } from "lodash";
 
@@ -145,6 +144,7 @@ const sharedOptions: Options<typeof SlackBolt.ExpressReceiver> & Options<typeof 
   },
 
   installerOptions: {
+    legacyStateVerification: true,
     callbackOptions: {
       success(installation, options, req, res) {
         const { redirectURL } = parseMetadata(installation);
@@ -158,7 +158,7 @@ const sharedOptions: Options<typeof SlackBolt.ExpressReceiver> & Options<typeof 
         const { redirectURL } = parseMetadata({ metadata: options.metadata });
         const isAlreadyUsedError = Boolean(error.stack?.includes(SLACK_WORKSPACE_ALREADY_USED_ERROR));
         if (!isAlreadyUsedError) {
-          Sentry.captureException(error);
+          logger.error(error, "Error during slack installation");
         }
         handleInstallationResponse(res, redirectURL, {
           // puts the error into the URL's query params for the frontend to pick it up

--- a/backend/src/slack/installMetadata.ts
+++ b/backend/src/slack/installMetadata.ts
@@ -8,8 +8,5 @@ export type InstallMetadata = { teamId?: string; userId?: string; redirectURL?: 
  */
 
 export function parseMetadata({ metadata }: { metadata?: string }): InstallMetadata {
-  if (!metadata) {
-    throw new Error("Missing metadata");
-  }
-  return JSON.parse(metadata);
+  return metadata ? JSON.parse(metadata) : {};
 }

--- a/desktop/domains/integrations/slack.tsx
+++ b/desktop/domains/integrations/slack.tsx
@@ -97,6 +97,7 @@ async function querySlackInstallationURL(teamId?: string) {
         }
       `,
       variables: { input: { teamId, redirectURL: "" } },
+      fetchPolicy: "no-cache",
     }
   );
   return assertDefined(slackInstallation?.url, "missing slack installation url");


### PR DESCRIPTION
A couple of mis-directions in our code which I also fixed in here. Main issue was that the way we do state verification was secretly deprecated. So for now I'm opting us into the old flow (which stopped being the default). I'm going to nag them to be more mindful about changelogs, though ultimately the best thing would be if we had an e2e that would've tested this but yeah that's whole other thing.

And there will be follow-up PR to get us out of legacy. This here is for fighting the fire.