### PR TITLE
fix(slack): more explicit user not found error

### DIFF
--- a/backend/src/slack/capture.ts
+++ b/backend/src/slack/capture.ts
@@ -195,7 +195,7 @@ async function createNotificationFromMessage(
 
   const [{ permalink }, { user: authorUser }, { channel: slackChannel }] = await Promise.all([
     slackClient.chat.getPermalink({ token: userToken, channel, message_ts: messageTs }),
-    slackClient.users.info({ token: userToken, user: authorSlackUserId }),
+    slackClient.users.info({ token: userToken, user: authorSlackUserId }).catch(() => ({ user: null })),
     is_IM_or_MPIM
       ? // we only need to fetch info for channels, as we use their name for the notification title
         { channel: undefined }


### PR DESCRIPTION
Seeing a lot of [`user_not_found` errors in Sentry](https://sentry.io/organizations/acapela/issues/3136271286) and I don't yet know what it means, due to Slack's error being uninformative. This forwards the errors into our own assert, which does log the user id, which gives me sth to work with.