### PR TITLE
fix: only focus views if window is focused

### DIFF
--- a/desktop/electron/bridgeHandlers/system.ts
+++ b/desktop/electron/bridgeHandlers/system.ts
@@ -139,10 +139,14 @@ export function initializeSystemHandlers() {
   });
 
   focusMainViewRequest.handle(async () => {
-    focusMainView();
+    if (getMainWindow().isFocused()) {
+      focusMainView();
+    }
   });
 
   focusSenderViewRequest.handle(async (data, event) => {
-    event?.sender.focus();
+    if (getMainWindow().isFocused()) {
+      event?.sender.focus();
+    }
   });
 }


### PR DESCRIPTION
We focused views within the main window even if that window did not have focus, thus stealing focus from other windows.