### PR TITLE
feat: add reconnect toasts when notion/figma session lost

### DIFF
--- a/desktop/electron/auth/figma.ts
+++ b/desktop/electron/auth/figma.ts
@@ -22,6 +22,15 @@ export async function loginFigma() {
 
   window.webContents.loadURL(figmaURL + "/login");
 
+  /*
+    This is done as some previous actions that trigger a figma login may steal focus
+    I believe the right fix for this is have the login screens as modals, but this would require
+    managing closing the modals https://github.com/electron/electron/issues/30232
+  */
+  window.webContents.on("did-finish-load", () => {
+    window.focus();
+  });
+
   return new Promise<void>((resolve) => {
     window.webContents.on("did-navigate-in-page", async () => {
       const token = await getFigmaAuthToken();

--- a/desktop/electron/auth/notion.ts
+++ b/desktop/electron/auth/notion.ts
@@ -25,6 +25,15 @@ export async function loginNotion() {
 
   window.webContents.loadURL(notionURL + "/login");
 
+  /*
+    This is done as some previous actions that trigger a figma login may steal focus
+    I believe the right fix for this is have the login screens as modals, but this would require
+    managing closing the modals https://github.com/electron/electron/issues/30232
+  */
+  window.webContents.on("did-finish-load", () => {
+    window.focus();
+  });
+
   return new Promise<void>((resolve) => {
     window.webContents.on("did-navigate-in-page", async () => {
       const token = await getNotionAuthToken();


### PR DESCRIPTION
<img width="982" alt="Screenshot 2022-04-06 at 10 52 57" src="https://user-images.githubusercontent.com/4765697/161948968-b169c2f9-008f-4091-9a72-b39c3ee84589.png">

@pie6k thank you for the toast util. It's amazingly easy to use.