### PR TITLE
fix: replace node-fetch with axios

### DIFF
--- a/desktop/electron/apps/figma/push.ts
+++ b/desktop/electron/apps/figma/push.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/electron";
+import axios from "axios";
 import { omit } from "lodash";
-import fetch from "node-fetch";
 
 import { figmaAuthTokenBridgeValue } from "@aca/desktop/bridge/auth";
 import { notificationResolvedChannel } from "@aca/desktop/bridge/notification";
@@ -33,8 +33,7 @@ export async function initializeFigmaPush() {
       return;
     }
 
-    const response = await fetch(figmaURL + `/api/file/${event.inner.file_id}/unread_comments`, {
-      method: "DELETE",
+    await axios.delete(figmaURL + `/api/file/${event.inner.file_id}/unread_comments`, {
       headers: {
         "content-type": "application/json",
         cookie: session.cookie,
@@ -42,13 +41,7 @@ export async function initializeFigmaPush() {
         "x-csrf-bypass": "yes",
         tsid: session.trackingSessionId,
       },
-      body: JSON.stringify({
-        comment_ids: [commentId],
-      }),
+      data: { comment_ids: [commentId] },
     });
-
-    if (!response.ok) {
-      log.error("Unable to delete unread comment" + JSON.stringify(await response.json()));
-    }
   });
 }

--- a/desktop/electron/apps/notion/push.ts
+++ b/desktop/electron/apps/notion/push.ts
@@ -1,5 +1,4 @@
-import * as Sentry from "@sentry/electron";
-import fetch from "node-fetch";
+import axios from "axios";
 
 import { notificationResolvedChannel } from "@aca/desktop/bridge/notification";
 import { notionURL } from "@aca/desktop/electron/auth/notion";
@@ -24,13 +23,9 @@ export async function initializeNotionPush() {
       return;
     }
 
-    const response = await fetch(notionURL + "/api/v3/saveTransactions", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        cookie: sessionData.cookie,
-      },
-      body: JSON.stringify({
+    await axios.post(
+      notionURL + "/api/v3/saveTransactions",
+      {
         requestId: getUUID(),
         transactions: [
           {
@@ -52,11 +47,8 @@ export async function initializeNotionPush() {
             ],
           },
         ],
-      }),
-    });
-
-    if (!response.ok) {
-      Sentry.captureException("[Notion] Unable to archive notification" + JSON.stringify(await response.json()));
-    }
+      },
+      { headers: { cookie: sessionData.cookie } }
+    );
   });
 }

--- a/desktop/electron/auth/acapela.ts
+++ b/desktop/electron/auth/acapela.ts
@@ -1,5 +1,5 @@
+import axios from "axios";
 import { BrowserWindow, session } from "electron";
-import fetch from "node-fetch";
 
 import { authTokenBridgeValue, autoLoginBridge, canAutoLoginBridge, loginBridge } from "@aca/desktop/bridge/auth";
 import { FRONTEND_URL } from "@aca/desktop/lib/env";
@@ -56,9 +56,9 @@ export async function loginAcapela(provider: "slack" | "google") {
 }
 
 async function fetchTestUserJWT() {
-  const response = await fetch("http://localhost:3000/api/backend/e2e/test_user");
-  const { jwt } = await response.json();
-  return jwt;
+  const response = await axios.get("http://localhost:3000/api/backend/e2e/test_user");
+  const { jwt } = response.data;
+  return jwt as string;
 }
 
 async function autoLoginAcapelaForEnd2EndTest() {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -47,7 +47,6 @@
     "glob": "^7.2.0",
     "glob-promise": "^4.2.2",
     "node-cleanup": "^2.1.2",
-    "node-fetch": "^2.6.7",
     "parcel": "^2.2.1",
     "react-chicane": "^0.6.1",
     "ts-node": "^10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,7 +120,6 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.2
     node-cleanup: ^2.1.2
-    node-fetch: ^2.6.7
     parcel: ^2.2.1
     react-chicane: ^0.6.1
     ts-node: ^10.4.0


### PR DESCRIPTION
Did that on Friday for Notion where hanging requests, because of connection resets, caused the sync to stop working. Today we got a report that the same thing is happening for Figma.

Now this PR throws out all `node-fetch` call sites in favor of `axios`.

I had a preference for `node-fetch` over `axios` as the latter seemed on the way out, with `fetch` coming to Node. Now what I probably did not properly weigh is that, while `node-fetch` is battle-tested, it is battle-tested in the context of servers that tend to have a more stable connection than clients, which is where we are shipping `node-fetch`, thus higher likelihood of erros in that context, like the connection reset one we experienced. Good lesson for next time.