### PR TITLE
fix: false no internet issue

### DIFF
--- a/desktop/electron/apps/figma/worker.ts
+++ b/desktop/electron/apps/figma/worker.ts
@@ -5,7 +5,7 @@ import { FigmaWorkerSync, figmaSyncPayload } from "@aca/desktop/bridge/apps/figm
 import { authTokenBridgeValue, figmaAuthTokenBridgeValue, loginFigmaBridge } from "@aca/desktop/bridge/auth";
 import { makeLogger } from "@aca/desktop/domains/dev/makeLogger";
 import { addToast } from "@aca/desktop/domains/toasts/store";
-import { FigmaSessionData, clearFigmaSessionData, figmaDomain, figmaURL } from "@aca/desktop/electron/auth/figma";
+import { FigmaSessionData, clearFigmaSessionData, figmaURL } from "@aca/desktop/electron/auth/figma";
 import { timeDuration } from "@aca/shared/time";
 
 import { KnownSyncError, ServiceSyncController, makeServiceSyncController } from "../serviceSyncController";
@@ -40,7 +40,7 @@ export function isFigmaReadyToSync() {
 }
 
 export function startFigmaSync(): ServiceSyncController {
-  return makeServiceSyncController("figma", figmaDomain, async () => await captureLatestNotifications());
+  return makeServiceSyncController("figma", figmaURL, async () => await captureLatestNotifications());
 }
 
 async function captureLatestNotifications() {

--- a/desktop/electron/apps/notion/worker.ts
+++ b/desktop/electron/apps/notion/worker.ts
@@ -13,7 +13,7 @@ import {
   ServiceSyncController,
   makeServiceSyncController,
 } from "@aca/desktop/electron/apps/serviceSyncController";
-import { clearNotionSessionData, notionDomain, notionURL } from "@aca/desktop/electron/auth/notion";
+import { clearNotionSessionData, notionURL } from "@aca/desktop/electron/auth/notion";
 import { assert } from "@aca/shared/assert";
 import { timeDuration, wait } from "@aca/shared/time";
 
@@ -66,7 +66,7 @@ export async function getNotionSessionData(): Promise<NotionSessionData> {
 }
 
 export function startNotionSync(): ServiceSyncController {
-  return makeServiceSyncController("notion", notionDomain, runSync);
+  return makeServiceSyncController("notion", notionURL, runSync);
 }
 
 async function runSync() {

--- a/desktop/electron/utils/internet.ts
+++ b/desktop/electron/utils/internet.ts
@@ -1,17 +1,18 @@
-import dns from "dns";
+import http2 from "http2";
 
 /**
- * https://stackoverflow.com/questions/15270902/check-for-internet-connectivity-in-nodejs
+ * https://stackoverflow.com/a/60902742
  */
-
-export async function checkAccessToInternet(domainToCheckAccess = "www.google.com") {
-  return new Promise<boolean>((resolve) => {
-    dns.resolve(domainToCheckAccess, (error) => {
-      if (error) {
-        resolve(false);
-      } else {
-        resolve(true);
-      }
+export async function checkAccessToInternet(host = "https://www.google.com") {
+  return new Promise((resolve) => {
+    const client = http2.connect(host);
+    client.on("connect", () => {
+      resolve(true);
+      client.destroy();
+    });
+    client.on("error", () => {
+      resolve(false);
+      client.destroy();
     });
   });
 }


### PR DESCRIPTION
We've been depending on node's `dns` package to check the internet connectivity of a service. 

Roland reported that his apps were not syncing, and the main culprit of it is that "notion" and "figma" dns lookups were failing. Instead of depending on DNS's, we're trying to connect right away.