### PR TITLE
fix: extract/use channel mentions correctly

### DIFF
--- a/backend/src/slack/capture.ts
+++ b/backend/src/slack/capture.ts
@@ -95,7 +95,7 @@ const createTextPreviewFromSlackMessage = async (
 };
 
 async function recordInvolvedThreadUsers(message: GenericMessageEvent) {
-  const userIds = extractMentionedSlackUserIdsFromMd(message.text).concat(message.user).filter(isNotNullish);
+  const userIds = extractMentionedSlackUserIdsFromMd(message.text)[0].concat(message.user).filter(isNotNullish);
   if (userIds.length > 0) {
     await db.slack_thread_involed_user.createMany({
       data: userIds.map((userId) => ({ user_id: userId, thread_ts: message.thread_ts ?? message.ts })),


### PR DESCRIPTION
Added a simple fix to check for channel/here mentions in addition to user mentions to determine if a notification should be created