### PR TITLE
fix: unread badge count opt-in

### DIFF
--- a/desktop/bridge/system.ts
+++ b/desktop/bridge/system.ts
@@ -46,6 +46,7 @@ export const applicationWideSettingsBridge = createBridgeValue("app-wide-setting
     globalPeekShortcut: null as ShortcutKeys | null,
     enableDesktopNotifications: true,
     showNotificationsCountBadge: true,
+    showUnreadNotificationsCountBadge: false,
     notificationsCountBadgeListIds: [] as string[],
     showShortcutsBar: true,
   }),

--- a/desktop/views/BadgeCountManager.tsx
+++ b/desktop/views/BadgeCountManager.tsx
@@ -20,7 +20,9 @@ function getOpenNotifications() {
 
 export const BadgeCountManager = observer(() => {
   useAutorun(() => {
-    if (!applicationWideSettingsBridge.get().showNotificationsCountBadge) {
+    const settings = applicationWideSettingsBridge.get();
+
+    if (!settings.showNotificationsCountBadge) {
       setBadgeCountRequest(0);
       return;
     }
@@ -29,11 +31,16 @@ export const BadgeCountManager = observer(() => {
 
     if (openNotifications === undefined) return;
 
-    const unreadCount = openNotifications.filter((n) => n.isUnread).length;
-    if (unreadCount > 0) {
-      setBadgeCountRequest(unreadCount);
+    if (!settings.showUnreadNotificationsCountBadge) {
+      setBadgeCountRequest(openNotifications.length);
     } else {
-      setBadgeCountRequest(openNotifications.length > 0 ? "•" : 0);
+      const unreadCount = openNotifications.filter((n) => n.isUnread).length;
+      if (unreadCount > 0) {
+        setBadgeCountRequest(unreadCount);
+      } else {
+        // If there are open notifications, but all are read, we still show an indicator
+        setBadgeCountRequest(openNotifications.length > 0 ? "•" : 0);
+      }
     }
   });
 

--- a/desktop/views/SettingsView/Notifications.tsx
+++ b/desktop/views/SettingsView/Notifications.tsx
@@ -29,7 +29,7 @@ export const NotificationsSettings = observer(function ThemeSelector() {
       </SettingRow>
       <SettingRow
         title="Show notifications count badge"
-        description="Show number of new notifications next to Acapela app icon"
+        description="Show number of unresolved notifications next to Acapela app icon"
       >
         <Toggle
           size="small"
@@ -41,21 +41,36 @@ export const NotificationsSettings = observer(function ThemeSelector() {
         />
       </SettingRow>
       {settings.showNotificationsCountBadge && (
-        <SettingRow
-          title="Lists to count notifications for count badge"
-          description="Select lists from which to count notifications to show next to Acapela app icon"
-        >
-          <MultipleOptionsDropdown<NotificationListEntity>
-            items={allLists.all}
-            keyGetter={(l) => l.id}
-            labelGetter={(l) => l.title}
-            selectedItems={allLists.all.filter((l) => settings.notificationsCountBadgeListIds.includes(l.id))}
-            placeholder="All lists"
-            onChange={(lists) => {
-              applicationWideSettingsBridge.update({ notificationsCountBadgeListIds: lists.map((l) => l.id) });
-            }}
-          />
-        </SettingRow>
+        <>
+          <SettingRow
+            title="Only count unread notifications for count badge"
+            description="Shows number of unread notifications that have not been resolved yet"
+          >
+            <Toggle
+              size="small"
+              isDisabled
+              isSet={settings.showUnreadNotificationsCountBadge}
+              onChange={(isEnabled) => {
+                applicationWideSettingsBridge.update({ showUnreadNotificationsCountBadge: isEnabled });
+              }}
+            />
+          </SettingRow>
+          <SettingRow
+            title="Lists to count notifications for count badge"
+            description="Select lists from which to count notifications to show next to Acapela app icon"
+          >
+            <MultipleOptionsDropdown<NotificationListEntity>
+              items={allLists.all}
+              keyGetter={(l) => l.id}
+              labelGetter={(l) => l.title}
+              selectedItems={allLists.all.filter((l) => settings.notificationsCountBadgeListIds.includes(l.id))}
+              placeholder="All lists"
+              onChange={(lists) => {
+                applicationWideSettingsBridge.update({ notificationsCountBadgeListIds: lists.map((l) => l.id) });
+              }}
+            />
+          </SettingRow>
+        </>
       )}
     </SettingsList>
   );


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/161746010-ea2346ab-5db1-46e0-a202-ddb4fb8c4be3.mov

Roland asked to make the unread badge count opt-in. I made that the default recently since I noticed that its not a good signal for my usage which is less inbox-zero centered and more around letting notifications lie around. We both agreed that this breaks with our inbox-zero principle.