### PR TITLE
fix(slack): reduce resolve-to-read raciness

### DIFF
--- a/backend/src/notification/index.ts
+++ b/backend/src/notification/index.ts
@@ -25,7 +25,11 @@ async function addRelatedSlackMessageToMarkAsReadQueue(notification_id: string) 
       },
     });
   } else {
-    await db.user_slack_conversation_read.create({ data: { ...keyFields, slack_last_message_ts: messageTs } });
+    await db.user_slack_conversation_read.upsert({
+      where: { user_slack_installation_id_slack_conversation_id: keyFields },
+      create: { ...keyFields, slack_last_message_ts: messageTs },
+      update: {},
+    });
   }
 }
 


### PR DESCRIPTION
Reduce being the keyword. [Prisma unfortunately does not use PG's native upsert](https://github.com/prisma/prisma/issues/3242), thus we will still hit some racy errors here. Fortunately the source of the error is that another node has already picked up the job, thus this only being for error/sentry-hygiene and not for functionality.