### PR TITLE
fix: up sentry's maxValueLength

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.STAGE,
-    maxValueLength: 1000,
+    maxValueLength: 10000,
   });
 }
 

--- a/desktop/client/index.tsx
+++ b/desktop/client/index.tsx
@@ -36,7 +36,7 @@ if (!appEnv.isDev) {
     environment: process.env.STAGE,
     // we can safely ignore this error: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
     ignoreErrors: ["ResizeObserver loop limit exceeded"],
-    maxValueLength: 1000,
+    maxValueLength: 10000,
   });
 
   autorun(() => {

--- a/desktop/electron/windows/mainWindow.ts
+++ b/desktop/electron/windows/mainWindow.ts
@@ -19,7 +19,7 @@ if (!IS_DEV) {
     dsn: process.env.SENTRY_DSN,
     release: app.getVersion(),
     environment: process.env.STAGE,
-    maxValueLength: 1000,
+    maxValueLength: 10000,
   });
 }
 


### PR DESCRIPTION
Notion errors are still hard to debug due to truncated error messages. Now this ups the max value length to 10000 chars which should be like 20kb. I think usually our error messages are not that large and I did not find docs saying this counts towards quota, so I think upping it should be fine.