### PR TITLE
feat: remember previous window bounds

### DIFF
--- a/desktop/bridge/system.ts
+++ b/desktop/bridge/system.ts
@@ -1,3 +1,5 @@
+import type { Rectangle } from "electron";
+
 import { ShortcutKeys } from "@aca/ui/keyboard/shortcutBase";
 
 import { createInvokeBridge } from "./base/invoke";
@@ -47,5 +49,17 @@ export const applicationWideSettingsBridge = createBridgeValue("app-wide-setting
     showUnreadNotificationsCountBadge: false,
     notificationsCountBadgeListIds: [] as string[],
     showShortcutsBar: true,
+  }),
+});
+
+export interface MainWindowLastBounds {
+  bounds: Rectangle;
+  isMaximized: boolean;
+}
+
+export const electronSettingsBridge = createBridgeValue("electronSettingsBridge", {
+  isPersisted: true,
+  getDefault: () => ({
+    lastMainWindowBounds: null as MainWindowLastBounds | null,
   }),
 });

--- a/desktop/electron/windows/mainWindow.ts
+++ b/desktop/electron/windows/mainWindow.ts
@@ -10,6 +10,7 @@ import { initializeChildWindowHandlers } from "./childWindows";
 import { appEnvData } from "./env";
 import { initializeMainView } from "./mainView";
 import { initializeOverlayView } from "./overlayView";
+import { initializeMainWindowRememberBounds, restoreLastMainWindowBounds } from "./rememberBounds";
 import { createBrowserWindowMobxBinding } from "./utils/browserWindowMobxBinding";
 import { handleHideWindowOnClose } from "./utils/hideWindowOnClose";
 import { makeLinksOpenInDefaultBrowser } from "./utils/openLinks";
@@ -53,11 +54,17 @@ function initializeMainWindow() {
     },
   });
 
+  // If window had previous bounds (size, position) - restore it
+  restoreLastMainWindowBounds(mainWindow);
+  // After we restored previous bounds - start watching it to save it for next app opening
+  initializeMainWindowRememberBounds(mainWindow);
+
   const mainView = initializeMainView(mainWindow, appEnvData.get());
 
   const overlayView = initializeOverlayView(mainWindow, mainView, appEnvData.get());
 
   const mainWindowWebContents = mainWindow.webContents;
+  mainWindow.getBounds;
 
   Reflect.set(mainWindow, "webContents", {
     get() {

--- a/desktop/electron/windows/rememberBounds.ts
+++ b/desktop/electron/windows/rememberBounds.ts
@@ -1,0 +1,42 @@
+import { BrowserWindow } from "electron";
+
+import { MainWindowLastBounds, electronSettingsBridge } from "@aca/desktop/bridge/system";
+
+function getCurrentBounds(window: BrowserWindow): MainWindowLastBounds {
+  const bounds = window.getBounds();
+  const isMaximized = window.isMaximized();
+
+  return { bounds, isMaximized };
+}
+
+export function initializeMainWindowRememberBounds(window: BrowserWindow) {
+  function saveBounds() {
+    const boundsInfo = getCurrentBounds(window);
+    electronSettingsBridge.update({ lastMainWindowBounds: boundsInfo });
+  }
+
+  window.on("resized", saveBounds);
+  window.on("moved", saveBounds);
+
+  return () => {
+    window.off("resized", saveBounds);
+    window.off("moved", saveBounds);
+  };
+}
+
+function applyLastBoundsToWindow(boundsInfo: MainWindowLastBounds, window: BrowserWindow) {
+  if (boundsInfo.isMaximized) {
+    window.maximize();
+    return;
+  }
+
+  window.setBounds(boundsInfo.bounds);
+}
+
+export function restoreLastMainWindowBounds(window: BrowserWindow) {
+  const lastBounds = electronSettingsBridge.get().lastMainWindowBounds;
+
+  if (!lastBounds) return;
+
+  applyLastBoundsToWindow(lastBounds, window);
+}


### PR DESCRIPTION
Remembers window bounds (position, size) and restores it on next app open

"Ask" as we have release soon and I don't want to accidentally break anything

![CleanShot 2022-05-09 at 11 25 37](https://user-images.githubusercontent.com/7311462/167381314-ef31200b-2546-4bbd-9e6f-0de5f2281683.gif)

