### PR TITLE
fix: full trace for axios

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@slack/web-api": "^6.7.1",
     "airtable": "^0.11.2",
     "asana": "^0.18.6",
+    "axios-better-stacktrace": "^2.1.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "customerio-node": "^3.1.4",

--- a/backend/src/axios-trace.ts
+++ b/backend/src/axios-trace.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+import axiosBetterStacktrace from "axios-better-stacktrace";
+
+// Axios stack traces do not include originating source location, so we use this library to add them
+axiosBetterStacktrace(axios);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,8 @@ process.env.APP = "backend";
 
 import "@aca/config/dotenv";
 
+import "./axios-trace";
+
 import * as Sentry from "@sentry/node";
 
 import { IS_DEV } from "@aca/shared/dev";

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,7 @@ __metadata:
     "@types/uuid": ^8.3.4
     airtable: ^0.11.2
     asana: ^0.18.6
+    axios-better-stacktrace: ^2.1.2
     cookie-parser: ^1.4.6
     cors: ^2.8.5
     customerio-node: ^3.1.4
@@ -9620,6 +9621,15 @@ __metadata:
   version: 1.11.0
   resolution: "aws4@npm:1.11.0"
   checksum: 5a00d045fd0385926d20ebebcfba5ec79d4482fe706f63c27b324d489a04c68edb0db99ed991e19eda09cb8c97dc2452059a34d97545cebf591d7a2b5a10999f
+  languageName: node
+  linkType: hard
+
+"axios-better-stacktrace@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "axios-better-stacktrace@npm:2.1.2"
+  peerDependencies:
+    axios: "*"
+  checksum: c7c1162ebda174ef3367c2001a42280ab89699f2402c748ffb8c7f427e25d9ee02516b5c8e6a763170f02b9de961088701970fa4d37d12a4960cea03443ac491
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Another dagger in our back from HTTP clients, after `node-fetch` cheated on us with hidden logic bugs, it turns out that axios does not care about error debuggability by default.</rant> This library should make it easier to debug fetch errors (and hopefully let me finally figure out the jira 403 errors).