### PR TITLE
feat(slack): capture unread IMs on install

### DIFF
--- a/infrastructure/hasura/metadata/databases/default/tables/public_user_slack_installation.yaml
+++ b/infrastructure/hasura/metadata/databases/default/tables/public_user_slack_installation.yaml
@@ -48,3 +48,17 @@ delete_permissions:
       user_id:
         _eq: X-Hasura-User-Id
   role: user
+event_triggers:
+- definition:
+    enable_manual: false
+    insert:
+      columns: "*"
+  headers:
+  - name: Authorization
+    value_from_env: HASURA_EVENTS_WEBHOOK_AUTHORIZATION_HEADER
+  name: user_slack_installation_updates
+  retry_conf:
+    interval_sec: 10
+    num_retries: 0
+    timeout_sec: 60
+  webhook_from_env: HASURA_EVENTS_WEBHOOK_URL


### PR DESCRIPTION

https://user-images.githubusercontent.com/4051932/161974007-42e90244-e4d6-4918-875b-d7b098232554.mov

A few limitations:
- `unread_count_display` is only documented for some other calls, not this one, but it works and is the only method I found for figuring out how much is unread. I still think that's a bit weird
- when someone chooses extra channels after installing, we won't capture unread messages for those. We could have a follow-up issue & PR for figuring that out if we think that's important