### PR TITLE
fix: dont show preloading window in dock list

### DIFF
--- a/desktop/electron/bridgeHandlers/previews/preloadingWindow.ts
+++ b/desktop/electron/bridgeHandlers/previews/preloadingWindow.ts
@@ -46,6 +46,7 @@ export const getPreloadingWindow = memoize(() => {
     height: mainWindowSize?.y ?? 900,
     x: 1,
     y: 1,
+    title: "",
 
     // if set to false, it prevents acapela from closing
     // closable: false,


### PR DESCRIPTION
<img width="261" alt="CleanShot 2022-04-25 at 15 04 43@2x" src="https://user-images.githubusercontent.com/7311462/165094853-1c00da32-6eb2-4dbe-925e-ca38d44c62c5.png">

Before we seen 2 windows here (one was preloading window)