### PR TITLE
fix(notion): parse union late

### DIFF
--- a/desktop/electron/apps/notion/schema.ts
+++ b/desktop/electron/apps/notion/schema.ts
@@ -204,7 +204,7 @@ const ActivityEdit = z.union([
   z.object({ authors: z.array(z.object({ id: z.string() })) }),
 ]);
 
-const ActivityValueCommon = z.object({
+export const ActivityValueCommon = z.object({
   id: z.string(),
   edits: z.array(ActivityEdit).optional(),
   end_time: z.string(),
@@ -239,9 +239,7 @@ export const UserMentionedActivityValue = ActivityValueCommon.extend({
 
 export const ActivityPayload = z.object({
   role: z.string(),
-  value: z
-    .discriminatedUnion("type", [UserInvitedActivityValue, CommentedActivityValue, UserMentionedActivityValue])
-    .optional(),
+  value: z.unknown().optional(),
 });
 
 export const GetSpacesResult = z.record(

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -18,6 +18,7 @@ import { wait } from "@aca/shared/time";
 
 import { extractBlockMention, extractNotionComment } from "./commentExtractor";
 import {
+  ActivityValueCommon,
   CollectionViewPageBlockValue,
   CommentedActivityValue,
   GetNotificationLogResult,
@@ -221,7 +222,7 @@ function extractNotifications(payload: Awaited<ReturnType<typeof fetchNotionNoti
         continue;
       }
 
-      const activity = recordMap.activity?.[notification.activity_id]?.value;
+      const activity = ActivityValueCommon.parse(recordMap.activity?.[notification.activity_id]?.value);
 
       // Weird bug where activity is undefined for a user
       // https://sentry.io/organizations/acapela/issues/3114653912/


### PR DESCRIPTION
To address https://sentry.io/organizations/acapela/issues/3144862397/events/8950f4b7a91340f0a735c3d0c1f9eebf

Unfortunately zod does not allow for sth like "open unions" which to be fair I don't even know how that could work. So the approach I'm starting to favor is to parse sub-entities late, on-demand and only for the fields we actually use in that context.