### PR TITLE
fix(gmail): client-side drop message notifications on disconnect

### DIFF
--- a/desktop/clientdb/notification/gmail/message.ts
+++ b/desktop/clientdb/notification/gmail/message.ts
@@ -4,6 +4,7 @@ import { defineEntity } from "@aca/clientdb";
 import { EntityByDefinition } from "@aca/clientdb";
 import { createHasuraSyncSetupFromFragment } from "@aca/clientdb/sync";
 import { getFragmentKeys } from "@aca/clientdb/utils/analyzeFragment";
+import { notificationEntity } from "@aca/desktop/clientdb/notification";
 import { NotificationGmailFragment } from "@aca/gql";
 
 const notificationGmailFragment = gql`
@@ -23,6 +24,10 @@ export const notificationGmailEntity = defineEntity<NotificationGmailFragment>({
   keyField: "id",
   keys: getFragmentKeys<NotificationGmailFragment>(notificationGmailFragment),
   sync: createHasuraSyncSetupFromFragment<NotificationGmailFragment>(notificationGmailFragment),
-});
+}).addConnections((gmailMessage, { getEntity }) => ({
+  get notification() {
+    return getEntity(notificationEntity).findById(gmailMessage.notification_id);
+  },
+}));
 
 export type NotificationGmailEntity = EntityByDefinition<typeof notificationGmailEntity>;

--- a/desktop/domains/integrations/gmail.tsx
+++ b/desktop/domains/integrations/gmail.tsx
@@ -23,8 +23,12 @@ export const gmailIntegrationClient: IntegrationClient = {
     await loginGmailBridge();
   },
   async disconnect() {
-    for (const account of getDb().gmailAccount.all) {
+    const db = getDb();
+    for (const account of db.gmailAccount.all) {
       account.remove();
+    }
+    for (const gmailNotification of db.notificationGmail.all) {
+      gmailNotification.notification?.remove("sync");
     }
   },
   icon: <IntegrationIcon imageUrl={integrationLogos.gmail} />,


### PR DESCRIPTION
Piggy backing on the way Chris did it for Asana, since we don't seem to have an idea on the horizon for fixing these kind of sync scenarios