### PR TITLE
fix: undo multi targets, compose-targets for compose action

### DIFF
--- a/desktop/actions/action/context.ts
+++ b/desktop/actions/action/context.ts
@@ -50,7 +50,7 @@ export function getImplicitTargets() {
 }
 
 export const createActionContext = deepMemoize(function createActionContext(
-  forcedTargets?: unknown | unknown[],
+  forcedTarget?: unknown,
   options?: ActionContextConfig
 ) {
   const {
@@ -59,9 +59,10 @@ export const createActionContext = deepMemoize(function createActionContext(
     initialSearchValue = "",
     hideTarget = false,
   } = options ?? {};
+  // TODO: handle forced target as array
   const targetPredicates = createActionTargetPredicates(() => {
-    const targets = Array.isArray(forcedTargets) ? forcedTargets.slice() : [forcedTargets];
-    targets.push(...[uiStore.focusedTarget, ...routeTargets()].filter(isNotNullish));
+    const targets = [forcedTarget, uiStore.focusedTarget, ...routeTargets()].filter(isNotNullish);
+
     return targets;
   });
 
@@ -71,7 +72,7 @@ export const createActionContext = deepMemoize(function createActionContext(
       hideTarget,
       isContextual,
       // Not really used, but makes it easier to debug actions
-      forcedTargets,
+      forcedTarget,
       view<D>(view: ActionView<D>): D {
         return view.getView(context);
       },

--- a/desktop/actions/action/targets.ts
+++ b/desktop/actions/action/targets.ts
@@ -1,13 +1,17 @@
 import { NotificationEntity } from "@aca/desktop/clientdb/notification";
 import { getIsNotificationsGroup } from "@aca/desktop/domains/group/group";
 import { getIsIntegrationClient } from "@aca/desktop/domains/integrations";
-import { IntegrationAccount } from "@aca/desktop/domains/integrations/types";
+import { IntegrationAccount, IntegrationClient } from "@aca/desktop/domains/integrations/types";
 import { getIsNotificationsList } from "@aca/desktop/domains/list/defineList";
 
 import { createPredicates } from "./predicates";
 
 export const getIsNotification = (input: unknown): input is NotificationEntity =>
   (input as NotificationEntity)?.__typename === "notification";
+
+const getIsAccount = (input: unknown): input is IntegrationAccount => (input as IntegrationAccount)?.kind == "account";
+
+type IntegrationWithAccount = { integration: IntegrationClient; account: IntegrationAccount };
 
 /**
  * All types of targets that action context is able to recognize are here
@@ -23,7 +27,10 @@ export const targetPredicates = {
   list: getIsNotificationsList,
   group: getIsNotificationsGroup,
   integration: getIsIntegrationClient,
-  account: (input: unknown): input is IntegrationAccount => (input as IntegrationAccount)?.kind == "account",
+  account: getIsAccount,
+  integrationWithAccount: (input: unknown): input is IntegrationWithAccount =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Boolean(getIsIntegrationClient((input as any).integration) && getIsAccount((input as any).account)),
 };
 
 export function createActionTargetPredicates(targets: () => unknown[]) {

--- a/desktop/domains/commandMenu/CommandMenuManager.tsx
+++ b/desktop/domains/commandMenu/CommandMenuManager.tsx
@@ -30,7 +30,7 @@ actionResultChannel.subscribe(
     }
 
     commandMenuStore.session = createCommandMenuSession({
-      actionContext: createActionContext(currentSession?.actionContext.forcedTargets, {
+      actionContext: createActionContext(currentSession?.actionContext.forcedTarget, {
         isContextual: actionResult.isContextual ?? currentSession?.actionContext.isContextual,
         searchPlaceholder: actionResult.searchPlaceholder,
         initialSearchValue: actionResult.initialSearchValue,

--- a/desktop/ui/ActionIconButton.tsx
+++ b/desktop/ui/ActionIconButton.tsx
@@ -12,12 +12,13 @@ import { SharedActionButtonProps } from "./actionShared";
 
 type Props = SharedActionButtonProps & {
   action: ActionData;
+  target?: unknown;
   hideShortcutTooltip?: boolean;
   showTitleInTooltip?: boolean;
   kind?: ButtonKind;
   size?: ButtonSize;
   className?: string;
-} & ({ target?: unknown } | { targets?: unknown[] });
+};
 
 export const ActionIconButton = styledObserver(function ActionIconButton({
   action,
@@ -29,9 +30,7 @@ export const ActionIconButton = styledObserver(function ActionIconButton({
   notApplicableMode = "disable",
   ...props
 }: Props) {
-  const context = createActionContext(
-    "target" in props ? props.target : "targets" in props ? props.targets : undefined
-  );
+  const context = createActionContext(props.target);
   const { icon, canApply, shortcut, name } = resolveActionData(action, context);
 
   const isApplicable = canApply(context);

--- a/desktop/ui/ShortcutsFooter/ShortcutLabel.tsx
+++ b/desktop/ui/ShortcutsFooter/ShortcutLabel.tsx
@@ -27,7 +27,7 @@ export const FooterShortcutLabel = observer(function FooterShortcutLabel({ actio
     <UIHolder
       action={action}
       data-tooltip={shouldShowTooltip ? name : undefined}
-      target={context.forcedTargets}
+      target={context.forcedTarget}
       $isEnabled={isEnabled}
     >
       <UIName ref={nameRef}>{name}</UIName>

--- a/desktop/ui/systemTopBar/ComposeButton.tsx
+++ b/desktop/ui/systemTopBar/ComposeButton.tsx
@@ -32,7 +32,7 @@ export const ComposeButton = observer(() => {
               size="compactWide"
               kind="transparent"
               action={goToComposeView}
-              targets={[account, client]}
+              target={{ integration: client, account }}
             />
             {isHovered && <PreloadEmbed url={url} priority={PreviewLoadingPriority.next} />}
           </React.Fragment>


### PR DESCRIPTION
I did not manage to quickly figure out why the new multi-targets thing did not work for the focus actions, so I just reverted them and went with a composite-object for the compose action instead.